### PR TITLE
Resources page

### DIFF
--- a/_data/about.yml
+++ b/_data/about.yml
@@ -35,3 +35,8 @@
   description: "How to cite SoyBase"
   name: "Citing SoyBase"
   url: "/about/citing_soybase"
+- category: "Sitemap"
+  description: "Overview of pages and content at SoyBase"
+  name: "SoyBase Sitemap"
+  url: "/about/sitemap"
+

--- a/resources/index.html
+++ b/resources/index.html
@@ -5,6 +5,7 @@ sitemap: sequence map
 tools_menu: true
 ---
 
+{% capture jbrowse_base_url %}/assets/js/jbrowse{% endcapture %}
 {% assign genus = "Glycine" %}
 
 {% for about_file in site.data.datastore-metadata[genus].GENUS.about_this_collection %}
@@ -14,16 +15,22 @@ tools_menu: true
   {% endif %}
 {% endfor %}
 
-<h1><i>{{ genus_resources.genus }}</i> ({{ genus_resources.commonName }})</h2>
+<h1>
+  <i>{{ genus_resources.genus }}</i>
+  ({{ genus_resources.commonName }})</h2>
 <p>{{ genus_resources.description }}</p>
-<p>NCBI taxonomy ID: <b>{{ genus_resources.taxid }}</b></p>
+<p>NCBI taxonomy ID:
+  <b>{{ genus_resources.taxid }}</b>
+</p>
 
 {% if genus_resources contains "resources" %}
   <h2>Tools and resources for the genus as a whole</h2>
   <dl>
     {% for resource in genus_resources.resources %}
-    <dt><a href="{{ resource.URL }}">{{ resource.name }}</a></dt>
-    <dd>{{ resource.description }}</dd>
+      <dt>
+        <a href="{{ resource.URL }}">{{ resource.name }}</a>
+      </dt>
+      <dd>{{ resource.description }}</dd>
     {% endfor %}
   </dl>
 {% endif %}
@@ -31,46 +38,113 @@ tools_menu: true
 <h2>Tools and resources for particular species</h2>
 
 {% for species in genus_resources.species %}
-{% for about_file in site.data.datastore-metadata[genus][species].about_this_collection %}
-  {% if about_file[0] contains "description_" %}
-    {% assign species_resources = about_file[1] %}
-    {% break %}
-  {% endif %}
-{% endfor %}
+  {% for about_file in site.data.datastore-metadata[genus][species].about_this_collection %}
+    {% if about_file[0] contains "description_" %}
+      {% assign species_resources = about_file[1] %}
+      {% break %}
+    {% endif %}
+  {% endfor %}
 
   <hr/>
 
-  <h3><i>{{ species_resources.genus }} {{ species_resources.species }}</i>: {{ genus_resources.commonName }}</h3>
-  {% capture species_photo %}{% file_exists assets/img/species_images/{{ species_resources.abbrev }}.jpg %}{% endcapture %}
+  <h3>
+    <i>{{ species_resources.genus }} {{ species_resources.species }}</i>: {{ genus_resources.commonName }}</h3>
+  {% capture species_photo %}
+    {% file_exists assets/img/species_images/{{ species_resources.abbrev }}.jpg %}{% endcapture %}
   {% if species_photo == "true" %}
     <div style="float:right;margin:10px;border:1px solid darkgreen;">
-      <img src="/assets/img/species_images/{{ species_resources.abbrev }}.jpg" alt="Image: {{ species_resources.abbrev }}"/><br/>
+      <img src="/assets/img/species_images/{{ species_resources.abbrev }}.jpg" alt="Image: {{ species_resources.abbrev }}" /><br/>
     </div>
   {% endif %}
   <p>{{ species_resources.description }}</p>
-  <p>NCBI taxonomy ID: <b>{{ species_resources.taxid }}</b></p>
+  <p>NCBI taxonomy ID:
+    <b>{{ species_resources.taxid }}</b>
+  </p>
 
   {% if species_resources contains "resources" %}
-    <h4><i>{{ species_resources.genus }} {{ species_resources.species }}</i> resources</h4>
+    <h4>
+      <i>{{ species_resources.genus }} {{ species_resources.species }}</i>
+      resources</h4>
     <dl>
       {% for resource in species_resources.resources %}
-      <dt><a href="{{ resource.URL }}">{{ resource.name }}</a></dt>
-      <dd>{{ resource.description }}</dd>
+        <dt>
+          <a href="{{ resource.URL }}">{{ resource.name }}</a>
+        </dt>
+        <dd>{{ resource.description }}</dd>
       {% endfor %}
     </dl>
   {% endif %}
 
-  <h4><i>{{ species_resources.genus }} {{ species_resources.species }}</i> accessions</h4>
-  {% for strain in species_resources.strains %}
-    <b>{{ strain.identifier }}</b> ({{ strain.origin }}) <br/>
-    {{ strain.description }}
-    {% if strain contains "resources" %}
-    <ul>
-      {% for resource in strain.resources %}
-      <li><a href="{{ resource.URL }}">{{ resource.name }}</a> : {{ resource.description }}</li>
+  <h4>
+    <i>{{ species_resources.genus }} {{ species_resources.species }}</i>
+    accessions</h4>
+  {% for datatype_dir in site.data.datastore-metadata[genus][species] %}
+    {% assign datatype = datatype_dir[0] %}
+    {% if datatype == "about_this_collection" %}
+      {% for about_file in datatype_dir[1] %}
+        {% if about_file[0] contains "description_" %}
+          {% assign about = about_file[1] %}
+        {% endif %}
       {% endfor %}
-    </ul>
     {% endif %}
   {% endfor %}
-
+  {% for datatype_dir in site.data.datastore-metadata[genus][species] %}
+    {% assign datatype = datatype_dir[0] %}
+    {% if datatype == "annotations" %}
+      {% assign existing_headers = '' | split: ',' %}
+      {% for strain in about.strains %}
+        {% unless existing_headers contains strain.accession_group %}
+          <h4 class="uk-margin-small-bottom">
+            <b>{{ strain.accession_group }}</b><br>
+          </h4>
+          {% assign existing_headers = existing_headers | push: strain.accession_group %}
+        {% endunless %}
+        {% for collection_dir in datatype_dir[1] %}
+          {% assign collection_name = collection_dir[0] | split: 'gnm' %}
+          {% if collection_name[0] == strain.identifier %}
+            {% assign collection = collection_dir[0] %}
+            {% for metadata_file in collection_dir[1] %}
+              {% if metadata_file[0] contains "README" %}
+                {% assign readme = metadata_file[1] %}
+                {% assign assembly = readme.identifier | split: '.' | slice: 0, 2 | join: '.' %}
+                {% assign annotation = readme.identifier | split: '.' | slice: 0, 3 | join: '.' %}
+                {% for datatype_dir in site.data.datastore-metadata[genus][species] %}
+                  {% assign datatype = datatype_dir[0] %}
+                  {% if datatype == "genomes" %}
+                    {% for collection_dir in datatype_dir[1] %}
+                      {% assign collection = collection_dir[0] %}
+                      {% for metadata_file in collection_dir[1] %}
+                        {% if metadata_file[0] contains "README" %}
+                          {% assign readme_genome = metadata_file[1] %}
+                          {% assign assembly_genome = readme_genome.identifier | split: '.' | slice: 0, 2 | join: '.' %}
+                          {% if assembly_genome == assembly %}
+                            {% assign chromosome_prefix = readme_genome.chromosome_prefix %}
+                            {% assign synopsis = readme_genome.synopsis %}
+                            {% assign doi = readme_genome.publication_doi %}
+                          {% endif %}
+                        {% endif %}
+                      {% endfor %}
+                    {% endfor %}
+                  {% endif %}
+                {% endfor %}
+                <dt>
+                  <a target="_blank" href="{{ jbrowse_base_url }}/?assembly={{ assembly }}&tracks={{ annotation }}&loc={{ readme.scientific_name_abbrev }}.{{ assembly }}.{{ chromosome_prefix }}01:1-1000000">{{ assembly }}</a>
+                </dt>
+                <dd>{{ synopsis }}
+                  {% assign doiCheck = doi | slice: 0, 2 %}
+                  <i>
+                    {% if doiCheck == "10" %}
+                      <a href="https://doi.org/{{ doi }}">doi.org/{{ doi }}</a>
+                    {% else %}
+                      {{ doi }}
+                    {% endif %}
+                  </i>
+                </dd>
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+        {% endfor %}
+      {% endfor %}
+    {% endif %}
+  {% endfor %}
 {% endfor %}

--- a/resources/index.html
+++ b/resources/index.html
@@ -22,7 +22,6 @@ tools_menu: true
 <p>NCBI taxonomy ID:
   <b>{{ genus_resources.taxid }}</b>
 </p>
-
 {% if genus_resources contains "resources" %}
   <h2>Tools and resources for the genus as a whole</h2>
   <dl>
@@ -105,7 +104,7 @@ tools_menu: true
           </h4>
           {% assign existing_headers = existing_headers | push: strain.accession_group %}
         {% endunless %}
-        {% for collection_dir in datatype_dir[1] %}
+        {% for collection_dir in datatype_dir[1] reversed %}
           {% assign collection_name = collection_dir[0] | split: 'gnm' %}
           {% if collection_name[0] == strain.identifier %}
             {% assign collection = collection_dir[0] %}

--- a/resources/index.html
+++ b/resources/index.html
@@ -63,8 +63,11 @@ tools_menu: true
 
   {% if species_resources contains "resources" %}
     <h4>
-      <i>{{ species_resources.genus }} {{ species_resources.species }}</i>
-      resources</h4>
+      <b>
+        <i>{{ species_resources.genus }} {{ species_resources.species }}</i>
+        resources
+      </b>
+    </h4>
     <dl>
       {% for resource in species_resources.resources %}
         <dt>
@@ -76,8 +79,11 @@ tools_menu: true
   {% endif %}
 
   <h4>
-    <i>{{ species_resources.genus }} {{ species_resources.species }}</i>
-    accessions</h4>
+    <b>
+      <i>{{ species_resources.genus }} {{ species_resources.species }}</i>
+      accessions
+    </b>
+  </h4>
   {% for datatype_dir in site.data.datastore-metadata[genus][species] %}
     {% assign datatype = datatype_dir[0] %}
     {% if datatype == "about_this_collection" %}
@@ -95,7 +101,7 @@ tools_menu: true
       {% for strain in about.strains %}
         {% unless existing_headers contains strain.accession_group %}
           <h4 class="uk-margin-small-bottom">
-            <b>{{ strain.accession_group }}</b><br>
+            {{ strain.accession_group }}
           </h4>
           {% assign existing_headers = existing_headers | push: strain.accession_group %}
         {% endunless %}
@@ -127,10 +133,9 @@ tools_menu: true
                     {% endfor %}
                   {% endif %}
                 {% endfor %}
-                <dt>
-                  <a target="_blank" href="{{ jbrowse_base_url }}/?assembly={{ assembly }}&tracks={{ annotation }}&loc={{ readme.scientific_name_abbrev }}.{{ assembly }}.{{ chromosome_prefix }}01:1-1000000">{{ assembly }}</a>
-                </dt>
-                <dd>{{ synopsis }}
+                <span>
+                  <b>{{ assembly }}</b>
+                  - {{ synopsis }}
                   {% assign doiCheck = doi | slice: 0, 2 %}
                   <i>
                     {% if doiCheck == "10" %}
@@ -139,7 +144,12 @@ tools_menu: true
                       {{ doi }}
                     {% endif %}
                   </i>
-                </dd>
+                </span>
+                <div class="uk-margin-left">
+                  <dd>
+                    <a target="_blank" href="{{ jbrowse_base_url }}/?assembly={{ assembly }}&tracks={{ annotation }}&loc={{ readme.scientific_name_abbrev }}.{{ assembly }}.{{ chromosome_prefix }}01:1-1000000">Genome Browser</a>
+                  </dd>
+                </div>
               {% endif %}
             {% endfor %}
           {% endif %}

--- a/tools/browsers/index.html
+++ b/tools/browsers/index.html
@@ -50,11 +50,14 @@ tools_menu: true
           <h4 class="uk-margin-small-bottom">
             <b>{{ strain.accession_group }}</b><br>
           </h4>
-          <h5 class="uk-margin-small-top">
-            <i>
-              <a href="https://doi.org/{{ strain.publication_doi }}">doi.org/{{ strain.publication_doi }}</a>
-            </i>
-          </h5>
+          {% assign doiCheck = strain.publication_doi | slice: 0, 2 %}
+          {% if doiCheck == "10" %}
+            <h5 class="uk-margin-small-top">
+              <i>
+                <a href="https://doi.org/{{ strain.publication_doi }}">doi.org/{{ strain.publication_doi }}</a>
+              </i>
+            </h5>
+          {% endif %}
 
           {% assign existing_headers = existing_headers | push: strain.accession_group %}
         {% endunless %}

--- a/tools/browsers/index.html
+++ b/tools/browsers/index.html
@@ -9,47 +9,12 @@ tools_menu: true
 
 <p>
   Genome browsers are available for most of the genome assemblies at SoyBase. 
-  These can be accessed from the <a href="/resources">GENOMICS</a> tab, with browsers listed under each accession -- or directly from the links below.
+  These can be accessed from the
+  <a href="/resources">GENOMICS</a>
+  tab, with browsers listed under each accession -- or directly from the links below.
 </p>
 
-<h4><i>Glycine max</i> accessions</h4>
-
-<b>Wm82</b> (Northern United States) <br/>
-Williams 82, the soybean cultivar used to produce the reference genome sequence, was derived from backcrossing a phytophthora root rot resistance locus from the donor parent Kingwa into the recurrent parent Williams.
-<ul>
-  <li><a href="https://soybase.org/gb2/gbrowse/gmax2.0">Genome Browser (GBrowse)</a> for Wm82 assembly 2.0</li>
-  <li><a href="https://soybase.org/gb2/gbrowse/gmax1.01">Genome Browser (GBrowse)</a> for Wm82 assembly 1.01</li>
-  <li><a href="{{ jbrowse_base_url }}?assembly=Wm82_ISU01.gnm2&tracks=Wm82_ISU01.gnm2.ann1&loc=glyma.Wm82_ISU01.gnm2.Gm01:1-1000000">Genome Browser (JBrowse)</a> for Wm82_ISU01 assembly 2</li>
-</ul>
-
-<b>Zh13</b> (China) <br/>
-Zhonghuang 13 is a Chinese cultivar derived from accessions Yudou 18 and Zhongzuo 90052-76 by pedigree selection for high yield and stress tolerance (Shen et al., 2018; https://doi.org/10.1007/s11427-018-9360-0).
-<ul>
-  <li><a href="https://soybase.org/gb2/gbrowse/glyma.Zh13.gnm1">Genome Browser (GBrowse)</a> for glycine max Zh13 genome assembly verson 1</li>
-</ul>
-
-<b>Lee</b> (Southern United States) <br/>
-Cultivar Lee, which derives from a cross of Chinese lines CNS and S-100, has been widely used as a parent in many breeding projects in the Southern U.S. and in Brazil (Wysmierski and Vello, 2013; http://doi.org/10.1590/S1415-47572013005000041). The variety is notable for resistance to Phytophthora rot, Peanut Mottle Virus, and bacterial pustule (Wysmierski and Vello, 2013).
-<ul>
-  <li><a href="https://soybase.org/gb2/gbrowse/glyma.Lee.gnm1">Genome Browser (GBrowse)</a> for glycine max Lee genome assembly verson 1</li>
-</ul>
-
-<h4><i>Glycine soja</i> accessions</h4>
-
-<b>PI483463</b> (Shanxi Province, China) <br/>
-Glycine soja accession PI 483463 has been identified as being unusually tolerant (Lee et al., 2009; https://doi.org/10.1093/jhered/esp027). The genome for this accession has been sequenced, partly on the basis of this salt-tolerance trait.
-<ul>
-  <li><a href="https://soybase.org/gb2/gbrowse/glyso.PI483463.gnm1">Genome Browser (GBrowse)</a> for Glycine soja PI483463 genome assembly version 1</li>
-</ul>
-
-<b>W05</b> (Henan Province, China) <br/>
-Glycine soja accession W05 is a salt-tolerant wild soybean whose genome has been sequenced to serve as a reference genome assembly. The W05 accession has been used for genetic studies of several traits, including indeterminacy, seed size, pod number per plant, and seed color (Xie et al., 2019; https://doi.org/10.1038/s41467-019-09142-9).
-<ul>
-  <li><a href="https://soybase.org/gb2/gbrowse/glyso.W05.gnm1">Genome Browser (GBrowse)</a> :for glycine soja W05 genome assembly verson 1</li>
-</ul>
-
 {% assign genus = "Glycine" %}
-
 {% for about_file in site.data.datastore-metadata[genus].GENUS.about_this_collection %}
   {% if about_file[0] contains "description_" %}
     {% assign genus_resources = about_file[1] %}
@@ -84,7 +49,6 @@ Glycine soja accession W05 is a salt-tolerant wild soybean whose genome has been
         {% for collection_dir in datatype_dir[1] %}
           {% assign collection_name = collection_dir[0] | split: 'gnm' %}
           {% if collection_name[0] == strain.identifier %}
-            {% assign count = count | plus: 1 %}
             {% assign collection = collection_dir[0] %}
             {% for metadata_file in collection_dir[1] %}
               {% if metadata_file[0] contains "README" %}
@@ -122,4 +86,3 @@ Glycine soja accession W05 is a salt-tolerant wild soybean whose genome has been
   {% endfor %}
   {% if forloop.last == false %}<hr>{% endif %}
 {% endfor %}
-

--- a/tools/browsers/index.html
+++ b/tools/browsers/index.html
@@ -50,15 +50,6 @@ tools_menu: true
           <h4 class="uk-margin-small-bottom">
             <b>{{ strain.accession_group }}</b><br>
           </h4>
-          {% assign doiCheck = strain.publication_doi | slice: 0, 2 %}
-          {% if doiCheck == "10" %}
-            <h5 class="uk-margin-small-top">
-              <i>
-                <a href="https://doi.org/{{ strain.publication_doi }}">doi.org/{{ strain.publication_doi }}</a>
-              </i>
-            </h5>
-          {% endif %}
-
           {% assign existing_headers = existing_headers | push: strain.accession_group %}
         {% endunless %}
         {% for collection_dir in datatype_dir[1] %}
@@ -82,6 +73,7 @@ tools_menu: true
                           {% if assembly_genome == assembly %}
                             {% assign chromosome_prefix = readme_genome.chromosome_prefix %}
                             {% assign synopsis = readme_genome.synopsis %}
+                            {% assign doi = readme_genome.publication_doi %}
                           {% endif %}
                         {% endif %}
                       {% endfor %}
@@ -91,7 +83,16 @@ tools_menu: true
                 <dt>
                   <a target="_blank" href="{{ jbrowse_base_url }}/?assembly={{ assembly }}&tracks={{ annotation }}&loc={{ readme.scientific_name_abbrev }}.{{ assembly }}.{{ chromosome_prefix }}01:1-1000000">{{ assembly }}</a>
                 </dt>
-                <dd>{{ synopsis }}</dd>
+                <dd>{{ synopsis }}
+                  {% assign doiCheck = doi | slice: 0, 2 %}
+                  <i>
+                    {% if doiCheck == "10" %}
+                      <a href="https://doi.org/{{ doi }}">doi.org/{{ doi }}</a>
+                    {% else %}
+                      {{ doi }}
+                    {% endif %}
+                  </i>
+                </dd>
               {% endif %}
             {% endfor %}
           {% endif %}

--- a/tools/browsers/index.html
+++ b/tools/browsers/index.html
@@ -50,47 +50,76 @@ Glycine soja accession W05 is a salt-tolerant wild soybean whose genome has been
 
 {% assign genus = "Glycine" %}
 
-{% for species_dir in site.data.datastore-metadata[genus] %}
-  {% assign species = species_dir[0] %}
+{% for about_file in site.data.datastore-metadata[genus].GENUS.about_this_collection %}
+  {% if about_file[0] contains "description_" %}
+    {% assign genus_resources = about_file[1] %}
+    {% break %}
+  {% endif %}
+{% endfor %}
+{% for species in genus_resources.species %}
   {% if species == "GENUS" %}
     {% continue %}
   {% endif %}
-  <h4><i>Glycine {{ species }}</i> accessions</h4>
-  {% for datatype_dir in species_dir[1] %}
+  <h4>
+    <i>Glycine {{ species }}</i>
+    accessions</h4>
+  {% for datatype_dir in site.data.datastore-metadata[genus][species] %}
     {% assign datatype = datatype_dir[0] %}
-    {% if datatype == "annotations" %} 
-      {% for collection_dir in datatype_dir[1] %}
-        {% assign collection = collection_dir[0] %}
-        {% for metadata_file in collection_dir[1] %}
-          {% if metadata_file[0] contains "README" %}
-            {% assign readme = metadata_file[1] %}
-            {% assign assembly = readme.identifier | split: '.' | slice: 0, 2 | join: '.' %}
-            {% assign annotation = readme.identifier | split: '.' | slice: 0, 3 | join: '.' %}
-            {% for datatype_dir in species_dir[1] %}
-              {% assign datatype = datatype_dir[0] %}
-              {% if datatype == "genomes" %} 
-                {% for collection_dir in datatype_dir[1] %}
-                  {% assign collection = collection_dir[0] %}
-                  {% for metadata_file in collection_dir[1] %}
-                    {% if metadata_file[0] contains "README" %}
-                      {% assign readme_genome = metadata_file[1] %}
-                      {% assign assembly_genome = readme_genome.identifier | split: '.' | slice: 0, 2 | join: '.' %}
-                      {% if assembly_genome == assembly %}
-                        {% assign chromosome_prefix = readme_genome.chromosome_prefix %}
-                        {% assign synopsis = readme_genome.synopsis %}
-                      {% endif %}
-                    {% endif %}
-                  {% endfor %}
+    {% if datatype == "about_this_collection" %}
+      {% for about_file in datatype_dir[1] %}
+        {% if about_file[0] contains "description_" %}
+          {% assign about = about_file[1] %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+    {% if datatype == "annotations" %}
+      {% assign existing_headers = '' | split: ',' %}
+      {% for strain in about.strains %}
+        {% unless existing_headers contains strain.accession_group %}
+          <h5>
+            <i>{{ strain.accession_group }}</i>
+          </h5>
+          {% assign existing_headers = existing_headers | push: strain.accession_group %}
+        {% endunless %}
+        {% for collection_dir in datatype_dir[1] %}
+          {% assign collection_name = collection_dir[0] | split: 'gnm' %}
+          {% if collection_name[0] == strain.identifier %}
+            {% assign count = count | plus: 1 %}
+            {% assign collection = collection_dir[0] %}
+            {% for metadata_file in collection_dir[1] %}
+              {% if metadata_file[0] contains "README" %}
+                {% assign readme = metadata_file[1] %}
+                {% assign assembly = readme.identifier | split: '.' | slice: 0, 2 | join: '.' %}
+                {% assign annotation = readme.identifier | split: '.' | slice: 0, 3 | join: '.' %}
+                {% for datatype_dir in site.data.datastore-metadata[genus][species] %}
+                  {% assign datatype = datatype_dir[0] %}
+                  {% if datatype == "genomes" %}
+                    {% for collection_dir in datatype_dir[1] %}
+                      {% assign collection = collection_dir[0] %}
+                      {% for metadata_file in collection_dir[1] %}
+                        {% if metadata_file[0] contains "README" %}
+                          {% assign readme_genome = metadata_file[1] %}
+                          {% assign assembly_genome = readme_genome.identifier | split: '.' | slice: 0, 2 | join: '.' %}
+                          {% if assembly_genome == assembly %}
+                            {% assign chromosome_prefix = readme_genome.chromosome_prefix %}
+                            {% assign synopsis = readme_genome.synopsis %}
+                          {% endif %}
+                        {% endif %}
+                      {% endfor %}
+                    {% endfor %}
+                  {% endif %}
                 {% endfor %}
-              {% endif %} 
+                <dt>
+                  <a target="_blank" href="{{ jbrowse_base_url }}/?assembly={{ assembly }}&tracks={{ annotation }}&loc={{ readme.scientific_name_abbrev }}.{{ assembly }}.{{ chromosome_prefix }}01:1-1000000">{{ assembly }}</a>
+                </dt>
+                <dd>{{ synopsis }}</dd>
+              {% endif %}
             {% endfor %}
-            <dt><a target="_blank" href="{{ jbrowse_base_url }}/?assembly={{ assembly }}&tracks={{ annotation }}&loc={{ readme.scientific_name_abbrev }}.{{ assembly }}.{{ chromosome_prefix }}01:1-1000000">{{ assembly }}</a></dt>
-            <dd>{{ synopsis }}</dd>
           {% endif %}
         {% endfor %}
       {% endfor %}
     {% endif %}
   {% endfor %}
-  <hr>
+  {% if forloop.last == false %}<hr>{% endif %}
 {% endfor %}
 

--- a/tools/browsers/index.html
+++ b/tools/browsers/index.html
@@ -25,9 +25,10 @@ tools_menu: true
   {% if species == "GENUS" %}
     {% continue %}
   {% endif %}
-  <h4>
-    <i>Glycine {{ species }}</i>
-    accessions</h4>
+  <hr>
+  <h3>
+    <b><i>Glycine {{ species }}</i> accessions</b>
+  </h3>
   {% for datatype_dir in site.data.datastore-metadata[genus][species] %}
     {% assign datatype = datatype_dir[0] %}
     {% if datatype == "about_this_collection" %}
@@ -37,13 +38,16 @@ tools_menu: true
         {% endif %}
       {% endfor %}
     {% endif %}
+  {% endfor %}
+  {% for datatype_dir in site.data.datastore-metadata[genus][species] %}
+    {% assign datatype = datatype_dir[0] %}
     {% if datatype == "annotations" %}
       {% assign existing_headers = '' | split: ',' %}
       {% for strain in about.strains %}
         {% unless existing_headers contains strain.accession_group %}
-          <h5>
-            <i>{{ strain.accession_group }}</i>
-          </h5>
+          <h4>
+            <b>{{ strain.accession_group }}</b>
+          </h4>
           {% assign existing_headers = existing_headers | push: strain.accession_group %}
         {% endunless %}
         {% for collection_dir in datatype_dir[1] %}
@@ -84,5 +88,5 @@ tools_menu: true
       {% endfor %}
     {% endif %}
   {% endfor %}
-  {% if forloop.last == false %}<hr>{% endif %}
 {% endfor %}
+

--- a/tools/browsers/index.html
+++ b/tools/browsers/index.html
@@ -27,7 +27,9 @@ tools_menu: true
   {% endif %}
   <hr>
   <h3>
-    <b><i>Glycine {{ species }}</i> accessions</b>
+    <b>
+      <i>{{ genus }} {{ species }}</i>
+      accessions</b>
   </h3>
   {% for datatype_dir in site.data.datastore-metadata[genus][species] %}
     {% assign datatype = datatype_dir[0] %}
@@ -45,9 +47,15 @@ tools_menu: true
       {% assign existing_headers = '' | split: ',' %}
       {% for strain in about.strains %}
         {% unless existing_headers contains strain.accession_group %}
-          <h4>
-            <b>{{ strain.accession_group }}</b>
+          <h4 class="uk-margin-small-bottom">
+            <b>{{ strain.accession_group }}</b><br>
           </h4>
+          <h5 class="uk-margin-small-top">
+            <i>
+              <a href="https://doi.org/{{ strain.publication_doi }}">doi.org/{{ strain.publication_doi }}</a>
+            </i>
+          </h5>
+
           {% assign existing_headers = existing_headers | push: strain.accession_group %}
         {% endunless %}
         {% for collection_dir in datatype_dir[1] %}
@@ -89,4 +97,3 @@ tools_menu: true
     {% endif %}
   {% endfor %}
 {% endfor %}
-


### PR DESCRIPTION
Modified resources index page has a cleaner listing with the species order being taken from `GENUS/about_this_collection/description_{Genus}.yml`.  
Accessions are grouped together under an accession group header and provide a link to a genome browser as well as a DOI link after the synopsis. 