### PR TITLE
Rearranged about the soybase genetic maps under community

### DIFF
--- a/_data/community.yml
+++ b/_data/community.yml
@@ -28,8 +28,6 @@
       url: "https://www.ncsrp.com/"
   - name: "Communications"
     resources:
-    - description: "About the SoyBase Genetic Maps"
-      url: "https://soybase.org/community/aboutgeneticmaps.php"
     - description: "Soybean Genetics Newsletter"
       url: "/community/sgn"
     - description: "2009 Soybean Genomic Sequence Assembly Announcement"

--- a/_data/community.yml
+++ b/_data/community.yml
@@ -28,6 +28,8 @@
       url: "https://www.ncsrp.com/"
   - name: "Communications"
     resources:
+    - description: "About the SoyBase Genetic Maps"
+      url: "/about/about_maps/"
     - description: "Soybean Genetics Newsletter"
       url: "/community/sgn"
     - description: "2009 Soybean Genomic Sequence Assembly Announcement"

--- a/_data/community.yml
+++ b/_data/community.yml
@@ -28,12 +28,8 @@
       url: "https://www.ncsrp.com/"
   - name: "Communications"
     resources:
-    - description: "About the SoyBase Genetic Maps"
-      url: "/about/about_maps/"
     - description: "Soybean Genetics Newsletter"
       url: "/community/sgn"
-    - description: "2009 Soybean Genomic Sequence Assembly Announcement"
-      url: "https://soybase.org/community/about_sequence_map.php"
     - description: "2000 Soybean Genomics White Paper"
       url: "https://soybase.org/archive/Genomics/Soybean_Genomics.html"
     - description: "2000 Soybean Genetic Resources White Paper"

--- a/_data/map_resources.yml
+++ b/_data/map_resources.yml
@@ -9,7 +9,7 @@ resources:
     description: "Association viewers (QTL, GWAS)"
     name: ZZBrowse
   -
-    URL: "https://soybase.org/gcvit"
+    URL: "/tools/gcvit"
     description: "Genotype comparison visualization tool"
     name: GCViT
   -

--- a/maps/index.html
+++ b/maps/index.html
@@ -19,7 +19,8 @@ tools_menu: true
   Maps below show QTLs and GWAS features. Click a chromosome number to go to the corresponding linkage group views. 
   See correspondences on rollover: chromosome Gm<strong>01</strong> ==> linkage group <strong>D1a</strong>; 
   chromosome Gm<strong>20</strong> ==> linkage group <strong>I</strong>, etc. <br>
-  For more convenient browsing, the QTLs have been divided into the categories listed below.
+  For more convenient browsing, the QTLs have been divided into the categories listed below. <br>
+  <a href="/about/about_maps/" target="_blank">Details about the SoyBase genetic maps.</a>
 </p>
 
 {% comment %}


### PR DESCRIPTION
Removed "about the SoyBase Genetic maps" under community, and added a link "Details about the SoyBase genetic maps" to MAPS. Changed GCViT URL link under MAPS.