### PR TITLE
Updated web components and added gene search examples

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,7 +57,7 @@ liquid:
 strict_front_matter: true
 
 # the GraphQL Server URI; LIS by default
-graphql_uri: https://graphql.lis.ncgr.org/
+graphql_uri: https://graphql.soybase.ncgr.org/
 
 # Build settings
 theme: jekyll-theme-legumeinfo
@@ -72,7 +72,7 @@ plugins:
   # - jekyll-sitemap
 
 # LIS Web Components
-web_components_version: 1.2.0
+web_components_version: 1.3.0
 
 #### jekyll-datapage-generator config
 page_gen:

--- a/tools/search/gene.html
+++ b/tools/search/gene.html
@@ -4,7 +4,7 @@ title: Gene Search
 web_components: true
 ---
 <!-- the custom gene search element -->
-<lis-gene-search-element id="gene-search" genus="Glycine"></lis-gene-search-element>
+<lis-gene-search-element id="gene-search" genus="Glycine" identifierExample="Glyma.16G044100" descriptionExample="proteasome subunit alpha" familyExample="L_6BFHQX"></lis-gene-search-element>
 <lis-modal-element modalId="modal">
   <lis-linkout-element id="linkouts"></lis-linkout-element>
 </lis-modal-element>


### PR DESCRIPTION
- Web components are now at version 1.3.0
- GraphQL uri is changed to `https://graphql.soybase.ncgr.org/`
- Gene search has examples from [the issue](https://github.com/soybase/jekyll-soybase/issues/76#issuecomment-1874757172) (set in the html attributes of the component)