### PR TITLE
Submodule update - round 2

### DIFF
--- a/tools/search/gene.html
+++ b/tools/search/gene.html
@@ -10,10 +10,22 @@ web_components: true
 </lis-modal-element>
 
 <script type="module">
-  import {getOrganismsFormDataFunction, geneSearchFunctionFactory, allLinkoutsFunction, geneLinkoutsFunction, geneIdentifierModalLinkFactory, locationModalLinkFactory} from "lis-graphql";
+    import {
+    // genes
+    getOrganismsFormDataFunction,
+    geneSearchFunctionFactory,
+    allModalLinksFactory,
+    // linkouts
+    allLinkoutsFunction,
+    // modal
+    modalEventToLinkData
+  } from "lis-graphql";
   const geneSearchElement = document.getElementById('gene-search');
   geneSearchElement.formDataFunction = getOrganismsFormDataFunction;
-  geneSearchElement.searchFunction = geneSearchFunctionFactory(geneIdentifierModalLinkFactory('modal'), locationModalLinkFactory('modal'));
+  const searchDataProcessors = allModalLinksFactory('modal');
+  geneSearchElement.searchFunction =
+    geneSearchFunctionFactory(...searchDataProcessors);
+
   const linkoutElement = document.getElementById('linkouts');
   const modal = document.getElementById('modal');
   modal.addEventListener('toggle', (event) => {


### PR DESCRIPTION
After yesterday's merge attempt failed, I updated the Data Store READMEs (adding `scientific_name_abbrev` where it was missing). I had deleted the branch, so today I recovered it; that's what you're looking at.