### PR TITLE
Update the gene-name translator page

### DIFF
--- a/tools/translate/index.html
+++ b/tools/translate/index.html
@@ -4,41 +4,47 @@ sitemap: correspondence
 tools_menu: true
 
 example:
-- pangene: Glycine.pan4.pan00923
-  glyma_Wm82_gnm1_ann1: Glyma01g08690
-  glyma_Wm82_gnm2_ann1: Glyma.01G066000
-  glyma_Wm82_gnm4_ann1: Glyma.01G066000
-  glyma_Lee_gnm1_ann1: GlymaLee.01G056800
+- pangene: Glycine.pan5.pan46446
+  glyma_Wm82_gnm1_ann1: Glyma01g00210
+  glyma_Wm82_gnm2_ann1: Glyma.01G000100
+  glyma_Wm82_gnm4_ann1: Glyma.01G000100
+  glyma_Wm82_gnm5_ann1: NONE
+  glyma_Wm82_gnm6_ann1: Glyma.01G000100
   more: ...
-- pangene: Glycine.pan4.pan79925
-  glyma_Wm82_gnm1_ann1: Glyma01g08730, Glyma01g08760
-  glyma_Wm82_gnm2_ann1: Glyma.01G066300
-  glyma_Wm82_gnm4_ann1: Glyma.01G066300, Glyma.01G066100
-  glyma_Lee_gnm1_ann1: GlymaLee.01G057000, GlymaLee.01G056900
+- pangene: Glycine.pan5.pan46447
+  glyma_Wm82_gnm1_ann1: Glyma01g00291
+  glyma_Wm82_gnm2_ann1: Glyma.01G000300
+  glyma_Wm82_gnm4_ann1: Glyma.01G000322
+  glyma_Wm82_gnm5_ann1: Gm_Wm82_00003
+  glyma_Wm82_gnm6_ann1: Glyma.01G000322
   more: ...
-- pangene: Glycine.pan4.pan29456
-  glyma_Wm82_gnm1_ann1: Glyma01g08980
-  glyma_Wm82_gnm2_ann1: Glyma.01G066500
-  glyma_Wm82_gnm4_ann1: Glyma.01G066500
-  glyma_Lee_gnm1_ann1: NONE
+- pangene: Glycine.pan5.pan43005
+  glyma_Wm82_gnm1_ann1: Glyma01g00300
+  glyma_Wm82_gnm2_ann1: Glyma.01G000400
+  glyma_Wm82_gnm4_ann1: Glyma.01G000400
+  glyma_Wm82_gnm5_ann1: NONE
+  glyma_Wm82_gnm6_ann1: Glyma.01G000400
   more: ...
-- pangene: Glycine.pan4.pan29457
-  glyma_Wm82_gnm1_ann1: Glyma01g09010
-  glyma_Wm82_gnm2_ann1: Glyma.01G066600
-  glyma_Wm82_gnm4_ann1: Glyma.01G066600
-  glyma_Lee_gnm1_ann1: NONE
+- pangene: Glycine.pan5.pan34709
+  glyma_Wm82_gnm1_ann1: Glyma01g00321
+  glyma_Wm82_gnm2_ann1: Glyma.01G000600
+  glyma_Wm82_gnm4_ann1: Glyma.01G000600
+  glyma_Wm82_gnm5_ann1: NONE
+  glyma_Wm82_gnm6_ann1: Glyma.01G000600
   more: ...
-- pangene: Glycine.pan4.pan00924
-  glyma_Wm82_gnm1_ann1: Glyma01g09120
-  glyma_Wm82_gnm2_ann1: Glyma.01G067000
-  glyma_Wm82_gnm4_ann1: Glyma.01G067000
-  glyma_Lee_gnm1_ann1: GlymaLee.01G057300
+- pangene: Glycine.pan5.pan74052
+  glyma_Wm82_gnm1_ann1: NONE
+  glyma_Wm82_gnm2_ann1: NONE
+  glyma_Wm82_gnm4_ann1: NONE
+  glyma_Wm82_gnm5_ann1: NONE
+  glyma_Wm82_gnm6_ann1: Glyma.01G000750
   more: ...
-- pangene: Glycine.pan4.pan99999
+- pangene: Glycine.pan5.pan99999
   glyma_Wm82_gnm1_ann1: ...
   glyma_Wm82_gnm2_ann1: ...
   glyma_Wm82_gnm4_ann1: ...
-  glyma_Lee_gnm1_ann1: ...
+  glyma_Wm82_gnm5_ann1: ...
+  glyma_Wm82_gnm6_ann1: ...
   more: ...
 
 ---
@@ -50,27 +56,49 @@ example:
 
   <b>There are several good options for identifying corresponding genes in different accessions or annotations. If you have ...</b>
   <ul>
+    <li> One or a few genes to look up? Use the <a href="/tools/search/gene.html"><b>Gene Search tool</b></a>, 
+    then click on the "PANGENE SETS" link. 
+    <details>
+      Try it out with a <a href="/tools/search/gene.html?page=1&genus=Glycine&species=max&strain=&identifier=Glyma.01G000322&description=&family=">sample gene, Glyma.01G000322</a>.<br>
+      At the linked pangene report page in InterMine (set "Rows to page" to "All" to see all corresponding genes).
+      <br>
+    </details>
+    </li>
     <li> Many genes to look up among <b>reference</b> accessions? Download a 
-        <a href="https://soybase.org/data/v2/Glycine/GENUS/pangenes/Glycine.pan4.RK4P/Glycine.pan4.RK4P.table_ref_lines.tsv.gz">
+        <a href="https://soybase.org/data/v2/Glycine/GENUS/pangenes/Glycine.pan5.MKRS/Glycine.pan5.MKRS.table_ref_lines.tsv.gz">
           <b>correspondence table for the reference lines</b>.
         </a>
+
       <details>
         <ul>
+          <li>#pangene</li>
+          <li>glyma.FiskebyIII.gnm1.ann1</li>
+          <li>glyma.JD17.gnm1.ann1</li>
+          <li>glyma.Lee.gnm1.ann1</li>
+          <li>glyma.Lee.gnm2.ann1</li>
           <li>glyma.Wm82.gnm1.ann1 = Wm82.a1.v1</li>
           <li>glyma.Wm82.gnm2.ann1 = Wm82.a2.v1</li>
           <li>glyma.Wm82.gnm4.ann1 = Wm82.a4.v1</li>
-          <li>glyma.Wm82_IGA1008.gnm1.ann1</li>
-          <li>glyma.Wm82_ISU01.gnm2.ann1 = Wm82.a6.v1</li>
-          <li>glyma.Lee.gnm1.ann1</li>
-          <li>glyma.Lee.gnm2.ann1</li>
+          <li>glyma.Wm82.gnm5.ann1</li>
+          <li>glyma.Wm82.gnm6.ann1 = Wm82.a6.v1</li>
+          <li>glyma.Wm82_NJAU.gnm1.ann1</li>
           <li>glyma.Zh13.gnm1.ann1</li>
           <li>glyma.Zh13.gnm2.ann1</li>
           <li>glyma.Zh13_IGA1005.gnm1.ann1</li>
-          <li>glyma.JD17.gnm1.ann1</li>
+          <li>glyma.Zh35_IGA1004.gnm1.ann1</li>
         <ul>
+        
+        To work with this file, uncompress it, then open it using Excel or similar spreadsheet program;<br>
+        or if you have a little familiarity with a Unix terminal, you can extract data in many ways (a few examples):
+<pre>
+  cat Glycine.pan5.MKRS.table_ref_lines.tsv | tr '\t' '\n'   # to see the list of headers
+  cut -f1,2,8,10 Glycine.pan5.MKRS.table_ref_lines.tsv | head   # to see four selected columns (the first 10 entries)
+  grep -f YOUR_LIST_OF_GENES.txt Glycine.pan5.MKRS.table_ref_lines.tsv  # to search a provided list of gene IDs against the file
+</pre>
       </details>
+
     <li> Many genes to look up among non-reference accessions? Download a 
-        <a href="https://soybase.org/data/v2/Glycine/GENUS/pangenes/Glycine.pan4.RK4P/Glycine.pan4.RK4P.table.tsv.gz">
+        <a href="https://soybase.org/data/v2/Glycine/GENUS/pangenes/Glycine.pan5.MKRS/Glycine.pan5.MKRS.table.tsv.gz">
           <b>correspondence table for <b>all</b> pangene accessions.</b>
         </a>
       <details>
@@ -97,6 +125,7 @@ example:
           <li>glyma.KeShanNo_1.gnm1.ann1</li>
           <li>glyma.Lee.gnm1.ann1</li>
           <li>glyma.Lee.gnm2.ann1</li>
+          <li>glyma.Lee.gnm3.ann1</li>
           <li>glyma.PI_398296.gnm1.ann1</li>
           <li>glyma.PI_548362.gnm1.ann1</li>
           <li>glyma.QiHuangNo_34.gnm1.ann1</li>
@@ -106,11 +135,14 @@ example:
           <li>glyma.TongShanTianEDan.gnm1.ann1</li>
           <li>glyma.WanDouNo_28.gnm1.ann1</li>
           <li>glyma.Wenfeng7_IGA1001.gnm1.ann1</li>
-          <li>glyma.Wm82.gnm1.ann1 = Wm82.a1.v1</li>
-          <li>glyma.Wm82.gnm2.ann1 = Wm82.a2.v1</li>
-          <li>glyma.Wm82.gnm4.ann1 = Wm82.a4.v1</li>
+          <li>glyma.Wm82.gnm1.ann1</li>
+          <li>glyma.Wm82.gnm2.ann1</li>
+          <li>glyma.Wm82.gnm4.ann1</li>
+          <li>glyma.Wm82.gnm5.ann1</li>
+          <li>glyma.Wm82.gnm6.ann1</li>
           <li>glyma.Wm82_IGA1008.gnm1.ann1</li>
-          <li>glyma.Wm82_ISU01.gnm2.ann1 = Wm82.a6.v1</li>
+          <li>glyma.Wm82_ISU01.gnm2.ann1</li>
+          <li>glyma.Wm82_NJAU.gnm1.ann1</li>
           <li>glyma.XuDouNo_1.gnm1.ann1</li>
           <li>glyma.YuDouNo_22.gnm1.ann1</li>
           <li>glyma.Zh13.gnm1.ann1</li>
@@ -129,15 +161,20 @@ example:
           <li>glyst.G1974.gnm1.ann1</li>
           <li>glysy.G1300.gnm1.ann1</li>
         <ul>
+        To work with this file, uncompress it, then open it using Excel or similar spreadsheet program;<br>
+        or if you have a little familiarity with a Unix terminal, you can extract data in many ways (a few examples):
+<pre>
+  cat Glycine.pan5.MKRS.table.tsv | head -1 | tr '\t' '\n'   # to see the list of headers
+  cut -f1,2,8,10 Glycine.pan5.MKRS.table.tsv| head   # to see four selected columns (the first 10 entries)
+  grep -f YOUR_LIST_OF_GENES.txt Glycine.pan5.MKRS.table.tsv  # to search a provided list of gene IDs against the file
+</pre>
       </details>
-      </details>
-    <li> Coming soon (est. Jan 2024): a pangene search tool for interactively looking up individual genes.</a>.
   </ul>
 </p> 
 <!--    <li> One or a few genes to look up? Use the <a href=""><b>pangene search tool</b></a>.> -->
 
 <p>Sample data from the 
-  <a href="https://soybase.org/data/v2/Glycine/GENUS/pangenes/Glycine.pan4.RK4P/Glycine.pan4.RK4P.table_ref_lines.tsv.gz">
+  <a href="https://soybase.org/data/v2/Glycine/GENUS/pangenes/Glycine.pan5.MKRS/Glycine.pan5.MKRS.table_ref_lines.tsv.gz">
     <b>correspondence table for the reference lines</b>:
   </a>
 </p>
@@ -147,7 +184,7 @@ example:
     <th class="uk-text-center uk-text-normal">Wm82.gnm1.ann1 / Wm82.a1.v1</th>
     <th class="uk-text-center uk-text-normal">Wm82.gnm2.ann1 / Wm82.a2.v1</th>
     <th class="uk-text-center uk-text-normal">Wm82.gnm4.ann1 / Wm82.a4.v1</th>
-    <th class="uk-text-center uk-text-normal">Lee.gnm1.ann1 / Lee.a1.v1</th>
+    <th class="uk-text-center uk-text-normal">Wm82.gnm6.ann1 / Wm82.a6.v1</th>
     <th class="uk-text-center uk-text-normal">more</th>
   </tr>
   {% for name in page.example %}
@@ -156,7 +193,7 @@ example:
       <td class="uk-text-light">{{ name.glyma_Wm82_gnm1_ann1 }}</td>
       <td class="uk-text-light">{{ name.glyma_Wm82_gnm2_ann1 }}</td>
       <td class="uk-text-light">{{ name.glyma_Wm82_gnm4_ann1 }}</td>
-      <td class="uk-text-light">{{ name.glyma_Lee_gnm1_ann1 }}</td>
+      <td class="uk-text-light">{{ name.glyma_Wm82_gnm6_ann1 }}</td>
       <td class="uk-text-light">{{ name.more }}</td>
     </tr>
   {% endfor %}
@@ -179,7 +216,7 @@ The method is described briefly here:
 
 <p>The Pandagma package is available at <a href="https://github.com/legumeinfo/pandagma">https://github.com/legumeinfo/pandagma</a>, including the configuration used to calculate the pangene data above.</p>
 
-<p>The pangene collection for Glycine, including data in several formats and descriptions of the fies, is in the <a href="https://soybase.org/data/v2/Glycine/GENUS/pangenes/Glycine.pan4.RK4P/Glycine.pan4.RK4P.table.tsv.gz">"Glycine/GENUS/pangenes"</a> section of the Data Store.</p>
+<p>The pangene collection for Glycine, including data in several formats and descriptions of the fies, is in the <a href="https://soybase.org/data/v2/Glycine/GENUS/pangenes/Glycine.pan5.MKRS/Glycine.pan5.MKRS.table.tsv.gz">"Glycine/GENUS/pangenes"</a> section of the Data Store.</p>
 
 <p>If you have extensive programmatic work and need to translate among arbitrary accessions, 
   the <a href="https://github.com/legumeinfo/pandagma/blob/main/bin/gene_translate.pl">gene_translate.pl</a> 


### PR DESCRIPTION
Update the gene-name translator page, replacing pan4 with pan5 and linking to the Gene Search Tool. Also gave some hints for working with the tabular data (in Details for the second and third bullets):

<i>To work with this file, uncompress it, then open it using Excel or similar spreadsheet program;
or if you have a little familiarity with a Unix terminal, you can extract data in many ways (a few examples):</i>
```
  cat Glycine.pan5.MKRS.table_ref_lines.tsv | tr '\t' '\n'   # to see the list of headers
  cut -f1,2,8,10 Glycine.pan5.MKRS.table_ref_lines.tsv | head   # to see four selected columns (the first 10 entries)
  grep -f YOUR_LIST_OF_GENES.txt Glycine.pan5.MKRS.table_ref_lines.tsv  # to search a provided list of gene IDs against the file
```

The pan-gene set in GlycineMine is still using pan4; this will change when the mine is rebuilt. The correspondences should still work but Wm82.a6 is missing from pan4.