### PR TITLE
Remove http-server node package

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -119,8 +119,8 @@ jobs:
         with:
           name: github-pages
       - run: tar -xf artifact.tar && rm artifact.tar
-      - run: npm install -g pa11y-ci@3.X http-server
-      - run: http-server . -c-1 -p 4000 &
+      - run: npm install -g pa11y-ci@3.X
+      - run: busybox httpd -p 4000
       # FIXME: patty-ci concurrency > 1 results in errors in this GA workflow
       - run: |
           printf '{"defaults": {"runners": ["axe"]}}\n' > .pa11yci

--- a/_config.yml
+++ b/_config.yml
@@ -135,6 +135,7 @@ defaults:
       path: "assets"
     values:
       layout: "none"
+      sitemap: false
 
 # Exclude from processing.
 # The following items will not be processed, by default.


### PR DESCRIPTION
Work around http-server installation failure in pa11y job by using `busybox httpd` instead.

Also exclude assets from sitemap.