### PR TITLE
Add links to legacy GBrowse instances at top of browsers page

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@ blog_card: true
         <td>
           <div class="uk-button uk-width-1-1 uk-margin-small-bottom" title="Enter one or more sequences and annotate them, view in a phylogenetic tree, etc.">
             <button class="uk-button uk-width-1-1 uk-button-small uk-text-capitalize uk-text-nowrap" type="button" style="background-color:Cornsilk;">
-              <a href="https://funnotate.legumeinfo.org/"><b>Sequence annotate</b></a>
+              <a href="https://funnotate.legumeinfo.org/"><b>Annotate sequences</b></a>
             </button>
           </div>
         </td>

--- a/tools/browsers/gbrowse.html
+++ b/tools/browsers/gbrowse.html
@@ -1,0 +1,5 @@
+---
+layout: iframe
+iframe_url: "https://legacy.soybase.org/gb2/gbrowse/"
+---
+

--- a/tools/browsers/index.html
+++ b/tools/browsers/index.html
@@ -2,17 +2,58 @@
 title: Genome browsers
 sitemap: sequence map
 tools_menu: true
+
+gbrowse_instances:
+- category: "Glycine max"
+  name: "Wm82.a4"
+  url: "https://soybase.org/gb2/gbrowse/glyma.Wm82.gnm4/"
+- category: "Glycine max"
+  name: "Wm82.a2"
+  url: "https://soybase.org/gb2/gbrowse/gmax2.0/"
+  description: "(The largest track collection: genes, markers, expression, methylation, synteny ...)"
+- category: "Glycine max"
+  name: "Wm82.a1"
+  url: "https://soybase.org/gb2/gbrowse/gmax1.01/"
+- category: "Glycine max"
+  name: "Fiskeby III"
+  url: "https://soybase.org/gb2/gbrowse/glyma.FiskebyIII.gnm1/"
+- category: "Glycine max"
+  name: "Lee"
+  url: "https://soybase.org/gb2/gbrowse/glyma.Lee.gnm1/"
+- category: "Glycine max"
+  name: "Zh13"
+  url: "https://soybase.org/gb2/gbrowse/glyma.Zh13.gnm1/"
+- category: "Glycine soja"
+  name: "PI 483463"
+  url: "https://soybase.org/gb2/gbrowse/glyso.PI483463.gnm1/"
+- category: "Glycine soja"
+  name: "W05"
+  url: "https://soybase.org/gb2/gbrowse/glyso.W05.gnm1/"
+
 ---
 
 {% capture jbrowse_base_url %}/assets/js/jbrowse{% endcapture %}
 <h2>Genome browsers</h2>
 
 <p>
-  Genome browsers are available for most of the genome assemblies at SoyBase. 
-  These can be accessed from the
+  Genome browsers can be accessed from the
   <a href="/resources">GENOMICS</a>
-  tab, with browsers listed under each accession -- or directly from the links below.
+  tab, with browsers listed under each accession -- or directly from the links below; legacy GBrowse first, then JBrowse.
 </p>
+
+{% assign groups = page.gbrowse_instances | group_by: "category" | sort: "name" %}
+{% for species in groups %}
+  <u>G</u>Browse instances for <b><i>{{ species.name }}</i></b> (legacy; see newer JBrowse instances below)
+  <br>
+  <div style="margin-left:10px">
+    {% for item in species.items %}
+      <a href="{{ item.url }}"><b>{{ item.name }}</b></a> 
+      {{ item.description }}
+      <br>
+    {% endfor %}
+  </div>
+{% endfor %}
+
 
 {% assign doi = "DOI" %}
 {% assign genus = "Glycine" %}
@@ -27,10 +68,9 @@ tools_menu: true
     {% continue %}
   {% endif %}
   <hr>
+  
   <h3>
-    <b>
-      <i>{{ genus }} {{ species }}</i>
-      accessions</b>
+    <u>J</u>Browse instances for <i><b>{{ genus }} {{ species }}</b></i> accessions
   </h3>
   {% for datatype_dir in site.data.datastore-metadata[genus][species] %}
     {% assign datatype = datatype_dir[0] %}

--- a/tools/browsers/index.html
+++ b/tools/browsers/index.html
@@ -33,29 +33,29 @@ gbrowse_instances:
 gbrowse_iframe_suffixes:
 - category: "Glycine max"
   name: "Wm82.a4"
-  url_suffix: "/gbrowse/glyma.Wm82.gnm4/"
+  url_suffix: "glyma.Wm82.gnm4"
 - category: "Glycine max"
   name: "Wm82.a2"
-  url_suffix: "/gbrowse/gmax2.0/"
+  url_suffix: "gmax2.0"
   description: "(The largest track collection: genes, markers, expression, methylation, synteny ...)"
 - category: "Glycine max"
   name: "Wm82.a1"
-  url_suffix: "/gbrowse/gmax1.01/"
+  url_suffix: "gmax1.01"
 - category: "Glycine max"
   name: "Fiskeby III"
-  url_suffix: "/gbrowse/glyma.FiskebyIII.gnm1/"
+  url_suffix: "glyma.FiskebyIII.gnm1"
 - category: "Glycine max"
   name: "Lee"
-  url_suffix: "/gbrowse/glyma.Lee.gnm1/"
+  url_suffix: "glyma.Lee.gnm1"
 - category: "Glycine max"
   name: "Zh13"
-  url_suffix: "/gbrowse/glyma.Zh13.gnm1/"
+  url_suffix: "glyma.Zh13.gnm1"
 - category: "Glycine soja"
   name: "PI 483463"
-  url_suffix: "/gbrowse/glyso.PI483463.gnm1/"
+  url_suffix: "glyso.PI483463.gnm1"
 - category: "Glycine soja"
   name: "W05"
-  url_suffix: "/gbrowse/glyso.W05.gnm1/"
+  url_suffix: "glyso.W05.gnm1"
 
 ---
 
@@ -91,7 +91,8 @@ gbrowse_iframe_suffixes:
   <br>
   <div style="margin-left:10px">
     {% for item in species.items %}
-      <a href="{{ item.url_suffix | prepend: '/tools/browsers/gbrowse.html?iframe_pathname_suffix=' }}"><b>{{ item.url_suffix | prepend: '/tools/browsers/gbrowse.html?iframe_pathname_suffix=' }}</b></a>
+      <a href="{{ item.url_suffix | prepend: '/tools/browsers/gbrowse.html?iframe_pathname_suffix=' }}"><b>{{ item.name }}</b>
+      </a>
       {{ item.description }}
       <br>
     {% endfor %}

--- a/tools/browsers/index.html
+++ b/tools/browsers/index.html
@@ -5,39 +5,11 @@ tools_menu: true
 
 gbrowse_instances:
 - category: "Glycine max"
-  name: "Wm82.a4"
-  url: "https://legacy.soybase.org/gb2/gbrowse/glyma.Wm82.gnm4/"
-- category: "Glycine max"
   name: "Wm82.a2"
-  url: "https://legacy.soybase.org/gb2/gbrowse/gmax2.0/"
-  description: "(The largest track collection: genes, markers, expression, methylation, synteny ...)"
-- category: "Glycine max"
-  name: "Wm82.a1"
-  url: "https://legacy.soybase.org/gb2/gbrowse/gmax1.01/"
-- category: "Glycine max"
-  name: "Fiskeby III"
-  url: "https://legacy.soybase.org/gb2/gbrowse/glyma.FiskebyIII.gnm1/"
-- category: "Glycine max"
-  name: "Lee"
-  url: "https://legacy.soybase.org/gb2/gbrowse/glyma.Lee.gnm1/"
-- category: "Glycine max"
-  name: "Zh13"
-  url: "https://legacy.soybase.org/gb2/gbrowse/glyma.Zh13.gnm1/"
-- category: "Glycine soja"
-  name: "PI 483463"
-  url: "https://legacy.soybase.org/gb2/gbrowse/glyso.PI483463.gnm1/"
-- category: "Glycine soja"
-  name: "W05"
-  url: "https://legacy.soybase.org/gb2/gbrowse/glyso.W05.gnm1/"
-
-gbrowse_iframe_suffixes:
+  url_suffix: "gmax2.0"
 - category: "Glycine max"
   name: "Wm82.a4"
   url_suffix: "glyma.Wm82.gnm4"
-- category: "Glycine max"
-  name: "Wm82.a2"
-  url_suffix: "gmax2.0"
-  description: "(The largest track collection: genes, markers, expression, methylation, synteny ...)"
 - category: "Glycine max"
   name: "Wm82.a1"
   url_suffix: "gmax1.01"
@@ -68,36 +40,28 @@ gbrowse_iframe_suffixes:
   tab, with browsers listed under each accession -- or directly from the links below; legacy GBrowse first, then JBrowse.
 </p>
 
+<b><u>G</u>Browse instances</b> (legacy; see newer JBrowse instances below). The largest track collection is in Wm82.a2.
 <br>
-
-<p><b>TEST direct links:</b></p>
+(Click <b>**</b> for unframed links: use for Safari; also useful for bookmarking and sharing track configurations and views)
+<br>
 {% assign groups = page.gbrowse_instances | group_by: "category" | sort: "name" %}
+{% assign asterisk = "**" %}
 {% for species in groups %}
-  <u>G</u>Browse instances for <b><i>{{ species.name }}</i></b> (legacy; see newer JBrowse instances below)
+  <u><i>{{ species.name }}</i></u>
   <br>
-  <div style="margin-left:10px">
+  {%- capture browser_list -%}
     {% for item in species.items %}
-      <a href="{{ item.url }}"><b>{{ item.name }}</b></a> 
-      {{ item.description }}
-      <br>
+      <a href="{{ item.url_suffix | prepend: '/tools/browsers/gbrowse.html?iframe_pathname_suffix=' }}">
+        <b>{{ item.name | prepend: ", " }} </b>
+      </a>
+      <a href="{{ item.url_suffix | prepend: 'https://legacy.soybase.org/gb2/gbrowse/' }}"><b>{{ asterisk }}</b></a> 
     {% endfor %}
+  {%- endcapture -%}
+  <div style="margin-left:10px">
+    {{ browser_list | remove_first: ', ' }}
   </div>
 {% endfor %}
 
-<p><b>TEST iframed links:</b></p>
-{% assign groups = page.gbrowse_iframe_suffixes | group_by: "category" | sort: "name" %}
-{% for species in groups %}
-  <u>G</u>Browse instances for <b><i>{{ species.name }}</i></b> (legacy; see newer JBrowse instances below)
-  <br>
-  <div style="margin-left:10px">
-    {% for item in species.items %}
-      <a href="{{ item.url_suffix | prepend: '/tools/browsers/gbrowse.html?iframe_pathname_suffix=' }}"><b>{{ item.name }}</b>
-      </a>
-      {{ item.description }}
-      <br>
-    {% endfor %}
-  </div>
-{% endfor %}
 
 {% assign doi = "DOI" %}
 {% assign genus = "Glycine" %}

--- a/tools/browsers/index.html
+++ b/tools/browsers/index.html
@@ -6,29 +6,56 @@ tools_menu: true
 gbrowse_instances:
 - category: "Glycine max"
   name: "Wm82.a4"
-  url: "https://soybase.org/gb2/gbrowse/glyma.Wm82.gnm4/"
+  url: "https://legacy.soybase.org/gb2/gbrowse/glyma.Wm82.gnm4/"
 - category: "Glycine max"
   name: "Wm82.a2"
-  url: "https://soybase.org/gb2/gbrowse/gmax2.0/"
+  url: "https://legacy.soybase.org/gb2/gbrowse/gmax2.0/"
   description: "(The largest track collection: genes, markers, expression, methylation, synteny ...)"
 - category: "Glycine max"
   name: "Wm82.a1"
-  url: "https://soybase.org/gb2/gbrowse/gmax1.01/"
+  url: "https://legacy.soybase.org/gb2/gbrowse/gmax1.01/"
 - category: "Glycine max"
   name: "Fiskeby III"
-  url: "https://soybase.org/gb2/gbrowse/glyma.FiskebyIII.gnm1/"
+  url: "https://legacy.soybase.org/gb2/gbrowse/glyma.FiskebyIII.gnm1/"
 - category: "Glycine max"
   name: "Lee"
-  url: "https://soybase.org/gb2/gbrowse/glyma.Lee.gnm1/"
+  url: "https://legacy.soybase.org/gb2/gbrowse/glyma.Lee.gnm1/"
 - category: "Glycine max"
   name: "Zh13"
-  url: "https://soybase.org/gb2/gbrowse/glyma.Zh13.gnm1/"
+  url: "https://legacy.soybase.org/gb2/gbrowse/glyma.Zh13.gnm1/"
 - category: "Glycine soja"
   name: "PI 483463"
-  url: "https://soybase.org/gb2/gbrowse/glyso.PI483463.gnm1/"
+  url: "https://legacy.soybase.org/gb2/gbrowse/glyso.PI483463.gnm1/"
 - category: "Glycine soja"
   name: "W05"
-  url: "https://soybase.org/gb2/gbrowse/glyso.W05.gnm1/"
+  url: "https://legacy.soybase.org/gb2/gbrowse/glyso.W05.gnm1/"
+
+gbrowse_iframe_suffixes:
+- category: "Glycine max"
+  name: "Wm82.a4"
+  url_suffix: "/gbrowse/glyma.Wm82.gnm4/"
+- category: "Glycine max"
+  name: "Wm82.a2"
+  url_suffix: "/gbrowse/gmax2.0/"
+  description: "(The largest track collection: genes, markers, expression, methylation, synteny ...)"
+- category: "Glycine max"
+  name: "Wm82.a1"
+  url_suffix: "/gbrowse/gmax1.01/"
+- category: "Glycine max"
+  name: "Fiskeby III"
+  url_suffix: "/gbrowse/glyma.FiskebyIII.gnm1/"
+- category: "Glycine max"
+  name: "Lee"
+  url_suffix: "/gbrowse/glyma.Lee.gnm1/"
+- category: "Glycine max"
+  name: "Zh13"
+  url_suffix: "/gbrowse/glyma.Zh13.gnm1/"
+- category: "Glycine soja"
+  name: "PI 483463"
+  url_suffix: "/gbrowse/glyso.PI483463.gnm1/"
+- category: "Glycine soja"
+  name: "W05"
+  url_suffix: "/gbrowse/glyso.W05.gnm1/"
 
 ---
 
@@ -41,6 +68,9 @@ gbrowse_instances:
   tab, with browsers listed under each accession -- or directly from the links below; legacy GBrowse first, then JBrowse.
 </p>
 
+<br>
+
+<p><b>TEST direct links:</b></p>
 {% assign groups = page.gbrowse_instances | group_by: "category" | sort: "name" %}
 {% for species in groups %}
   <u>G</u>Browse instances for <b><i>{{ species.name }}</i></b> (legacy; see newer JBrowse instances below)
@@ -54,6 +84,19 @@ gbrowse_instances:
   </div>
 {% endfor %}
 
+<p><b>TEST iframed links:</b></p>
+{% assign groups = page.gbrowse_iframe_suffixes | group_by: "category" | sort: "name" %}
+{% for species in groups %}
+  <u>G</u>Browse instances for <b><i>{{ species.name }}</i></b> (legacy; see newer JBrowse instances below)
+  <br>
+  <div style="margin-left:10px">
+    {% for item in species.items %}
+      <a href="{{ item.url_suffix | prepend: '/tools/browsers/gbrowse.html?iframe_pathname_suffix=' }}"><b>{{ item.url_suffix | prepend: '/tools/browsers/gbrowse.html?iframe_pathname_suffix=' }}</b></a>
+      {{ item.description }}
+      <br>
+    {% endfor %}
+  </div>
+{% endfor %}
 
 {% assign doi = "DOI" %}
 {% assign genus = "Glycine" %}

--- a/tools/browsers/index.html
+++ b/tools/browsers/index.html
@@ -8,6 +8,9 @@ gbrowse_instances:
   name: "Wm82.a2"
   url_suffix: "gmax2.0"
 - category: "Glycine max"
+  name: "Wm82.a6"
+  url_suffix: "glyma.Wm82.gnm6"
+- category: "Glycine max"
   name: "Wm82.a4"
   url_suffix: "glyma.Wm82.gnm4"
 - category: "Glycine max"
@@ -42,7 +45,7 @@ gbrowse_instances:
 
 <b><u>G</u>Browse instances</b> (legacy; see newer JBrowse instances below). The largest track collection is in Wm82.a2.
 <br>
-(Click <b>**</b> for unframed links: use for Safari; also useful for bookmarking and sharing track configurations and views)
+(Click <b>**</b> for unframed links: useful for bookmarking and sharing track configurations and views)
 <br>
 {% assign groups = page.gbrowse_instances | group_by: "category" | sort: "name" %}
 {% assign asterisk = "**" %}
@@ -54,7 +57,9 @@ gbrowse_instances:
       <a href="{{ item.url_suffix | prepend: '/tools/browsers/gbrowse.html?iframe_pathname_suffix=' }}">
         <b>{{ item.name | prepend: ", " }} </b>
       </a>
-      <a href="{{ item.url_suffix | prepend: 'https://legacy.soybase.org/gb2/gbrowse/' }}"><b>{{ asterisk }}</b></a> 
+      <a href="{{ item.url_suffix | prepend: 'https://legacy.soybase.org/gb2/gbrowse/' }}" target="_blank">
+        <b>{{ asterisk }}</b>
+      </a> 
     {% endfor %}
   {%- endcapture -%}
   <div style="margin-left:10px">


### PR DESCRIPTION
Add links to legacy GBrowse instances at top of browsers page. A few other tweaks to the page layout.

To consider: should we put the GBrowse instances into I-frames? My inclination is "no" unless the SoyBase classic nav is removed. Probably worth some discussion here and/or at SoyBase meeting.