### PR TITLE
Updated SoyMap II project page

### DIFF
--- a/_data/projects/Zhuang_Wang_2022/project_details.yml
+++ b/_data/projects/Zhuang_Wang_2022/project_details.yml
@@ -1,110 +1,102 @@
 ---
--
-  DataStoreID: "Zhuang_Wang_2022"
-  short_title: "SoyMap II"
-  SoyBaseID: "SoyBase.C2022.01"
+- DataStoreID: Zhuang_Wang_2022
+  short_title: SoyMap II
+  SoyBaseID: SoyBase.C2022.01
   title: "SoyMap II: Leveraging untapped genetic diversity in soybean"
-  description: "Genomes and gene models were generated from multiple perennial soybean species across the Glycine genus to study insights into the polyploid and perennial genome evolution and genetic potential for soybean improvement."
-  BioProjectID: "PRJNA503746"
+  description: 'Genomes and gene models were generated from multiple perennial
+    soybean species across the Glycine genus to study insights into the
+    polyploid and perennial genome evolution and genetic potential for soybean
+    improvement.<br> <a
+    href="https://www.ncbi.nlm.nih.gov/bioproject/PRJNA315596"
+    target="_blank">NCBI BioProject for NSF SoyMapII project</a> (with links to
+    Illumina HiSeq data in SRA)</br> <a
+    href="https://www.ncbi.nlm.nih.gov/bioproject/PRJNA503746"
+    target="_blank">NCBI BioProject for subsequent genome sequencing project,
+    coordinated by Shandong Agricultural University</a> '
   publications:
-    - citation: "Zhuang Y, Wang X, Li X, Hu J, Fan L, Landis JB, Cannon SB, Grimwood J, Schmutz J, Jackson SA, Doyle JJ, Zhang XS, Zhang D, Ma J. Phylogenomics of the genus Glycine sheds light on polyploid evolution and life-strategy transition. Nat Plants. 2022 Mar;8(3):233-244."
-      doi: "10.1038/s41477-022-01102-4"
-      abstract: "Polyploidy and life-strategy transitions between annuality and perenniality often occur in flowering plants. However, the evolutionary propensities of polyploids and the genetic bases of such transitions remain elusive. We assembled chromosome-level genomes of representative perennial species across the genus Glycine including five diploids and a young allopolyploid, and constructed a Glycine super-pangenome framework by integrating 26 annual soybean genomes. These perennial diploids exhibit greater genome stability and possess fewer centromere repeats than the annuals. Biased subgenomic fractionation occurred in the allopolyploid, primarily by accumulation of small deletions in gene clusters through illegitimate recombination, which was associated with pre-existing local subgenomic differentiation. Two genes annotated to modulate vegetative-reproductive phase transition and lateral shoot outgrowth were postulated as candidates underlying the perenniality-annuality transition. Our study provides insights into polyploid genome evolution and lays a foundation for unleashing genetic potential from the perennial gene pool for soybean improvement."
+    - citation: Zhuang Y, Wang X, Li X, Hu J, Fan L, Landis JB, Cannon SB, Grimwood J,
+        Schmutz J, Jackson SA, Doyle JJ, Zhang XS, Zhang D, Ma J. Phylogenomics
+        of the genus Glycine sheds light on polyploid evolution and
+        life-strategy transition. Nat Plants. 2022 Mar;8(3):233-244.
+      doi: 10.1038/s41477-022-01102-4
+      abstract: Polyploidy and life-strategy transitions between annuality and
+        perenniality often occur in flowering plants. However, the evolutionary
+        propensities of polyploids and the genetic bases of such transitions
+        remain elusive. We assembled chromosome-level genomes of representative
+        perennial species across the genus Glycine including five diploids and a
+        young allopolyploid, and constructed a Glycine super-pangenome framework
+        by integrating 26 annual soybean genomes. These perennial diploids
+        exhibit greater genome stability and possess fewer centromere repeats
+        than the annuals. Biased subgenomic fractionation occurred in the
+        allopolyploid, primarily by accumulation of small deletions in gene
+        clusters through illegitimate recombination, which was associated with
+        pre-existing local subgenomic differentiation. Two genes annotated to
+        modulate vegetative-reproductive phase transition and lateral shoot
+        outgrowth were postulated as candidates underlying the
+        perenniality-annuality transition. Our study provides insights into
+        polyploid genome evolution and lays a foundation for unleashing genetic
+        potential from the perennial gene pool for soybean improvement.
   data_links:
     - category:
-        - name: Glycine cyrtoloba
+        - name: BAC-end sequences from the <a
+            href="https://www.ncbi.nlm.nih.gov/bioproject/PRJNA315596"
+            target="_blank">NSF SoyMapII project</a>
           instances:
-            - description: "Genome sequence of Glycine cyrtoloba version 1"
-              url: "https://data.soybase.org/Glycine/cyrtoloba/genomes/G1267.gnm1.YWW6/glycy.G1267.gnm1.YWW6.genome_main.fna.gz"
-            - description: "Gene models (GFF3) from Glycine cyrtoloba version 1"
-              url: "https://data.soybase.org/Glycine/cyrtoloba/annotations/G1267.gnm1.ann1.HRFD/glycy.G1267.gnm1.ann1.HRFD.gene_models_main.gff3.gz"
-            - description: "Coding sequence from Glycine cyrtoloba version 1"
-              url: "https://data.soybase.org/Glycine/cyrtoloba/annotations/G1267.gnm1.ann1.HRFD/glycy.G1267.gnm1.ann1.HRFD.cds.fna.gz"
-            - description: "Protein sequence from Glycine cyrtoloba version 1"
-              url: "https://data.soybase.org/Glycine/cyrtoloba/annotations/G1267.gnm1.ann1.HRFD/glycy.G1267.gnm1.ann1.HRFD.protein.faa.gz"
-            - description: "Transcript sequences mRNA from Glycine cyrtoloba version 1"
-              url: "https://data.soybase.org/Glycine/cyrtoloba/annotations/G1267.gnm1.ann1.HRFD/glycy.G1267.gnm1.ann1.HRFD.mrna.fna.gz"
-            - description: "Interproscan results (GFF3) from Glycine cyrtoloba version 1"
-              url: "https://data.soybase.org/Glycine/cyrtoloba/annotations/G1267.gnm1.ann1.HRFD/glycy.G1267.gnm1.ann1.HRFD.iprscan.gff3.gz"
-
+            - description: Glycine canescens; SRP202503
+              url: https://trace.ncbi.nlm.nih.gov/Traces/study/?acc=SRP202503&o=acc_s%3Aa
+            - description: Glycine cyrtoloba; SRP202504
+              url: https://trace.ncbi.nlm.nih.gov/Traces/study/?acc=SRP202504&o=acc_s%3Aa
+            - description: Glycine dolichocarpa; SRP202505
+              url: https://trace.ncbi.nlm.nih.gov/Traces/study/?acc=SRP202505&o=acc_s%3Aa
+            - description: Glycine falcata; SRP202506
+              url: https://trace.ncbi.nlm.nih.gov/Traces/study/?acc=SRP202506&o=acc_s%3Aa
+            - description: Glycine soja; SRP202507
+              url: https://trace.ncbi.nlm.nih.gov/Traces/study/?acc=SRP202507&o=acc_s%3Aa
+            - description: Glycine stenophita; SRP202508
+              url: https://trace.ncbi.nlm.nih.gov/Traces/study/?acc=SRP202508&o=acc_s%3Aa
+            - description: Glycine syndetika; SRP202509
+              url: https://trace.ncbi.nlm.nih.gov/Traces/study/?acc=SRP202509&o=acc_s%3Aa
+            - description: Glycine tomentella; SRP202510
+              url: https://trace.ncbi.nlm.nih.gov/Traces/study/?acc=SRP202510&o=acc_s%3Aa
     - category:
-        - name: Glycine D3 tomentella
+        - name: Glycine cyrtoloba genome and annotations
           instances:
-            - description: "Genome sequence of Glycine D3 tomentella version 1"
-              url: "https://data.soybase.org/Glycine/D3-tomentella/genomes/G1403.gnm1.CL6K/glyd3.G1403.gnm1.CL6K.genome_main.fna.gz"
-            - description: "Gene models (GFF3) from Glycine D3 tomentella version 1"
-              url: "https://data.soybase.org/Glycine/D3-tomentella/annotations/G1403.gnm1.ann1.XNZQ/glyd3.G1403.gnm1.ann1.XNZQ.gene_models_main.gff3.gz"
-            - description: "Coding sequence from Glycine D3 tomentella version 1"
-              url: "https://data.soybase.org/Glycine/D3-tomentella/annotations/G1403.gnm1.ann1.XNZQ/glyd3.G1403.gnm1.ann1.XNZQ.cds.fna.gz"
-            - description: "Protein sequence from Glycine D3 tomentella version 1"
-              url: "https://data.soybase.org/Glycine/D3-tomentella/annotations/G1403.gnm1.ann1.XNZQ/glyd3.G1403.gnm1.ann1.XNZQ.protein.faa.gz"
-            - description: "Transcript sequences mRNA from Glycine D3 tomentella version 1"
-              url: "https://data.soybase.org/Glycine/D3-tomentella/annotations/G1403.gnm1.ann1.XNZQ/glyd3.G1403.gnm1.ann1.XNZQ.mrna.fna.gz"
-            - description: "Interproscan results (GFF3) from Glycine D3 tomentella version 1"
-              url: "https://data.soybase.org/Glycine/D3-tomentella/annotations/G1403.gnm1.ann1.XNZQ/glyd3.G1403.gnm1.ann1.XNZQ.iprscan.gff3.gz"
-
+            - description: Genome sequence collection
+              url: https://data.soybase.org/Glycine/cyrtoloba/genomes/G1267.gnm1.YWW6
+            - description: Annotation collection
+              url: https://data.soybase.org/Glycine/cyrtoloba/annotations/G1267.gnm1.ann1.HRFD
     - category:
-        - name: Glycine dolichocarpa
+        - name: Glycine D3 tomentella genome and annotations
           instances:
-            - description: "Genome sequence of Glycine dolichocarpa version 1"
-              url: "https://data.soybase.org/Glycine/dolichocarpa/genomes/G1134.gnm1.PP7B/glydo.G1134.gnm1.PP7B.genome_main.fna.gz"
-            - description: "Gene models (GFF3) from Glycine dolichocarpa version 1"
-              url: "https://data.soybase.org/Glycine/dolichocarpa/annotations/G1134.gnm1.ann1.4BJM/glydo.G1134.gnm1.ann1.4BJM.gene_models_main.gff3.gz"
-            - description: "Coding sequence from Glycine dolichocarpa version 1"
-              url: "https://data.soybase.org/Glycine/dolichocarpa/annotations/G1134.gnm1.ann1.4BJM/glydo.G1134.gnm1.ann1.4BJM.cds.fna.gz"
-            - description: "Protein sequence from Glycine dolichocarpa version 1"
-              url: "https://data.soybase.org/Glycine/dolichocarpa/annotations/G1134.gnm1.ann1.4BJM/glydo.G1134.gnm1.ann1.4BJM.protein.faa.gz"
-            - description: "Transcript sequences mRNA from Glycine dolichocarpa version 1"
-              url: "https://data.soybase.org/Glycine/dolichocarpa/annotations/G1134.gnm1.ann1.4BJM/glydo.G1134.gnm1.ann1.4BJM.mrna.fna.gz"
-            - description: "Interproscan results (GFF3) from Glycine dolichocarpa version 1"
-              url: "https://data.soybase.org/Glycine/dolichocarpa/annotations/G1134.gnm1.ann1.4BJM/glydo.G1134.gnm1.ann1.4BJM.iprscan.gff3.gz"
-
+            - description: Genome sequence collection tomentella
+              url: https://data.soybase.org/Glycine/D3-tomentella/genomes/G1403.gnm1.CL6K
+            - description: Annotation collection tomentella
+              url: https://data.soybase.org/Glycine/D3-tomentella/annotations/G1403.gnm1.ann1.XNZQ
     - category:
-        - name: Glycine falcata
+        - name: Glycine dolichocarpa genome and annotations
           instances:
-            - description: "Genome sequence of Glycine falcata version 1"
-              url: "https://data.soybase.org/Glycine/falcata/genomes/G1718.gnm1.B1PY/glyfa.G1718.gnm1.B1PY.genome_main.fna.gz"
-            - description: "Gene models (GFF3) from Glycine falcata version 1"
-              url: "https://data.soybase.org/Glycine/falcata/annotations/G1718.gnm1.ann1.2KSV/glyfa.G1718.gnm1.ann1.2KSV.gene_models_main.gff3.gz"
-            - description: "Coding sequence from Glycine falcata version 1"
-              url: "https://data.soybase.org/Glycine/falcata/annotations/G1718.gnm1.ann1.2KSV/glyfa.G1718.gnm1.ann1.2KSV.cds.fna.gz"
-            - description: "Protein sequence from Glycine falcata version 1"
-              url: "https://data.soybase.org/Glycine/falcata/annotations/G1718.gnm1.ann1.2KSV/glyfa.G1718.gnm1.ann1.2KSV.protein.faa.gz"
-            - description: "Transcript sequences mRNA from Glycine falcata version 1"
-              url: "https://data.soybase.org/Glycine/falcata/annotations/G1718.gnm1.ann1.2KSV/glyfa.G1718.gnm1.ann1.2KSV.mrna.fna.gz"
-            - description: "Interproscan results (GFF3) from Glycine falcata version 1"
-              url: "https://data.soybase.org/Glycine/falcata/annotations/G1718.gnm1.ann1.2KSV/glyfa.G1718.gnm1.ann1.2KSV.iprscan.gff3.gz"
-
-
+            - description: Genome sequence collection
+              url: https://data.soybase.org/Glycine/dolichocarpa/genomes/G1134.gnm1.PP7B
+            - description: Annotation collection
+              url: https://data.soybase.org/Glycine/dolichocarpa/annotations/G1134.gnm1.ann1.4BJM
     - category:
-        - name: Glycine stenophita
+        - name: Glycine falcata genome and annotations
           instances:
-            - description: "Genome sequence of Glycine stenophita version 1"
-              url: "https://data.soybase.org/Glycine/stenophita/genomes/G1974.gnm1.7MZB/glyst.G1974.gnm1.7MZB.genome_main.fna.gz"
-            - description: "Gene models (GFF3) from Glycine stenophita version 1"
-              url: "https://data.soybase.org/Glycine/stenophita/annotations/G1974.gnm1.ann1.F257/glyst.G1974.gnm1.ann1.F257.gene_models_main.gff3.gz  "
-            - description: "Coding sequence from Glycine stenophita version 1"
-              url: "https://data.soybase.org/Glycine/stenophita/annotations/G1974.gnm1.ann1.F257/glyst.G1974.gnm1.ann1.F257.cds.fna.gz"
-            - description: "Protein sequence from Glycine stenophita version 1"
-              url: "https://data.soybase.org/Glycine/stenophita/annotations/G1974.gnm1.ann1.F257/glyst.G1974.gnm1.ann1.F257.protein.faa.gz"
-            - description: "Transcript sequences mRNA from Glycine stenophita version 1"
-              url: "https://data.soybase.org/Glycine/stenophita/annotations/G1974.gnm1.ann1.F257/glyst.G1974.gnm1.ann1.F257.mrna.fna.gz"
-            - description: "Interproscan results (GFF3) from Glycine stenophita version 1"
-              url: "https://data.soybase.org/Glycine/stenophita/annotations/G1974.gnm1.ann1.F257/glyst.G1974.gnm1.ann1.F257.iprscan.gff3.gz"
-
-
+            - description: Genome sequence collection
+              url: https://data.soybase.org/Glycine/falcata/genomes/G1718.gnm1.B1PY
+            - description: Annotation collection
+              url: https://data.soybase.org/Glycine/falcata/annotations/G1718.gnm1.ann1.2KSV
     - category:
-        - name: Glycine syndetika
+        - name: Glycine stenophita genome and annotations
           instances:
-            - description: "Genome sequence of Glycine syndetika version 1"
-              url: "https://data.soybase.org/Glycine/syndetika/genomes/G1300.gnm1.C11H/glysy.G1300.gnm1.C11H.genome_main.fna.gz"
-            - description: "Gene models (GFF3) from Glycine syndetika version 1"
-              url: "https://data.soybase.org/Glycine/syndetika/annotations/G1300.gnm1.ann1.RRK6/glysy.G1300.gnm1.ann1.RRK6.gene_models_main.gff3.gz"
-            - description: "Coding sequence from Glycine syndetika version 1"
-              url: "https://data.soybase.org/Glycine/syndetika/annotations/G1300.gnm1.ann1.RRK6/glysy.G1300.gnm1.ann1.RRK6.cds.fna.gz"
-            - description: "Protein sequence from Glycine syndetika version 1"
-              url: "https://data.soybase.org/Glycine/syndetika/annotations/G1300.gnm1.ann1.RRK6/glysy.G1300.gnm1.ann1.RRK6.protein.faa.gz"
-            - description: "Transcript sequences mRNA from Glycine syndetika version 1"
-              url: "https://data.soybase.org/Glycine/syndetika/annotations/G1300.gnm1.ann1.RRK6/glysy.G1300.gnm1.ann1.RRK6.mrna.fna.gz"
-            - description: "Interproscan results (GFF3) from Glycine syndetika version 1"
-              url: "https://data.soybase.org/Glycine/syndetika/annotations/G1300.gnm1.ann1.RRK6/glysy.G1300.gnm1.ann1.RRK6.iprscan.gff3.gz"
+            - description: Genome sequence collection
+              url: https://data.soybase.org/Glycine/stenophita/genomes/G1974.gnm1.7MZB
+            - description: Annotation collection
+              url: https://data.soybase.org/Glycine/stenophita/annotations/G1974.gnm1.ann1.F257
+    - category:
+        - name: Glycine syndetika genome and annotations
+          instances:
+            - description: Genome sequence collection
+              url: https://data.soybase.org/Glycine/syndetika/genomes/G1300.gnm1.C11H
+            - description: Annotation collection
+              url: https://data.soybase.org/Glycine/syndetika/annotations/G1300.gnm1.ann1.RRK6

--- a/_data/projects/Zhuang_Wang_2022/project_details.yml
+++ b/_data/projects/Zhuang_Wang_2022/project_details.yml
@@ -1,13 +1,18 @@
 ---
 - DataStoreID: Zhuang_Wang_2022
   short_title: SoyMap II
-  SoyBaseID: SoyBase.C2022.01
   title: "SoyMap II: Leveraging untapped genetic diversity in soybean"
-  description: 'Genomes and gene models were generated from multiple perennial
-    soybean species across the Glycine genus to study insights into the
-    polyploid and perennial genome evolution and genetic potential for soybean
-    improvement.<br> <a
-    href="https://www.ncbi.nlm.nih.gov/bioproject/PRJNA315596"
+  description: '<a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=0822258">The NSF-funded SoyMap II project</a>, 
+    led by Scott Jackson, involved sequencing corresponding regions around six regions of interest 
+    from eight <i>Glycine</i> species, to gain insights into the polyploid and perennial genome evolution and genetic potential for soybean improvement. This project finished in 2012. See more information about the project,
+    including pictures of the focal species and descriptions of the target regions, at
+    <a href="https://legacy.soybase.org/soymap2/">legacy.soybase.org/soymap2</a>.<br><br>
+    A subsequent project, led by Jianxin Ma and Dajian Zhang, with funding primarily from 
+    the Shandong Province (China), completed the genome assemblies for the species used in 
+    the SoyMap II project. The <a href="https://pubmed.ncbi.nlm.nih.gov/35288665/">Zhuang, Wang et al. (2022)</a> paper 
+    below describes the genome assemblies and analyses from the second project. 
+    See references therein for further citations and descriptions of the species and objectives for both projects.<br><br>
+    <a href="https://www.ncbi.nlm.nih.gov/bioproject/PRJNA315596"
     target="_blank">NCBI BioProject for NSF SoyMapII project</a> (with links to
     Illumina HiSeq data in SRA)</br> <a
     href="https://www.ncbi.nlm.nih.gov/bioproject/PRJNA503746"

--- a/_data/projects/Zhuang_Wang_2022/project_details.yml
+++ b/_data/projects/Zhuang_Wang_2022/project_details.yml
@@ -2,15 +2,16 @@
 - DataStoreID: Zhuang_Wang_2022
   short_title: SoyMap II
   title: "SoyMap II: Leveraging untapped genetic diversity in soybean"
-  description: '<a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=0822258">The NSF-funded SoyMap II project</a>, 
-    led by Scott Jackson, involved sequencing corresponding regions around six regions of interest 
-    from eight <i>Glycine</i> species, to gain insights into the polyploid and perennial genome evolution and genetic potential for soybean improvement. This project finished in 2012. See more information about the project,
+  description: '<a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=0822258">The NSF-funded SoyMap II project</a>,
+    led by Scott Jackson, involved sequencing corresponding regions around six regions of interest
+    from eight <i>Glycine</i> species, to gain insights into the polyploid and perennial genome evolution and
+    genetic potential for soybean improvement. This project finished in 2012. See more information about the project,
     including pictures of the focal species and descriptions of the target regions, at
     <a href="https://legacy.soybase.org/soymap2/">legacy.soybase.org/soymap2</a>.<br><br>
-    A subsequent project, led by Jianxin Ma and Dajian Zhang, with funding primarily from 
-    the Shandong Province (China), completed the genome assemblies for the species used in 
-    the SoyMap II project. The <a href="https://pubmed.ncbi.nlm.nih.gov/35288665/">Zhuang, Wang et al. (2022)</a> paper 
-    below describes the genome assemblies and analyses from the second project. 
+    A subsequent project, led by Jianxin Ma and Dajian Zhang, with funding primarily from
+    the Shandong Province (China), completed the genome assemblies for the species used in
+    the SoyMap II project. The <a href="https://pubmed.ncbi.nlm.nih.gov/35288665/">Zhuang, Wang et al. (2022)</a> paper
+    below describes the genome assemblies and analyses from the second project.
     See references therein for further citations and descriptions of the species and objectives for both projects.<br><br>
     <a href="https://www.ncbi.nlm.nih.gov/bioproject/PRJNA315596"
     target="_blank">NCBI BioProject for NSF SoyMapII project</a> (with links to


### PR DESCRIPTION
Added links to the NSF bioproject for SoyMap II and for the follow-on genome sequencing project.
Added links to the BAC-end sequences in SRA (similar to https://soybase-stage.usda.iastate.edu/soymap2/).
Simplified the links to the Data Store genome assemblies and annotations.

