### PR TITLE
Fix SoyBase theme so that words are not truncated

### DIFF
--- a/_includes/navbar-lower-menu.html
+++ b/_includes/navbar-lower-menu.html
@@ -1,3 +1,3 @@
-<ul class="uk-navbar-nav uk-hidden@l uk-visible@s">
+<ul class="uk-navbar-nav uk-hidden@xl uk-visible@s">
   {% include navbar-menu-items.html %}
 </ul>

--- a/_includes/navbar-menu-items.html
+++ b/_includes/navbar-menu-items.html
@@ -1,56 +1,57 @@
-<li><a href="{{ "/" | relative_url }}">Home</a></li>
-<li>
-  <a href="{{ "/tools" | relative_url }}">Tools</a>
-  {% assign groups = site.data.tools | group_by: "category" | sort: "name" %}
-  <div class="uk-navbar-dropdown uk-width-auto" uk-dropdown="delay-hide: 0;">
-    <ul class="uk-nav uk-navbar-dropdown-nav uk-link-reset">
-      {% for group in groups %}
-        {% for item in group.items %}
-          <li><a href="{{ item.url }}">{{ item.name }}</a></li>
+<div style="display: flex; flex-direction: row; gap: 15px;">
+  <li><a href="{{ "/" | relative_url }}">Home</a></li>
+  <li>
+    <a href="{{ "/tools" | relative_url }}">Tools</a>
+    {% assign groups = site.data.tools | group_by: "category" | sort: "name" %}
+    <div class="uk-navbar-dropdown uk-width-auto" uk-dropdown="delay-hide: 0;">
+      <ul class="uk-nav uk-navbar-dropdown-nav uk-link-reset">
+        {% for group in groups %}
+          {% for item in group.items %}
+            <li><a href="{{ item.url }}">{{ item.name }}</a></li>
+          {% endfor %}
         {% endfor %}
+      </ul>
+    </div>
+  </li>
+
+  <li>
+    <a href="{{ "/maps" | relative_url }}">Maps</a>
+  </li>
+
+  <li>
+    <a href="{{ "/resources" | relative_url }}">Genomics</a>
+  </li>
+
+  <li>
+    <a href="{{ "/collections" | relative_url }}">Data Collections</a>
+    {% assign genus_description = site.data.datastore-metadata.Glycine.GENUS.about_this_collection.description_Glycine %}
+    <div class="uk-navbar-dropdown uk-width-auto" uk-dropdown="delay-hide: 0;">
+      <ul class="uk-nav uk-navbar-dropdown-nav uk-link-reset">
+        {% for species in genus_description.species %}
+          <li> <a href="/collections/#{{ genus_description.genus }}_{{ species }}"> {{ species }}</a></li>
+        {% endfor %}
+      </ul>
+    </div>
+  </li>
+
+  <li>
+    <a class="project_list" href="{{ "/projects" | relative_url }}">Projects</a>
+    {% if site.data.project_list %}
+    {% assign groups = site.data.project_list | sort: "short_title" %}
+    <div class="uk-navbar-dropdown uk-width-auto" uk-dropdown="delay-hide: 0;">
+      <ul class="uk-nav uk-navbar-dropdown-nav uk-link-reset">
+      {% for group in groups %}
+        <li><a href="{{ group.DataStoreID | downcase | prepend: '/projects/' | relative_url }}">{{ group.short_title }}</a></li>
       {% endfor %}
-    </ul>
-  </div>
-</li>
+      </ul>
+    </div>
+    {% endif %}
+  </li>
 
-<li>
-  <a href="{{ "/maps" | relative_url }}">Maps</a>
-</li>
+  <li><a href="{{ "/community" | relative_url }}">Community</a></li>
 
-<li>
-  <a href="{{ "/resources" | relative_url }}">Genomics</a>
-</li>
+  <li><a href="{{ "/about" | relative_url }}">About & Contact</a></li>
 
-<li>
-  <a href="{{ "/collections" | relative_url }}">Data Collections</a>
-  {% assign genus_description = site.data.datastore-metadata.Glycine.GENUS.about_this_collection.description_Glycine %}
-  <div class="uk-navbar-dropdown uk-width-auto" uk-dropdown="delay-hide: 0;">
-    <ul class="uk-nav uk-navbar-dropdown-nav uk-link-reset">
-      {% for species in genus_description.species %}
-        <li> <a href="/collections/#{{ genus_description.genus }}_{{ species }}"> {{ species }}</a></li>
-      {% endfor %}
-    </ul>
-  </div>
-</li>
-
-<li>
-  <a class="project_list" href="{{ "/projects" | relative_url }}">Projects</a>
-  {% if site.data.project_list %}
-  {% assign groups = site.data.project_list | sort: "short_title" %}
-  <div class="uk-navbar-dropdown uk-width-auto" uk-dropdown="delay-hide: 0;">
-    <ul class="uk-nav uk-navbar-dropdown-nav uk-link-reset">
-    {% for group in groups %}
-      <li><a href="{{ group.DataStoreID | downcase | prepend: '/projects/' | relative_url }}">{{ group.short_title }}</a></li>
-    {% endfor %}
-    </ul>
-  </div>
-  {% endif %}
-</li>
-
-<li><a href="{{ "/community" | relative_url }}">Community</a></li>
-
-<li><a href="{{ "/about" | relative_url }}">About & Contact</a></li>
-
-<li><a href="{{ "/help" | relative_url }}">Help & Tutorials</a></li>
-
+  <li><a href="{{ "/help" | relative_url }}">Help & Tutorials</a></li>
+</div>
 

--- a/_includes/navbar-menu-items.html
+++ b/_includes/navbar-menu-items.html
@@ -1,4 +1,4 @@
-<div style="display: flex; flex-direction: row; gap: 15px;">
+<div class="uk-flex-inline" style="gap: 15px">
   <li><a href="{{ "/" | relative_url }}">Home</a></li>
   <li>
     <a href="{{ "/tools" | relative_url }}">Tools</a>

--- a/_includes/navbar-menu.html
+++ b/_includes/navbar-menu.html
@@ -1,4 +1,4 @@
-<ul class="uk-navbar-nav uk-visible@l">
+<ul class="uk-navbar-nav uk-visible@xl">
   {% include navbar-menu-items.html %}
 </ul>
 <a href="#off-screen-menu" class="uk-navbar-toggle uk-hidden@s" uk-navbar-toggle-icon uk-toggle></a>


### PR DESCRIPTION
## DG: Fix SoyBase theme so that words are not truncated
-  navbar-menu-items.html 
    - Add a wrapper around menu items and added class "uk-flex-inline" to utilize flexbox.
    - Add inline style "gap: 15px" to add spacing between nav menu elements.
- navbar-lower-menu.html
    - change class "uk-hidden@l" to "uk-hidden@xl" this will cause the bottom nav bar to hide when screen size is 1600px or larger and show when screen is smaller then 1600px.
 - navbar-menu.html   
    - change class "uk-visible@l" to "uk-visible@xl" to make nav bar show when screen is 1600px or larger.   
