### PR TITLE
Fixed Gene search on the front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@ blog_card: true
   </div>
 
   <div class="uk-text-nowrap uk-margin-remove-bottom uk-margin-small-top uk-align-center">
-    <form action="https://dev.soybase.org/tools/search/gene.html" name="search" method="get" style="display:inline;">
+    <form action="https://soybase.org/tools/search/gene.html" name="search" method="get" style="display:inline;">
   <div class="uk-text-left">
     <label class="uk-text-bold" for="identifier">Gene identifier search</label><br>
     <input class="uk-input uk-form-small" id="identifier" style="width:180px;color:#235626;font-style:italic;font-size:0.9em" type="text" name="identifier"


### PR DESCRIPTION
removed "dev." from gene search box form 

Now the Gene search form on the front page goes to SoyBase and NOT dev.soybase