### PR TITLE
Changed URL on top of home page

### DIFF
--- a/_includes/alerts.html
+++ b/_includes/alerts.html
@@ -1,5 +1,5 @@
 <div style="color:white;">
-&nbsp;<b>Welcome to the new website!</b> See the legacy site <a href='https://www.soybase.org/' target="_blank" style="color:Pink"><u>here</u></a>. 
+&nbsp;<b>Welcome to the new website!</b> See the legacy site <a href='https://legacy.soybase.org/' target="_blank" style="color:Pink"><u>here</u></a>. 
 Questions/suggestions? <a href="/about#contact" style="color:Pink"><u>contact us</u>.</a>
 Click the bell (<a class="tm-no-underline" title="Toggle alerts" uk-toggle="target: #alerts; animation: uk-animation-fade" style="color:Pink"><span uk-icon="bell"></span></a>) to toggle this alert.
 </div>


### PR DESCRIPTION
The URL on the top of the home page (alerts) was changed from soybase.org to legacy.soybase.org.


Change URL in alerts to https://legacy.soybase.org/

