### PR TITLE
Links to New Data templates

### DIFF
--- a/about/submitting_data/index.html
+++ b/about/submitting_data/index.html
@@ -7,9 +7,9 @@ tools_menu: false
 
 Please use the following spreadsheet templates for submitting data for the indicated data types. These templates are under active development. Please return here to get the latest versions.
 
-<p>Biparental QTL Data: <a href="/annex/Glycine/max/data_templates/SoyBase_QTL_Template_V2025.2.xlsx">Excel spreadsheet for data entry</a></p>
+<p>Biparental QTL Data: <a href="https://data.soybase.org/annex/Glycine/max/data_templates/SoyBase_QTL_Template_V2025.2.xlsx">Excel spreadsheet for data entry</a></p>
 
-<p>Genome Wide Association (GWAS) Data: <a href="/annex/Glycine/max/data_templates/SoyBase_GWAS_Template_V2025.2.xlsx">Excel spreadsheet for data entry</a></p>
+<p>Genome Wide Association (GWAS) Data: <a href="https://data.soybase.org/annex/Glycine/max/data_templates/SoyBase_GWAS_Template_V2025.2.xlsx">Excel spreadsheet for data entry</a></p>
 
 <p>Gene Data: <a href="/assets/templates/SoyBase_gene_data_submission_template_v1.3.xls">Excel spreadsheet for data entry</a></p>
 

--- a/about/submitting_data/index.html
+++ b/about/submitting_data/index.html
@@ -7,9 +7,9 @@ tools_menu: false
 
 Please use the following spreadsheet templates for submitting data for the indicated data types. These templates are under active development. Please return here to get the latest versions.
 
-<p>Biparental QTL Data: <a href="/assets/templates/SoyBase_QTL_data_submission_template_v1.3.xls">Excel spreadsheet for data entry</a></p>
+<p>Biparental QTL Data: <a href="/annex/Glycine/max/data_templates/SoyBase_QTL_Template_V2025.2.xlsx">Excel spreadsheet for data entry</a></p>
 
-<p>Genome Wide Association (GWAS) QTL Data: <a href="/assets/templates/SoyBase_GWAS_data_submission_template_v1.4.xls">Excel spreadsheet for data entry</a></p>
+<p>Genome Wide Association (GWAS) Data: <a href="/annex/Glycine/max/data_templates/SoyBase_GWAS_Template_V2025.2.xlsx">Excel spreadsheet for data entry</a></p>
 
 <p>Gene Data: <a href="/assets/templates/SoyBase_gene_data_submission_template_v1.3.xls">Excel spreadsheet for data entry</a></p>
 

--- a/community/sbw/registration.html
+++ b/community/sbw/registration.html
@@ -25,7 +25,7 @@ sitemap: community/sbw
     <li>The Soybean Breeders' Workshop has moved to a different location. The 2025 Soybean Breeders' Workshop will be held in the <a href="https://www.hilton.com/en/hotels/stlfhhf-hilton-st-louis-frontenac/?SEO_id=GMB-AMER-HH-STLFHHF&y_source=1_MTIyMDc4Ni03MTUtbG9jYXRpb24ud2Vic2l0ZQ%3D%3D" target="_blank">Hilton St. Louis Frontenac</a>. Further hotel information can be found below, including a direct booking link with group rate.</li>
     <li>This year the volunteered oral presentations on Wednesday morning will be selected from the poster abstracts. Abstracts must be submitted by <b>January 10</b> to be considered for an oral presentation.</li>
 <!--    <li>This year the Monday morning workshop is about <a href="workshop.html" target="_blank">effective visualization techniques in science</a>. The data visualization workshop costs $75.</li> -->
-    <li><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2025/SBW2025_Agenda_2025_1_27.pdf">Agenda</a> for the Soybean Breeders Workshop</li>
+    <li><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2025/SBW2025_Agenda_2025_01_24.pdf">Agenda</a> for the Soybean Breeders Workshop</li>
     <li>Techicians' Meeting <a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2025/SBW2025_Technician_Draft_Agenda.pdf" target="_blank">Agenda</a></li>
 </ul>    
     

--- a/news/_posts/2024-11-01-SBW2025.md
+++ b/news/_posts/2024-11-01-SBW2025.md
@@ -18,7 +18,7 @@ categories: general
 Please make reservations by <b>Friday January 24th, 2025</b>, to ensure group discount. 
 Here is the <a href="https://www.hilton.com/en/attend-my-event/stlfhhf-sbw25-9dce262b-71d5-4042-8649-cae0a78103fc/" target="_blank">direct booking link</a> for the Soybean Breeders Workshop 2025.</li>
     <li>This year the volunteered oral presentations on Wednesday morning will be selected from the poster abstracts. Abstracts must be submitted by <b>January 10</b> to be considered for an oral presentation.</li>
-    <li><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2025/SBW2025_Agenda_2025_1_27.pdf" target="_blank">Agenda</a> is available</li>
+    <li><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2025/SBW2025_Agenda_2025_01_24.pdf" target="_blank">Agenda</a> is available</li>
     
 </ul>
 </p>

--- a/news/_posts/2025-01-23-SBW2025-Update.md
+++ b/news/_posts/2025-01-23-SBW2025-Update.md
@@ -8,10 +8,11 @@ summary: Soybean Breeders' Workshop 2025 deadlines approaching
 categories: general    
 ---
 <div>
-<a href="/community/sbw/registration.html">Registration</a> for the 2025 Soybean Breeders' Workshop. 
+  <a href="/community/sbw/registration.html">Registration</a> for the 2025 Soybean Breeders' Workshop. 
 </div>
 <br>
 <br>
+<p>
 <b>Deadlines approaching</b>:
 <ul class="uk-list">
   <li>A reduced-rate room block is available at Hilton St. Louis Frontenac for February 16th, 2025, through February 20th, 2025. Please make reservations by <b>Friday January 24th, 2025</b>, to ensure group discount. Here is the <a href="https://www.hilton.com/en/attend-my-event/stlfhhf-sbw25-9dce262b-71d5-4042-8649-cae0a78103fc/" target="_blank">direct booking link</a> for the Soybean Breeders' Workshop 2025.</li>
@@ -20,7 +21,7 @@ categories: general
 
   <li>Last day to submit a poster abstract is <b>January 31st</b>. After registrating and paying for the meeting the poster abstract submission form will become available.</li>
 
-  <li><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2025/SBW2025_Agenda_2025_1_27.pdf" target="_blank">Agenda</a> is available.</li>
+  <li><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2025/SBW2025_Agenda_2025_01_24.pdf" target="_blank">Agenda</a> is available.</li>
     
 </ul>
 </p>


### PR DESCRIPTION
New GlycineMine / Datastore based data submission templates were created for Bi-parental QTL and GWAS data. 
The new templates were loaded to ceres annex yesterday and available on the datastore today. 

Please review the /about/submit_data/index.hmtl page 
