### PR TITLE
Past Soybean Breeders' Workshop webpages

### DIFF
--- a/community/sbw/SBW/SBW_2010.html
+++ b/community/sbw/SBW/SBW_2010.html
@@ -27,16 +27,16 @@ sitemap: community/sbw
     	</thead>
 		<body>
 			<tr><th colspan='2'>Public Breeder Coordination Session</th></tr>
-			<tr><td>Rich Wilson</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Wilson.pdf">Documenting Soybean Genomics Research</a></td></tr>
-			<tr><td>Roy Scott</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Scott.pdf">National Program Update</a></td></tr>
+			<tr><td>Rich Wilson</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Wilson.pdf">Documenting Soybean Genomics Research</a></td></tr>
+			<tr><td>Roy Scott</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Scott.pdf">National Program Update</a></td></tr>
 			<tr><td>Jim Orf, Univ. of Minnesota</td><td>Phytophtora</td></tr>
-			<tr><td>Katy Martin Rainey, Virginia Tech Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Rainey.pdf">Soybean Mosaic Virus</a></td></tr>
-			<tr><td>Brian Diers, Univ. of Illinois</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Diers.pdf">Asian Soybean Rust</a></td></tr>
-			<tr><td>Stella Kantartzi, Southern Illinois Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Kantartzi.pdf">Sudden Death Syndrome</a></td></tr>
-			<tr><td>David Lightfoot, Southern Illinois Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Lightfoot.pdf">Soybean Cyst Nematode</a></td></tr>
+			<tr><td>Katy Martin Rainey, Virginia Tech Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Rainey.pdf">Soybean Mosaic Virus</a></td></tr>
+			<tr><td>Brian Diers, Univ. of Illinois</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Diers.pdf">Asian Soybean Rust</a></td></tr>
+			<tr><td>Stella Kantartzi, Southern Illinois Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Kantartzi.pdf">Sudden Death Syndrome</a></td></tr>
+			<tr><td>David Lightfoot, Southern Illinois Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Lightfoot.pdf">Soybean Cyst Nematode</a></td></tr>
 			<tr><td>Paul Stephens, Pioneer Hi-Bred</td><td>Pioneer Optimum GAT Technology Update</td></tr>
-			<tr><td>Rick Leitz</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Leitz.pdf">Monsanto Technology Update</a></td></tr>
-			<tr><td>Wayne Parrot, Univ. of Georgia</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Parrot.pdf">USB Update: Center for Soybean Tissue Culture and Genetic Engineering</a></td></tr>
+			<tr><td>Rick Leitz</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Leitz.pdf">Monsanto Technology Update</a></td></tr>
+			<tr><td>Wayne Parrot, Univ. of Georgia</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Parrot.pdf">USB Update: Center for Soybean Tissue Culture and Genetic Engineering</a></td></tr>
 		</body>
 	</table>
 </div>
@@ -54,32 +54,32 @@ sitemap: community/sbw
     	</thead>
 		<body>
 			<tr><th colspan='2'>Nematodes | Chair: Prakash Arelli, USDA-ARS, Jackson, TN</tr></th>
-			<tr><td>Brian Diers, Univ. of Illinois</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Diers_2.pdf">Breeding soybean for nematode resistance in the Midwest</a></td></tr>
-			<tr><td>Grover Shannon, Univ. of Missouri</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Shannon.pdf">Soybean breeding for SCN resistance in the Midsouth</a></td></tr>
-			<tr><td>Bo-Keun Ha, Univ. of Georgia</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Ha.pdf">Breeding soybean for resistance to root-knot nematode</a></td></tr>
-			<tr><td>Don Hershman, Univ. of Kentucky</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Hershman.pdf">Hindrances to effective cyst nematode extension programming</a></td></tr>
-			<tr><td>Istvan Rajcan, Univ. of Guelph</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Rajcan.pdf">Recent mapping efforts for SCN resistance in G. max and G. soja</a></td></tr>
-			<tr><td>Prakash Arelli, USDA-ARS, TN</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Arelli.pdf">diverse sources of resistance to SCN in soybean</a></td></tr>
+			<tr><td>Brian Diers, Univ. of Illinois</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Diers_2.pdf">Breeding soybean for nematode resistance in the Midwest</a></td></tr>
+			<tr><td>Grover Shannon, Univ. of Missouri</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Shannon.pdf">Soybean breeding for SCN resistance in the Midsouth</a></td></tr>
+			<tr><td>Bo-Keun Ha, Univ. of Georgia</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Ha.pdf">Breeding soybean for resistance to root-knot nematode</a></td></tr>
+			<tr><td>Don Hershman, Univ. of Kentucky</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Hershman.pdf">Hindrances to effective cyst nematode extension programming</a></td></tr>
+			<tr><td>Istvan Rajcan, Univ. of Guelph</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Rajcan.pdf">Recent mapping efforts for SCN resistance in G. max and G. soja</a></td></tr>
+			<tr><td>Prakash Arelli, USDA-ARS, TN</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Arelli.pdf">diverse sources of resistance to SCN in soybean</a></td></tr>
 			<tr><th colspan='2'>Frogeye Leaf Spot and SMV | Chair: Jason Bond, Southern Illinois University</tr></th>
-			<tr><td>Melvin Newman, Univ. of Tennessee</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Newman.pdf">Soybean cultivar reaction to frogeye leaf spot</a></td></tr>
-			<tr><td>Rouf Mian, USDA-ARS, OH</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Mian.pdf">Genetic resistance of soybean to frogeye leaf spot, mapping of Rcs3, and breeding for resistance</a></td></tr>
-			<tr><td>Jason Bond, So. Illinois Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Bond.pdf">Identifying resistance to frogeye leaf spot in plant introductions</a></td></tr>
+			<tr><td>Melvin Newman, Univ. of Tennessee</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Newman.pdf">Soybean cultivar reaction to frogeye leaf spot</a></td></tr>
+			<tr><td>Rouf Mian, USDA-ARS, OH</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Mian.pdf">Genetic resistance of soybean to frogeye leaf spot, mapping of Rcs3, and breeding for resistance</a></td></tr>
+			<tr><td>Jason Bond, So. Illinois Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Bond.pdf">Identifying resistance to frogeye leaf spot in plant introductions</a></td></tr>
 			<tr><td>Saghai Maroof, Virginia Tech Univ.</td><td>Soybean mosaic virus resistance genes and their interactions</td></tr>
 			<tr><th colspan='2'>Charcoal Rot | Chair: Alemu Mengistu, USDA-ARS, Jackson, TN</tr></th>
-			<tr><td>Allen Wrather, Univ. of Missouri</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Wrather.pdf">Impact of charcoal rot and other diseases on world soybean supply</a></td></tr>
-			<tr><td>Alemu Mengistu, USDA-ARS, TN</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Mengistu.pdf">Screening and identifying soybean lines for resistance to charcoal rot in a field environment</a></td></tr>
-			<tr><td>Glen Hartman, USDA-ARS, IL</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Hartman.pdf">Screening and identifying soybean lines for resistance in non-field environments</a></td></tr>
-			<tr><td>Rusty Smith, USDA-ARS, MS</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Smith.pdf">Studies in genetics and breeding for resistance to charcoal rot in soybean</a></td></tr>
-			<tr><td>John Rupe, Univ. of Arkansas</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Rupe.pdf">Multi-environment testing for charcoal rot resistance: a regional approach</a></td></tr>
-			<tr><td>Ahmad Fakhoury, Purdue Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Fakhoury.pdf">Phasiolinone as a new tool to evaluate resistance to charcoal rot</a></td></tr>
+			<tr><td>Allen Wrather, Univ. of Missouri</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Wrather.pdf">Impact of charcoal rot and other diseases on world soybean supply</a></td></tr>
+			<tr><td>Alemu Mengistu, USDA-ARS, TN</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Mengistu.pdf">Screening and identifying soybean lines for resistance to charcoal rot in a field environment</a></td></tr>
+			<tr><td>Glen Hartman, USDA-ARS, IL</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Hartman.pdf">Screening and identifying soybean lines for resistance in non-field environments</a></td></tr>
+			<tr><td>Rusty Smith, USDA-ARS, MS</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Smith.pdf">Studies in genetics and breeding for resistance to charcoal rot in soybean</a></td></tr>
+			<tr><td>John Rupe, Univ. of Arkansas</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Rupe.pdf">Multi-environment testing for charcoal rot resistance: a regional approach</a></td></tr>
+			<tr><td>Ahmad Fakhoury, Purdue Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Fakhoury.pdf">Phasiolinone as a new tool to evaluate resistance to charcoal rot</a></td></tr>
 			<tr><th colspan='2'>Sudden Death Syndrome Chairs:  Jason Bond, SIU and Brian Diers, Univ. of IL</tr></th>
-			<tr><td>Leonor Leandro, Iowa State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Leandro.pdf">Epidemiological studies on the timing of inoculation and development of sudden death syndrome in soybean</a></td></tr>
-			<tr><td>Ahmad Fakhoury, Purdue Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Fakhoury_2.pdf">Identifying fungal factors affecting Fusarium virguliforme aggressiveness and SDS development</a></td></tr>
-			<tr><td>Silvia Cianzio, Iowa State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Cianzio.pdf">Breeding efforts for SDS resistance</a></td></tr>
-			<tr><td>Madan Bhattacharyya, Iowa State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Bhattacharyya.pdf">How does the fungal pathogen, Fusarium virguliforme cause SDS?</a></td></tr>
-			<tr><td>David Lightfoot, So. Illinois Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Lightfoot_2.pdf">Transgenics, QTL stacks and NIL verifications for SDS</a></td></tr>
+			<tr><td>Leonor Leandro, Iowa State Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Leandro.pdf">Epidemiological studies on the timing of inoculation and development of sudden death syndrome in soybean</a></td></tr>
+			<tr><td>Ahmad Fakhoury, Purdue Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Fakhoury_2.pdf">Identifying fungal factors affecting Fusarium virguliforme aggressiveness and SDS development</a></td></tr>
+			<tr><td>Silvia Cianzio, Iowa State Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Cianzio.pdf">Breeding efforts for SDS resistance</a></td></tr>
+			<tr><td>Madan Bhattacharyya, Iowa State Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Bhattacharyya.pdf">How does the fungal pathogen, Fusarium virguliforme cause SDS?</a></td></tr>
+			<tr><td>David Lightfoot, So. Illinois Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Lightfoot_2.pdf">Transgenics, QTL stacks and NIL verifications for SDS</a></td></tr>
 			<tr><th colspan='2'>Other Soybean Diseases | Chairs: Jason Bond, SIU and Brian Diers, Univ. of IL</tr></th>
-			<tr><td>Anne Dorrance, Ohio State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Dorrance.pdf">Resistance to Phytophthora sojae: current status and challenges</a></td></tr>
+			<tr><td>Anne Dorrance, Ohio State Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Dorrance.pdf">Resistance to Phytophthora sojae: current status and challenges</a></td></tr>
 		</body>
 	</table>
 </div>
@@ -96,10 +96,10 @@ sitemap: community/sbw
 		<body>			
 			<tr><th colspan='2'>Public Breeder Coordination Session</tr></th>
 			<tr><td>Vince Pantalone, Univ. of Tennessee</td><td>Soybean Germplasm Committee Report</td></tr>
-			<tr><td>David Walker, USDA-ARS, IL</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Walker_2.pdf">Soybean Genetics Committee Report</a></td></tr>
-			<tr><td>David Walker, USDA-ARS, IL</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Walker.pdf">Progress in Developing Soybean Resistant to Soybean Rust</a></td></tr>
-			<tr><td>Jim Specht, Univ. of Nebraska and Perry Cregan, USDA-ARS, MD</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Specht.pdf">Selective Genotyping and Association Mapping for Protein/Oil QTLs</a></td></tr>
-			<tr><td>David Grant, USDA-ARS, IA</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Grant.pdf">SoyBase &amp; the Soybean Breeders Toolbox</a></td></tr>
+			<tr><td>David Walker, USDA-ARS, IL</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Walker_2.pdf">Soybean Genetics Committee Report</a></td></tr>
+			<tr><td>David Walker, USDA-ARS, IL</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Walker.pdf">Progress in Developing Soybean Resistant to Soybean Rust</a></td></tr>
+			<tr><td>Jim Specht, Univ. of Nebraska and Perry Cregan, USDA-ARS, MD</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Specht.pdf">Selective Genotyping and Association Mapping for Protein/Oil QTLs</a></td></tr>
+			<tr><td>David Grant, USDA-ARS, IA</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Grant.pdf">SoyBase &amp; the Soybean Breeders Toolbox</a></td></tr>
 		</body>
 	</table>
 </div>			

--- a/community/sbw/SBW/SBW_2010.html
+++ b/community/sbw/SBW/SBW_2010.html
@@ -3,86 +3,107 @@ layout: default
 title: 2010 Soybean Breeders Workshop - Presentations and Reports 
 sitemap: community/sbw
 ---
+<h2>2010 SOYBEAN BREEDERS/PLANT PATHOLOGISTS WORKSHOP</h2>
+<hr >
+    
+<h3>Workshop Coordinatiors:</h3>
+<p><strong>Vince Pantalone</strong>(Public Breeder), Univ. of Tennessee, Overall planning and coordination<br>
+<strong>Clem Weidenbenner</strong> (Commercial Breeder), Harmony Agricultural Products in Ohio (HAPI-O)  Facilities and hotel arrangements<br>
+<strong>David Walker</strong> (Public Breeder), USDA-ARS, Urbana, IL, Program Chair<br>
+<strong>Jason Bond</strong> (Public Plant Pathologist), Southern Illinois University, Program Co-Chair</p>
+			
+<h3>Monday, February 22, 2010</h3>
+<div class="uk-overflow-auto">
+<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+    <thead>
+        <tr>
+            <th class="uk-table-expand">Speaker</th>
+            <th class="uk-table-expand">Topic</th>
+        </tr>
+    </thead>
+<body>
+	<tr><th colspan='2'>Public Breeder Coordination Session</th></tr>
+	<tr><td>Rich Wilson</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Wilson.pdf">Documenting Soybean Genomics Research</a></td></tr>
+	<tr><td>Roy Scott</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Scott.pdf">National Program Update</a></td></tr>
+	<tr><td>Jim Orf, Univ. of Minnesota</td><td>Phytophtora</td></tr>
+	<tr><td>Katy Martin Rainey, Virginia Tech Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Rainey.pdf">Soybean Mosaic Virus</a></td></tr>
+	<tr><td>Brian Diers, Univ. of Illinois</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Diers.pdf">Asian Soybean Rust</a></td></tr>
+	<tr><td>Stella Kantartzi, Southern Illinois Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Kantartzi.pdf">Sudden Death Syndrome</a></td></tr>
+	<tr><td>David Lightfoot, Southern Illinois Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Lightfoot.pdf">Soybean Cyst Nematode</a></td></tr>
+	<tr><td>Paul Stephens, Pioneer Hi-Bred</td><td>Pioneer Optimum GAT Technology Update</td></tr>
+	<tr><td>Rick Leitz</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Leitz.pdf">Monsanto Technology Update</a></td></tr>
+	<tr><td>Wayne Parrot, Univ. of Georgia</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Parrot.pdf">USB Update: Center for Soybean Tissue Culture and Genetic Engineering</a></td></tr>
+</body>
+</table>
+</div>
 
-			<div class ="top_bar">
-				<h2>2010 SOYBEAN BREEDERS/PLANT PATHOLOGISTS WORKSHOP</h2>
-       <hr >
-     </div>
-			<br>
-			<div class="head_link"><h3>Workshop Coordinatiors:</h3> </div>
-			<div class="setin">
-				Vince Pantalone (Public Breeder), Univ. of Tennessee, Overall planning and coordination<br>
-				Clem Weidenbenner (Commercial Breeder), Harmony Agricultural Products in Ohio (HAPI-O)  Facilities and hotel arrangements<br>
-			</div>
-			<br>
-			<div class="head_link"><h3>Program Committee for Tuesday General Sessions:</h3></div>
-			<div class="setin">
-				David Walker (Public Breeder), USDA-ARS, Urbana, IL (Chair)<br>
-				Jason Bond (Public Plant Pathologist), Southern Illinois University (Co-Chair)
-			</div>
-			<br>
-			<div class="head_link"><h3>Monday, February 22</h3></div>
-			<div class="sub_link">Public Breeder Coordination Session</div><br>
-			<div class="setin">
-				Rich Wilson - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Wilson.pdf">Documenting Soybean Genomics Research</a><br>
-				Roy Scott - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Scott.pdf">National Program Update</a><br>
-				Jim Orf, Univ. of Minnesota - Phytophtora<br>
-				Katy Martin Rainey, Virginia Tech Univ. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Rainey.pdf">Soybean Mosaic Virus</a><br>
-				Brian Diers, Univ. of Illinois - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Diers.pdf">Asian Soybean Rust</a><br>
-				Stella Kantartzi, Southern Illinois Univ. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Kantartzi.pdf">Sudden Death Syndrome</a><br>
-				David Lightfoot, Southern Illinois Univ. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Lightfoot.pdf">Soybean Cyst Nematode</a><br>
-				Paul Stephens, Pioneer Hi-Bred - Pioneer Optimum GAT Technology Update<br>
-				Rick Leitz - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Leitz.pdf">Monsanto Technology Update</a><br>
-				Wayne Parrot, Univ. of Georgia - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Parrot.pdf">USB Update: Center for Soybean Tissue Culture and Genetic Engineering</a><br>
-			</div>
-			<br>
-			<div class="head_link"><h3>Tuesday, February 23</h3></div>
-			<div class="sub_link">Plant Pathology General Session</div><br>
-			<div class="setin">
-				<u>Nematodes</u>, Prakash Arelli (Chair), USDA-ARS, Jackson, TN<br>
-				Brian Diers, Univ. of Illinois - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Diers_2.pdf">Breeding soybean for nematode resistance in the Midwest</a><br>
-				Grover Shannon, Univ. of Missouri - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Shannon.pdf">Soybean breeding for SCN resistance in the Midsouth</a><br>
-				Bo-Keun Ha, Univ. of Georgia - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Ha.pdf">Breeding soybean for resistance to root-knot nematode</a><br>
-				Don Hershman, Univ. of Kentucky - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Hershman.pdf">Hindrances to effective cyst nematode extension programming</a><br>
-				Istvan Rajcan, Univ. of Guelph - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Rajcan.pdf">Recent mapping efforts for SCN resistance in G. max and G. soja</a><br>
-				Prakash Arelli, USDA-ARS, TN - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Arelli.pdf">diverse sources of resistance to SCN in soybean</a><br>
-				<br>
-				<u>Frogeye Leaf Spot and SMV</u>, Jason Bond (Chair), Southern Illinois University<br>
-				Melvin Newman, Univ. of Tennessee - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Newman.pdf">Soybean cultivar reaction to frogeye leaf spot</a><br>
-				Rouf Mian, USDA-ARS, OH - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Mian.pdf">Genetic resistance of soybean to frogeye leaf spot, mapping of Rcs3, and breeding for resistance</a><br>
-				Jason Bond, So. Illinois Univ. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Bond.pdf">Identifying resistance to frogeye leaf spot in plant introductions</a><br>
-				Saghai Maroof, Virginia Tech Univ. - Soybean mosaic virus resistance genes and their interactions<br>
-				<br>
-				<u>Charcoal Rot</u>, Alemu Mengistu (Chair), USDA-ARS, Jackson, TN<br>
-				Allen Wrather, Univ. of Missouri - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Wrather.pdf">Impact of charcoal rot and other diseases on world soybean supply</a><br>
-				Alemu Mengistu, USDA-ARS, TN - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Mengistu.pdf">Screening and identifying soybean lines for resistance to charcoal rot in a field environment</a><br>
-				Glen Hartman, USDA-ARS, IL - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Hartman.pdf">Screening and identifying soybean lines for resistance in non-field environments</a><br>
-				Rusty Smith, USDA-ARS, MS - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Smith.pdf">Studies in genetics and breeding for resistance to charcoal rot in soybean</a><br>
-				John Rupe, Univ. of Arkansas - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Rupe.pdf">Multi-environment testing for charcoal rot resistance: a regional approach</a><br>
-				Ahmad Fakhoury, Purdue Univ. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Fakhoury.pdf">Phasiolinone as a new tool to evaluate resistance to charcoal rot</a><br>
-				<br>
-				<u>Sudden Death Syndrome</u>, Jason Bond (Co-Chair), SIU and Brian Diers (Co-Chair), Univ. of IL<br>
-				Leonor Leandro, Iowa State Univ. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Leandro.pdf">Epidemiological studies on the timing of inoculation and development of sudden death syndrome in soybean</a><br>
-				Ahmad Fakhoury, Purdue Univ. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Fakhoury_2.pdf">Identifying fungal factors affecting Fusarium virguliforme aggressiveness and SDS development</a><br>
-				Silvia Cianzio, Iowa State Univ. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Cianzio.pdf">Breeding efforts for SDS resistance</a><br>
-				Madan Bhattacharyya, Iowa State Univ. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Bhattacharyya.pdf">How does the fungal pathogen, Fusarium virguliforme cause SDS?</a><br>
-				David Lightfoot, So. Illinois Univ. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Lightfoot_2.pdf">Transgenics, QTL stacks and NIL verifications for SDS</a><br>
-				<br>
-				<u>Other Soybean Diseases</u>, Jason Bond (Co-Chair), SIU and Brian Diers (Co-Chair), Univ. of IL<br>
-				Anne Dorrance, Ohio State Univ. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Dorrance.pdf">Resistance to Phytophthora sojae: current status and challenges</a><br>
-			</div>
-			<br>
-			<div class="head_link"><h3>Wednesday, February 24</h3></div>
-			<div class="sub_link">Public Breeder Coordination Session</div><br>
-			<div class="setin">
-				Vince Pantalone, Univ. of Tennessee - Soybean Germplasm Committee Report<br>
-				David Walker, USDA-ARS, IL - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Walker_2.pdf">Soybean Genetics Committee Report</a><br>
-				David Walker, USDA-ARS, IL - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Walker.pdf">Progress in Developing Soybean Resistant to Soybean Rust</a><br>
-				Jim Specht, Univ. of Nebraska, Perry Cregan, USDA-ARS, MD - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Specht.pdf">Selective Genotyping and Association Mapping for Protein/Oil QTLs</a><br>
-				David Grant, USDA-ARS, IA - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Grant.pdf">SoyBase &amp; the Soybean Breeders Toolbox</a><br>
-			</div>
+	
+	
+<h3>Tuesday, February 23, 2010</h3>
+<div class="uk-overflow-auto">
+<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+    <thead>
+        <tr>
+            <th class="uk-table-expand">Speaker</th>
+            <th class="uk-table-expand">Topic</th>
+        </tr>
+    </thead>
+<body>
+
+	<tr><th colspan='2'>Nematodes | Chair: Prakash Arelli, USDA-ARS, Jackson, TN</tr></th>
+	<tr><td>Brian Diers, Univ. of Illinois</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Diers_2.pdf">Breeding soybean for nematode resistance in the Midwest</a></td></tr>
+	<tr><td>Grover Shannon, Univ. of Missouri</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Shannon.pdf">Soybean breeding for SCN resistance in the Midsouth</a></td></tr>
+	<tr><td>Bo-Keun Ha, Univ. of Georgia</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Ha.pdf">Breeding soybean for resistance to root-knot nematode</a></td></tr>
+	<tr><td>Don Hershman, Univ. of Kentucky</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Hershman.pdf">Hindrances to effective cyst nematode extension programming</a></td></tr>
+	<tr><td>Istvan Rajcan, Univ. of Guelph</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Rajcan.pdf">Recent mapping efforts for SCN resistance in G. max and G. soja</a></td></tr>
+	<tr><td>Prakash Arelli, USDA-ARS, TN</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Arelli.pdf">diverse sources of resistance to SCN in soybean</a></td></tr>
+	<tr><th colspan='2'>Frogeye Leaf Spot and SMV | Chair: Jason Bond, Southern Illinois University</tr></th>
+	<tr><td>Melvin Newman, Univ. of Tennessee</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Newman.pdf">Soybean cultivar reaction to frogeye leaf spot</a></td></tr>
+	<tr><td>Rouf Mian, USDA-ARS, OH</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Mian.pdf">Genetic resistance of soybean to frogeye leaf spot, mapping of Rcs3, and breeding for resistance</a></td></tr>
+	<tr><td>Jason Bond, So. Illinois Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Bond.pdf">Identifying resistance to frogeye leaf spot in plant introductions</a></td></tr>
+	<tr><td>Saghai Maroof, Virginia Tech Univ.</td><td>Soybean mosaic virus resistance genes and their interactions</td></tr>
+	
+	<tr><th colspan='2'>Charcoal Rot | Chair: Alemu Mengistu, USDA-ARS, Jackson, TN</tr></th>
+	<tr><td>Allen Wrather, Univ. of Missouri</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Wrather.pdf">Impact of charcoal rot and other diseases on world soybean supply</a></td></tr>
+	<tr><td>Alemu Mengistu, USDA-ARS, TN</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Mengistu.pdf">Screening and identifying soybean lines for resistance to charcoal rot in a field environment</a></td></tr>
+	<tr><td>Glen Hartman, USDA-ARS, IL</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Hartman.pdf">Screening and identifying soybean lines for resistance in non-field environments</a></td></tr>
+	<tr><td>Rusty Smith, USDA-ARS, MS</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Smith.pdf">Studies in genetics and breeding for resistance to charcoal rot in soybean</a></td></tr>
+	<tr><td>John Rupe, Univ. of Arkansas</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Rupe.pdf">Multi-environment testing for charcoal rot resistance: a regional approach</a></td></tr>
+	<tr><td>Ahmad Fakhoury, Purdue Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Fakhoury.pdf">Phasiolinone as a new tool to evaluate resistance to charcoal rot</a></td></tr>
+	
+	<tr><th colspan='2'>Sudden Death Syndrome Chairs:  Jason Bond, SIU and Brian Diers, Univ. of IL</tr></th>
+	<tr><td>Leonor Leandro, Iowa State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Leandro.pdf">Epidemiological studies on the timing of inoculation and development of sudden death syndrome in soybean</a></td></tr>
+	<tr><td>Ahmad Fakhoury, Purdue Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Fakhoury_2.pdf">Identifying fungal factors affecting Fusarium virguliforme aggressiveness and SDS development</a></td></tr>
+	<tr><td>Silvia Cianzio, Iowa State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Cianzio.pdf">Breeding efforts for SDS resistance</a></td></tr>
+	<tr><td>Madan Bhattacharyya, Iowa State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Bhattacharyya.pdf">How does the fungal pathogen, Fusarium virguliforme cause SDS?</a></td></tr>
+	<tr><td>David Lightfoot, So. Illinois Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Lightfoot_2.pdf">Transgenics, QTL stacks and NIL verifications for SDS</a></td></tr>
+				
+	<tr><th colspan='2'>Other Soybean Diseases | Chairs: Jason Bond, SIU and Brian Diers, Univ. of IL</tr></th>
+	<tr><td>Anne Dorrance, Ohio State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Dorrance.pdf">Resistance to Phytophthora sojae: current status and challenges</a></td></tr>
+</body>
+</table>
+</div>
+			
+<h3>Wednesday, February 24</h3></div>
+<div class="uk-overflow-auto">
+<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+    <thead>
+        <tr>
+            <th class="uk-table-expand">Speaker</th>
+            <th class="uk-table-expand">Topic</th>
+        </tr>
+    </thead>
+<body>			
+	<tr><th colspan='2'>Public Breeder Coordination Session</tr></th>
+	<tr><td>Vince Pantalone, Univ. of Tennessee</td><td>Soybean Germplasm Committee Report</td></tr>
+	<tr><td>David Walker, USDA-ARS, IL</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Walker_2.pdf">Soybean Genetics Committee Report</a></td></tr>
+	<tr><td>David Walker, USDA-ARS, IL</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Walker.pdf">Progress in Developing Soybean Resistant to Soybean Rust</a></td></tr>
+	<tr><td>Jim Specht, Univ. of Nebraska and Perry Cregan, USDA-ARS, MD</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Specht.pdf">Selective Genotyping and Association Mapping for Protein/Oil QTLs</a></td></tr>
+	<tr><td>David Grant, USDA-ARS, IA</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Grant.pdf">SoyBase &amp; the Soybean Breeders Toolbox</a></td></tr>
+</body>
+</table>
+</div>			
 
 
- </body>
-</html>
+
 

--- a/community/sbw/SBW/SBW_2010.html
+++ b/community/sbw/SBW/SBW_2010.html
@@ -5,103 +5,103 @@ sitemap: community/sbw
 ---
 <h2>2010 SOYBEAN BREEDERS/PLANT PATHOLOGISTS WORKSHOP</h2>
 <hr >
-    
-<h3>Workshop Coordinatiors:</h3>
-<p><strong>Vince Pantalone</strong>(Public Breeder), Univ. of Tennessee, Overall planning and coordination<br>
-<strong>Clem Weidenbenner</strong> (Commercial Breeder), Harmony Agricultural Products in Ohio (HAPI-O)  Facilities and hotel arrangements<br>
-<strong>David Walker</strong> (Public Breeder), USDA-ARS, Urbana, IL, Program Chair<br>
-<strong>Jason Bond</strong> (Public Plant Pathologist), Southern Illinois University, Program Co-Chair</p>
-			
+
+<div>
+	<h4>Workshop Coordinatiors:</h4>
+	<p>
+		<strong>Vince Pantalone</strong>(Public Breeder), Univ. of Tennessee, Overall planning and coordination<br>
+		<strong>Clem Weidenbenner</strong> (Commercial Breeder), Harmony Agricultural Products in Ohio (HAPI-O)  Facilities and hotel arrangements<br>
+		<strong>David Walker</strong> (Public Breeder), USDA-ARS, Urbana, IL, Program Chair<br>
+		<strong>Jason Bond</strong> (Public Plant Pathologist), Southern Illinois University, Program Co-Chair
+	</p>
+</div>			
+
 <h3>Monday, February 22, 2010</h3>
 <div class="uk-overflow-auto">
-<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
-    <thead>
-        <tr>
-            <th class="uk-table-expand">Speaker</th>
-            <th class="uk-table-expand">Topic</th>
-        </tr>
-    </thead>
-<body>
-	<tr><th colspan='2'>Public Breeder Coordination Session</th></tr>
-	<tr><td>Rich Wilson</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Wilson.pdf">Documenting Soybean Genomics Research</a></td></tr>
-	<tr><td>Roy Scott</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Scott.pdf">National Program Update</a></td></tr>
-	<tr><td>Jim Orf, Univ. of Minnesota</td><td>Phytophtora</td></tr>
-	<tr><td>Katy Martin Rainey, Virginia Tech Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Rainey.pdf">Soybean Mosaic Virus</a></td></tr>
-	<tr><td>Brian Diers, Univ. of Illinois</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Diers.pdf">Asian Soybean Rust</a></td></tr>
-	<tr><td>Stella Kantartzi, Southern Illinois Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Kantartzi.pdf">Sudden Death Syndrome</a></td></tr>
-	<tr><td>David Lightfoot, Southern Illinois Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Lightfoot.pdf">Soybean Cyst Nematode</a></td></tr>
-	<tr><td>Paul Stephens, Pioneer Hi-Bred</td><td>Pioneer Optimum GAT Technology Update</td></tr>
-	<tr><td>Rick Leitz</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Leitz.pdf">Monsanto Technology Update</a></td></tr>
-	<tr><td>Wayne Parrot, Univ. of Georgia</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Parrot.pdf">USB Update: Center for Soybean Tissue Culture and Genetic Engineering</a></td></tr>
-</body>
-</table>
+	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+    	<thead>
+        	<tr>
+            	<th class="uk-table-expand">Speaker</th>
+            	<th class="uk-table-expand">Topic</th>
+        	</tr>
+    	</thead>
+		<body>
+			<tr><th colspan='2'>Public Breeder Coordination Session</th></tr>
+			<tr><td>Rich Wilson</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Wilson.pdf">Documenting Soybean Genomics Research</a></td></tr>
+			<tr><td>Roy Scott</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Scott.pdf">National Program Update</a></td></tr>
+			<tr><td>Jim Orf, Univ. of Minnesota</td><td>Phytophtora</td></tr>
+			<tr><td>Katy Martin Rainey, Virginia Tech Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Rainey.pdf">Soybean Mosaic Virus</a></td></tr>
+			<tr><td>Brian Diers, Univ. of Illinois</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Diers.pdf">Asian Soybean Rust</a></td></tr>
+			<tr><td>Stella Kantartzi, Southern Illinois Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Kantartzi.pdf">Sudden Death Syndrome</a></td></tr>
+			<tr><td>David Lightfoot, Southern Illinois Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Lightfoot.pdf">Soybean Cyst Nematode</a></td></tr>
+			<tr><td>Paul Stephens, Pioneer Hi-Bred</td><td>Pioneer Optimum GAT Technology Update</td></tr>
+			<tr><td>Rick Leitz</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Leitz.pdf">Monsanto Technology Update</a></td></tr>
+			<tr><td>Wayne Parrot, Univ. of Georgia</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Parrot.pdf">USB Update: Center for Soybean Tissue Culture and Genetic Engineering</a></td></tr>
+		</body>
+	</table>
 </div>
 
 	
 	
 <h3>Tuesday, February 23, 2010</h3>
 <div class="uk-overflow-auto">
-<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
-    <thead>
-        <tr>
-            <th class="uk-table-expand">Speaker</th>
-            <th class="uk-table-expand">Topic</th>
-        </tr>
-    </thead>
-<body>
-
-	<tr><th colspan='2'>Nematodes | Chair: Prakash Arelli, USDA-ARS, Jackson, TN</tr></th>
-	<tr><td>Brian Diers, Univ. of Illinois</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Diers_2.pdf">Breeding soybean for nematode resistance in the Midwest</a></td></tr>
-	<tr><td>Grover Shannon, Univ. of Missouri</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Shannon.pdf">Soybean breeding for SCN resistance in the Midsouth</a></td></tr>
-	<tr><td>Bo-Keun Ha, Univ. of Georgia</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Ha.pdf">Breeding soybean for resistance to root-knot nematode</a></td></tr>
-	<tr><td>Don Hershman, Univ. of Kentucky</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Hershman.pdf">Hindrances to effective cyst nematode extension programming</a></td></tr>
-	<tr><td>Istvan Rajcan, Univ. of Guelph</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Rajcan.pdf">Recent mapping efforts for SCN resistance in G. max and G. soja</a></td></tr>
-	<tr><td>Prakash Arelli, USDA-ARS, TN</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Arelli.pdf">diverse sources of resistance to SCN in soybean</a></td></tr>
-	<tr><th colspan='2'>Frogeye Leaf Spot and SMV | Chair: Jason Bond, Southern Illinois University</tr></th>
-	<tr><td>Melvin Newman, Univ. of Tennessee</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Newman.pdf">Soybean cultivar reaction to frogeye leaf spot</a></td></tr>
-	<tr><td>Rouf Mian, USDA-ARS, OH</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Mian.pdf">Genetic resistance of soybean to frogeye leaf spot, mapping of Rcs3, and breeding for resistance</a></td></tr>
-	<tr><td>Jason Bond, So. Illinois Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Bond.pdf">Identifying resistance to frogeye leaf spot in plant introductions</a></td></tr>
-	<tr><td>Saghai Maroof, Virginia Tech Univ.</td><td>Soybean mosaic virus resistance genes and their interactions</td></tr>
-	
-	<tr><th colspan='2'>Charcoal Rot | Chair: Alemu Mengistu, USDA-ARS, Jackson, TN</tr></th>
-	<tr><td>Allen Wrather, Univ. of Missouri</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Wrather.pdf">Impact of charcoal rot and other diseases on world soybean supply</a></td></tr>
-	<tr><td>Alemu Mengistu, USDA-ARS, TN</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Mengistu.pdf">Screening and identifying soybean lines for resistance to charcoal rot in a field environment</a></td></tr>
-	<tr><td>Glen Hartman, USDA-ARS, IL</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Hartman.pdf">Screening and identifying soybean lines for resistance in non-field environments</a></td></tr>
-	<tr><td>Rusty Smith, USDA-ARS, MS</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Smith.pdf">Studies in genetics and breeding for resistance to charcoal rot in soybean</a></td></tr>
-	<tr><td>John Rupe, Univ. of Arkansas</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Rupe.pdf">Multi-environment testing for charcoal rot resistance: a regional approach</a></td></tr>
-	<tr><td>Ahmad Fakhoury, Purdue Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Fakhoury.pdf">Phasiolinone as a new tool to evaluate resistance to charcoal rot</a></td></tr>
-	
-	<tr><th colspan='2'>Sudden Death Syndrome Chairs:  Jason Bond, SIU and Brian Diers, Univ. of IL</tr></th>
-	<tr><td>Leonor Leandro, Iowa State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Leandro.pdf">Epidemiological studies on the timing of inoculation and development of sudden death syndrome in soybean</a></td></tr>
-	<tr><td>Ahmad Fakhoury, Purdue Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Fakhoury_2.pdf">Identifying fungal factors affecting Fusarium virguliforme aggressiveness and SDS development</a></td></tr>
-	<tr><td>Silvia Cianzio, Iowa State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Cianzio.pdf">Breeding efforts for SDS resistance</a></td></tr>
-	<tr><td>Madan Bhattacharyya, Iowa State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Bhattacharyya.pdf">How does the fungal pathogen, Fusarium virguliforme cause SDS?</a></td></tr>
-	<tr><td>David Lightfoot, So. Illinois Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Lightfoot_2.pdf">Transgenics, QTL stacks and NIL verifications for SDS</a></td></tr>
-				
-	<tr><th colspan='2'>Other Soybean Diseases | Chairs: Jason Bond, SIU and Brian Diers, Univ. of IL</tr></th>
-	<tr><td>Anne Dorrance, Ohio State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Dorrance.pdf">Resistance to Phytophthora sojae: current status and challenges</a></td></tr>
-</body>
-</table>
+	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+    	<thead>
+        	<tr>
+            	<th class="uk-table-expand">Speaker</th>
+           		<th class="uk-table-expand">Topic</th>
+        	</tr>
+    	</thead>
+		<body>
+			<tr><th colspan='2'>Nematodes | Chair: Prakash Arelli, USDA-ARS, Jackson, TN</tr></th>
+			<tr><td>Brian Diers, Univ. of Illinois</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Diers_2.pdf">Breeding soybean for nematode resistance in the Midwest</a></td></tr>
+			<tr><td>Grover Shannon, Univ. of Missouri</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Shannon.pdf">Soybean breeding for SCN resistance in the Midsouth</a></td></tr>
+			<tr><td>Bo-Keun Ha, Univ. of Georgia</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Ha.pdf">Breeding soybean for resistance to root-knot nematode</a></td></tr>
+			<tr><td>Don Hershman, Univ. of Kentucky</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Hershman.pdf">Hindrances to effective cyst nematode extension programming</a></td></tr>
+			<tr><td>Istvan Rajcan, Univ. of Guelph</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Rajcan.pdf">Recent mapping efforts for SCN resistance in G. max and G. soja</a></td></tr>
+			<tr><td>Prakash Arelli, USDA-ARS, TN</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Arelli.pdf">diverse sources of resistance to SCN in soybean</a></td></tr>
+			<tr><th colspan='2'>Frogeye Leaf Spot and SMV | Chair: Jason Bond, Southern Illinois University</tr></th>
+			<tr><td>Melvin Newman, Univ. of Tennessee</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Newman.pdf">Soybean cultivar reaction to frogeye leaf spot</a></td></tr>
+			<tr><td>Rouf Mian, USDA-ARS, OH</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Mian.pdf">Genetic resistance of soybean to frogeye leaf spot, mapping of Rcs3, and breeding for resistance</a></td></tr>
+			<tr><td>Jason Bond, So. Illinois Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Bond.pdf">Identifying resistance to frogeye leaf spot in plant introductions</a></td></tr>
+			<tr><td>Saghai Maroof, Virginia Tech Univ.</td><td>Soybean mosaic virus resistance genes and their interactions</td></tr>
+			<tr><th colspan='2'>Charcoal Rot | Chair: Alemu Mengistu, USDA-ARS, Jackson, TN</tr></th>
+			<tr><td>Allen Wrather, Univ. of Missouri</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Wrather.pdf">Impact of charcoal rot and other diseases on world soybean supply</a></td></tr>
+			<tr><td>Alemu Mengistu, USDA-ARS, TN</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Mengistu.pdf">Screening and identifying soybean lines for resistance to charcoal rot in a field environment</a></td></tr>
+			<tr><td>Glen Hartman, USDA-ARS, IL</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Hartman.pdf">Screening and identifying soybean lines for resistance in non-field environments</a></td></tr>
+			<tr><td>Rusty Smith, USDA-ARS, MS</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Smith.pdf">Studies in genetics and breeding for resistance to charcoal rot in soybean</a></td></tr>
+			<tr><td>John Rupe, Univ. of Arkansas</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Rupe.pdf">Multi-environment testing for charcoal rot resistance: a regional approach</a></td></tr>
+			<tr><td>Ahmad Fakhoury, Purdue Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Fakhoury.pdf">Phasiolinone as a new tool to evaluate resistance to charcoal rot</a></td></tr>
+			<tr><th colspan='2'>Sudden Death Syndrome Chairs:  Jason Bond, SIU and Brian Diers, Univ. of IL</tr></th>
+			<tr><td>Leonor Leandro, Iowa State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Leandro.pdf">Epidemiological studies on the timing of inoculation and development of sudden death syndrome in soybean</a></td></tr>
+			<tr><td>Ahmad Fakhoury, Purdue Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Fakhoury_2.pdf">Identifying fungal factors affecting Fusarium virguliforme aggressiveness and SDS development</a></td></tr>
+			<tr><td>Silvia Cianzio, Iowa State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Cianzio.pdf">Breeding efforts for SDS resistance</a></td></tr>
+			<tr><td>Madan Bhattacharyya, Iowa State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Bhattacharyya.pdf">How does the fungal pathogen, Fusarium virguliforme cause SDS?</a></td></tr>
+			<tr><td>David Lightfoot, So. Illinois Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Lightfoot_2.pdf">Transgenics, QTL stacks and NIL verifications for SDS</a></td></tr>
+			<tr><th colspan='2'>Other Soybean Diseases | Chairs: Jason Bond, SIU and Brian Diers, Univ. of IL</tr></th>
+			<tr><td>Anne Dorrance, Ohio State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Dorrance.pdf">Resistance to Phytophthora sojae: current status and challenges</a></td></tr>
+		</body>
+	</table>
 </div>
 			
-<h3>Wednesday, February 24</h3></div>
+<h3>Wednesday, February 24</h3>
 <div class="uk-overflow-auto">
-<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
-    <thead>
-        <tr>
-            <th class="uk-table-expand">Speaker</th>
-            <th class="uk-table-expand">Topic</th>
-        </tr>
-    </thead>
-<body>			
-	<tr><th colspan='2'>Public Breeder Coordination Session</tr></th>
-	<tr><td>Vince Pantalone, Univ. of Tennessee</td><td>Soybean Germplasm Committee Report</td></tr>
-	<tr><td>David Walker, USDA-ARS, IL</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Walker_2.pdf">Soybean Genetics Committee Report</a></td></tr>
-	<tr><td>David Walker, USDA-ARS, IL</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Walker.pdf">Progress in Developing Soybean Resistant to Soybean Rust</a></td></tr>
-	<tr><td>Jim Specht, Univ. of Nebraska and Perry Cregan, USDA-ARS, MD</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Specht.pdf">Selective Genotyping and Association Mapping for Protein/Oil QTLs</a></td></tr>
-	<tr><td>David Grant, USDA-ARS, IA</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Grant.pdf">SoyBase &amp; the Soybean Breeders Toolbox</a></td></tr>
-</body>
-</table>
+	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+    	<thead>
+        	<tr>
+            	<th class="uk-table-expand">Speaker</th>
+           		<th class="uk-table-expand">Topic</th>
+        	</tr>
+    	</thead>
+		<body>			
+			<tr><th colspan='2'>Public Breeder Coordination Session</tr></th>
+			<tr><td>Vince Pantalone, Univ. of Tennessee</td><td>Soybean Germplasm Committee Report</td></tr>
+			<tr><td>David Walker, USDA-ARS, IL</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Walker_2.pdf">Soybean Genetics Committee Report</a></td></tr>
+			<tr><td>David Walker, USDA-ARS, IL</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Walker.pdf">Progress in Developing Soybean Resistant to Soybean Rust</a></td></tr>
+			<tr><td>Jim Specht, Univ. of Nebraska and Perry Cregan, USDA-ARS, MD</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Specht.pdf">Selective Genotyping and Association Mapping for Protein/Oil QTLs</a></td></tr>
+			<tr><td>David Grant, USDA-ARS, IA</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2010/Grant.pdf">SoyBase &amp; the Soybean Breeders Toolbox</a></td></tr>
+		</body>
+	</table>
 </div>			
 
 

--- a/community/sbw/SBW/SBW_2012.html
+++ b/community/sbw/SBW/SBW_2012.html
@@ -25,13 +25,13 @@ sitemap: community/sbw
         	</tr>
     	</thead>
 		<body>
-			<tr><td>Henry Nguyen, Univ. Missouri</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Nguyen.pdf">Large-scale Genome Re-sequencing</a></td></tr>
-			<tr><td>Peter Morrell, Univ. Minnesota</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Morrell.pdf">Nextgen Pops, Genetic Load, and Other Advances and Applications in Crop Genomics</a></td></tr>
+			<tr><td>Henry Nguyen, Univ. Missouri</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Nguyen.pdf">Large-scale Genome Re-sequencing</a></td></tr>
+			<tr><td>Peter Morrell, Univ. Minnesota</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Morrell.pdf">Nextgen Pops, Genetic Load, and Other Advances and Applications in Crop Genomics</a></td></tr>
 			<tr><td>Scott Sebastian, Pioneer Hi-Bred</td><td>Context Specific MAS</td></tr>
-			<tr><td>Matt O'Neal, IA State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/ONeal.pdf">Insect Pollinators in Soybeans</a></td></tr>
-			<tr><td>Maria Ortega &amp; Wayne Parrott, Univ. Georgia</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Ortega.pdf">De-bugging Soybean: A Story of Nano-spears and QTLs</a></td></tr>
+			<tr><td>Matt O'Neal, IA State Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/ONeal.pdf">Insect Pollinators in Soybeans</a></td></tr>
+			<tr><td>Maria Ortega &amp; Wayne Parrott, Univ. Georgia</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Ortega.pdf">De-bugging Soybean: A Story of Nano-spears and QTLs</a></td></tr>
 			<tr><td>M.A. Saghai Maroof, Virginia Tech</td><td>Overview of $9.2 million AFRI Phytophthora Project</td></tr>
-			<tr><td>Rich Joost, Production Research Pgm. Director, USB/SmithBucklin</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Joost.pdf">Future Directions for United Soybean Board Breeding Funding</a></td></tr>
+			<tr><td>Rich Joost, Production Research Pgm. Director, USB/SmithBucklin</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Joost.pdf">Future Directions for United Soybean Board Breeding Funding</a></td></tr>
 		</body>
 	</table>
 </div>
@@ -47,20 +47,20 @@ sitemap: community/sbw
     	</thead>
 		<body>
 			<tr><th colspan='2'>Session: Stick Bug | Chair: Ames Herbert, Virginia Tech </th></tr>
-			<tr><td>Galen dively, Univ. Maryland</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Dively.pdf">Mid-Atlantic: Brown Marmorated Stink Bug</a></td></tr>
-			<tr><td>Ames Herbert, Virginia Tech</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Herbert.pdf">Mid-Atlantic: Brown Marmorated Stink Bug</a></td></tr>
-			<tr><td>Jeff Davis, LA State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Davis.pdf">Deep South: Redshouldered/redbanded Stink Bugs</a></td></tr>
+			<tr><td>Galen dively, Univ. Maryland</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Dively.pdf">Mid-Atlantic: Brown Marmorated Stink Bug</a></td></tr>
+			<tr><td>Ames Herbert, Virginia Tech</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Herbert.pdf">Mid-Atlantic: Brown Marmorated Stink Bug</a></td></tr>
+			<tr><td>Jeff Davis, LA State Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Davis.pdf">Deep South: Redshouldered/redbanded Stink Bugs</a></td></tr>
 			<tr><th colspan='2'>Sesion: Kudzu Bug | Chair: Ames Herbert, Virginia Tech</th></tr>
-			<tr><td>Phillip Roberts, Univ. Georgia</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Roberts.pdf">Southeast: Kudzu Bug</a><br><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/VID_20110930_143901.m4v">Video 1</a><br><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/VID_20110930_143943.m4v">Video 2</a></td></tr>
-			<tr><td>Jeremy Greene, Clemson Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Greene.pdf">Southeast: Kudzu Bug</a></td></tr>
-			<tr><td>Andrea Cardinal, North Carolina State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Cardinal.pdf">Stink Bugs White Paper</a></td></tr>
+			<tr><td>Phillip Roberts, Univ. Georgia</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Roberts.pdf">Southeast: Kudzu Bug</a><br><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/VID_20110930_143901.m4v">Video 1</a><br><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/VID_20110930_143943.m4v">Video 2</a></td></tr>
+			<tr><td>Jeremy Greene, Clemson Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Greene.pdf">Southeast: Kudzu Bug</a></td></tr>
+			<tr><td>Andrea Cardinal, North Carolina State Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Cardinal.pdf">Stink Bugs White Paper</a></td></tr>
 			<tr><th colspan='2'>Sesion: Aphids | Chair: Dechun Wang, Michigan State Univ.</th></tr>
-			<tr><td>Susannah Cooper, Monsanto Co.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Cooper.pdf">Soybean Aphid Biotypes: Understanding Geographic Distribution (2008-2010)</a></td></tr>
-			<tr><td>Matt O'Neal, IA State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/ONeal2.pdf">Is One Enough?: Combining Rag Genes Improves Aphid Resistance in Soybeans</a></td></tr>
-			<tr><td>Brian Diers, Univ. Illinois at Urbana-Champaign</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Diers.pdf">Fine Mapping Rag1 and Rag2 and the Evaluation of New Aphid Resistance Sources</a></td></tr>
-			<tr><td>Dechun Wang, Michigan State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Wang.pdf">Fine Mapping Rag3 and Rag4 Aphid Resistance Genes</a></td></tr>
-			<tr><td>Rouf Mian, USDA-ARS, Ohio State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Mian.pdf">Mapping and Characterization of a New Soybean Aphid Resistant Gene in PI 567301B</a></td></tr>
-			<tr><td>Andy Michel, Ohio State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Michel.pdf">Molecular Interactions Between Soybean Aphid and Resistant Soybean</a></td></tr>
+			<tr><td>Susannah Cooper, Monsanto Co.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Cooper.pdf">Soybean Aphid Biotypes: Understanding Geographic Distribution (2008-2010)</a></td></tr>
+			<tr><td>Matt O'Neal, IA State Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/ONeal2.pdf">Is One Enough?: Combining Rag Genes Improves Aphid Resistance in Soybeans</a></td></tr>
+			<tr><td>Brian Diers, Univ. Illinois at Urbana-Champaign</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Diers.pdf">Fine Mapping Rag1 and Rag2 and the Evaluation of New Aphid Resistance Sources</a></td></tr>
+			<tr><td>Dechun Wang, Michigan State Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Wang.pdf">Fine Mapping Rag3 and Rag4 Aphid Resistance Genes</a></td></tr>
+			<tr><td>Rouf Mian, USDA-ARS, Ohio State Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Mian.pdf">Mapping and Characterization of a New Soybean Aphid Resistant Gene in PI 567301B</a></td></tr>
+			<tr><td>Andy Michel, Ohio State Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Michel.pdf">Molecular Interactions Between Soybean Aphid and Resistant Soybean</a></td></tr>
 		</body>
 	</table>
 </div>			
@@ -77,13 +77,13 @@ sitemap: community/sbw
     	</thead>
 		<body>
 			<tr><th colspan='2'>Session: Public Breeder Coordination Session</th></tr>
-			<tr><td>Perry Cregan, USDA-ARS, Beltsville</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Cregan.pdf">Update on SNP Genotyping of the USDA Soybean Germplasm Collection</a></td></tr>
-			<tr><td>George Graef, Univ. Nebraska</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Graef.pdf">Soybean Genomics Strategic Plan: Accomplishments and Updates</a></td></tr>
-			<tr><td>Tommy Carter, USDA-ARS, Raleigh</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Carter.pdf">ARS Update (Including Status of Analytical Services)</a></td></tr>
+			<tr><td>Perry Cregan, USDA-ARS, Beltsville</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Cregan.pdf">Update on SNP Genotyping of the USDA Soybean Germplasm Collection</a></td></tr>
+			<tr><td>George Graef, Univ. Nebraska</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Graef.pdf">Soybean Genomics Strategic Plan: Accomplishments and Updates</a></td></tr>
+			<tr><td>Tommy Carter, USDA-ARS, Raleigh</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Carter.pdf">ARS Update (Including Status of Analytical Services)</a></td></tr>
 			<tr><td>Jeff Thompson, Pioneer Hi-Bred</td><td>Soybean Germplasm Committee Report</td></tr>
 			<tr><td>Istvan Rajcan, Univ. Guelph</td><td>Soybean Genetics Committee Report</td></tr>
-			<tr><td>David Grant, USDA-ARS, Ames</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Grant.pdf">SoyBase Update &amp; Tutorials</a></td></tr>
-			<tr><td>Group Discussion from the Floor to David Grant</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Grant2.pdf">Resequencing Data</a><br>
+			<tr><td>David Grant, USDA-ARS, Ames</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Grant.pdf">SoyBase Update &amp; Tutorials</a></td></tr>
+			<tr><td>Group Discussion from the Floor to David Grant</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Grant2.pdf">Resequencing Data</a><br>
 			How will soybean breeders use resequencing data?</br>
 				What tools are needed to enable this?
 			</td></tr>

--- a/community/sbw/SBW/SBW_2012.html
+++ b/community/sbw/SBW/SBW_2012.html
@@ -7,86 +7,88 @@ sitemap: community/sbw
 <h2>2012 SOYBEAN BREEDERS/ENTOMOLOGISTS WORKSHOP</h2>
 <hr>
 
-<h3>Workshop Coordinatiors:</h3>
-<p><strong>Katy Martin Rainey</strong> (Public Breeder), Purdue Univ. - Overall planning and coordination<br>
-<strong>Hari Ramasubramaniam</strong> (Plant Pathologist), Syngenta Seeds Inc. - Hotel arrangements<br>
-<strong>Jerry Lubich</strong>, Pioneer Hi-Bred - website<br>
-<strong>Andrea Cardinal</strong>, NC State Univ. - Program Chair, Tuesday General Session
+<h4>Workshop Coordinatiors:</h4>
+	<p>
+		<strong>Katy Martin Rainey</strong> (Public Breeder), Purdue Univ. - Overall planning and coordination<br>
+		<strong>Hari Ramasubramaniam</strong> (Plant Pathologist), Syngenta Seeds Inc. - Hotel arrangements<br>
+		<strong>Jerry Lubich</strong>, Pioneer Hi-Bred - website<br>
+		<strong>Andrea Cardinal</strong>, NC State Univ. - Program Chair, Tuesday General Session
+	</p>
 			
 <h3>Monday, February 27, 2012</h3>
-	
 <div class="uk-overflow-auto">
-<table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
-    <thead>
-        <tr>
-            <th class="uk-table-expand">Speaker</th>
-            <th class="uk-table-expand">Topic</th>
-        </tr>
-    </thead>
-<body>
-	<tr><td>Henry Nguyen, Univ. Missouri</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Nguyen.pdf">Large-scale Genome Re-sequencing</a></td></tr>
-	<tr><td>Peter Morrell, Univ. Minnesota</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Morrell.pdf">Nextgen Pops, Genetic Load, and Other Advances and Applications in Crop Genomics</a></td></tr>
-	<tr><td>Scott Sebastian, Pioneer Hi-Bred</td><td>Context Specific MAS</td></tr>
-	<tr><td>Matt O'Neal, IA State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/ONeal.pdf">Insect Pollinators in Soybeans</a></td></tr>
-	<tr><td>Maria Ortega &amp; Wayne Parrott, Univ. Georgia</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Ortega.pdf">De-bugging Soybean: A Story of Nano-spears and QTLs</a></td></tr>
-	<tr><td>M.A. Saghai Maroof, Virginia Tech</td><td>Overview of $9.2 million AFRI Phytophthora Project</td></tr>
-	<tr><td>Rich Joost, Production Research Pgm. Director, USB/SmithBucklin</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Joost.pdf">Future Directions for United Soybean Board Breeding Funding</a></td></tr>
-</body>
-</table>
+	<table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
+    	<thead>
+        	<tr>
+           		<th class="uk-table-expand">Speaker</th>
+            	<th class="uk-table-expand">Topic</th>
+        	</tr>
+    	</thead>
+		<body>
+			<tr><td>Henry Nguyen, Univ. Missouri</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Nguyen.pdf">Large-scale Genome Re-sequencing</a></td></tr>
+			<tr><td>Peter Morrell, Univ. Minnesota</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Morrell.pdf">Nextgen Pops, Genetic Load, and Other Advances and Applications in Crop Genomics</a></td></tr>
+			<tr><td>Scott Sebastian, Pioneer Hi-Bred</td><td>Context Specific MAS</td></tr>
+			<tr><td>Matt O'Neal, IA State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/ONeal.pdf">Insect Pollinators in Soybeans</a></td></tr>
+			<tr><td>Maria Ortega &amp; Wayne Parrott, Univ. Georgia</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Ortega.pdf">De-bugging Soybean: A Story of Nano-spears and QTLs</a></td></tr>
+			<tr><td>M.A. Saghai Maroof, Virginia Tech</td><td>Overview of $9.2 million AFRI Phytophthora Project</td></tr>
+			<tr><td>Rich Joost, Production Research Pgm. Director, USB/SmithBucklin</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Joost.pdf">Future Directions for United Soybean Board Breeding Funding</a></td></tr>
+		</body>
+	</table>
 </div>
 
 <h3>Tuesday, February 28, 2012</h3>
 <div class="uk-overflow-auto">
-<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
-    <thead>
-        <tr>
-            <th class="uk-table-expand">Speaker</th>
-            <th class="uk-table-expand">Topic</th>
-        </tr>
-    </thead>
-<body>
-	<tr><th colspan='4'>Session: Stick Bug | Chair: Ames Herbert, Virginia Tech </th></tr>
-	<tr><td>Galen dively, Univ. Maryland</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Dively.pdf">Mid-Atlantic: Brown Marmorated Stink Bug</a></td></tr>
-	<tr><td>Ames Herbert, Virginia Tech</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Herbert.pdf">Mid-Atlantic: Brown Marmorated Stink Bug</a></td></tr>
-	<tr><td>Jeff Davis, LA State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Davis.pdf">Deep South: Redshouldered/redbanded Stink Bugs</a></td></tr>
-	<tr><th colspan='4'>Sesion: Kudzu Bug | Chair: Ames Herbert, Virginia Tech</th></tr>
-	<tr><td>Phillip Roberts, Univ. Georgia</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Roberts.pdf">Southeast: Kudzu Bug</a><br><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/VID_20110930_143901.m4v">Video 1</a><br><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/VID_20110930_143943.m4v">Video 2</a></td></tr>
-	<tr><td>Jeremy Greene, Clemson Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Greene.pdf">Southeast: Kudzu Bug</a></td></tr>
-	<tr><td>Andrea Cardinal, North Carolina State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Cardinal.pdf">Stink Bugs White Paper</a></td></tr>
-	<tr><th colspan='4'>Sesion: Aphids | Chair: Dechun Wang, Michigan State Univ.</th></tr>
-	<tr><td>Susannah Cooper, Monsanto Co.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Cooper.pdf">Soybean Aphid Biotypes: Understanding Geographic Distribution (2008-2010)</a></td></tr>
-	<tr><td>Matt O'Neal, IA State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/ONeal2.pdf">Is One Enough?: Combining Rag Genes Improves Aphid Resistance in Soybeans</a></td></tr>
-	<tr><td>Brian Diers, Univ. Illinois at Urbana-Champaign</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Diers.pdf">Fine Mapping Rag1 and Rag2 and the Evaluation of New Aphid Resistance Sources</a></td></tr>
-	<tr><td>Dechun Wang, Michigan State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Wang.pdf">Fine Mapping Rag3 and Rag4 Aphid Resistance Genes</a></td></tr>
-	<tr><td>Rouf Mian, USDA-ARS, Ohio State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Mian.pdf">Mapping and Characterization of a New Soybean Aphid Resistant Gene in PI 567301B</a></td></tr>
-	<tr><td>Andy Michel, Ohio State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Michel.pdf">Molecular Interactions Between Soybean Aphid and Resistant Soybean</a></td></tr>
-</body>
-</table>
+	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+    	<thead>
+       		<tr>
+            	<th class="uk-table-expand">Speaker</th>
+            	<th class="uk-table-expand">Topic</th>
+        	</tr>
+    	</thead>
+		<body>
+			<tr><th colspan='2'>Session: Stick Bug | Chair: Ames Herbert, Virginia Tech </th></tr>
+			<tr><td>Galen dively, Univ. Maryland</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Dively.pdf">Mid-Atlantic: Brown Marmorated Stink Bug</a></td></tr>
+			<tr><td>Ames Herbert, Virginia Tech</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Herbert.pdf">Mid-Atlantic: Brown Marmorated Stink Bug</a></td></tr>
+			<tr><td>Jeff Davis, LA State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Davis.pdf">Deep South: Redshouldered/redbanded Stink Bugs</a></td></tr>
+			<tr><th colspan='2'>Sesion: Kudzu Bug | Chair: Ames Herbert, Virginia Tech</th></tr>
+			<tr><td>Phillip Roberts, Univ. Georgia</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Roberts.pdf">Southeast: Kudzu Bug</a><br><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/VID_20110930_143901.m4v">Video 1</a><br><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/VID_20110930_143943.m4v">Video 2</a></td></tr>
+			<tr><td>Jeremy Greene, Clemson Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Greene.pdf">Southeast: Kudzu Bug</a></td></tr>
+			<tr><td>Andrea Cardinal, North Carolina State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Cardinal.pdf">Stink Bugs White Paper</a></td></tr>
+			<tr><th colspan='2'>Sesion: Aphids | Chair: Dechun Wang, Michigan State Univ.</th></tr>
+			<tr><td>Susannah Cooper, Monsanto Co.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Cooper.pdf">Soybean Aphid Biotypes: Understanding Geographic Distribution (2008-2010)</a></td></tr>
+			<tr><td>Matt O'Neal, IA State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/ONeal2.pdf">Is One Enough?: Combining Rag Genes Improves Aphid Resistance in Soybeans</a></td></tr>
+			<tr><td>Brian Diers, Univ. Illinois at Urbana-Champaign</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Diers.pdf">Fine Mapping Rag1 and Rag2 and the Evaluation of New Aphid Resistance Sources</a></td></tr>
+			<tr><td>Dechun Wang, Michigan State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Wang.pdf">Fine Mapping Rag3 and Rag4 Aphid Resistance Genes</a></td></tr>
+			<tr><td>Rouf Mian, USDA-ARS, Ohio State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Mian.pdf">Mapping and Characterization of a New Soybean Aphid Resistant Gene in PI 567301B</a></td></tr>
+			<tr><td>Andy Michel, Ohio State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Michel.pdf">Molecular Interactions Between Soybean Aphid and Resistant Soybean</a></td></tr>
+		</body>
+	</table>
 </div>			
 
 
 <h3>Wednesday, February 29, 2012</h3>
 <div class="uk-overflow-auto">
-<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
-    <thead>
-        <tr>
-            <th class="uk-table-expand">Speaker</th>
-            <th class="uk-table-expand">Topic</th>
-        </tr>
-    </thead>
-<body>
-	<tr><th colspan='4'>Session: Public Breeder Coordination Session</th></tr>
-	<tr><td>Perry Cregan, USDA-ARS, Beltsville</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Cregan.pdf">Update on SNP Genotyping of the USDA Soybean Germplasm Collection</a></td></tr>
-	<tr><td>George Graef, Univ. Nebraska</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Graef.pdf">Soybean Genomics Strategic Plan: Accomplishments and Updates</a></td></tr>
-	<tr><td>Tommy Carter, USDA-ARS, Raleigh</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Carter.pdf">ARS Update (Including Status of Analytical Services)</a></td></tr>
-	<tr><td>Jeff Thompson, Pioneer Hi-Bred</td><td>Soybean Germplasm Committee Report</td></tr>
-	<tr><td>Istvan Rajcan, Univ. Guelph</td><td>Soybean Genetics Committee Report</td></tr>
-	<tr><td>David Grant, USDA-ARS, Ames</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Grant.pdf">SoyBase Update &amp; Tutorials</a></td></tr>
-	<tr><td>Group Discussion from the Floor to David Grant</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Grant2.pdf">Resequencing Data</a><br>
+	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+    	<thead>
+        	<tr>
+            	<th class="uk-table-expand">Speaker</th>
+            	<th class="uk-table-expand">Topic</th>
+        	</tr>
+    	</thead>
+		<body>
+			<tr><th colspan='2'>Session: Public Breeder Coordination Session</th></tr>
+			<tr><td>Perry Cregan, USDA-ARS, Beltsville</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Cregan.pdf">Update on SNP Genotyping of the USDA Soybean Germplasm Collection</a></td></tr>
+			<tr><td>George Graef, Univ. Nebraska</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Graef.pdf">Soybean Genomics Strategic Plan: Accomplishments and Updates</a></td></tr>
+			<tr><td>Tommy Carter, USDA-ARS, Raleigh</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Carter.pdf">ARS Update (Including Status of Analytical Services)</a></td></tr>
+			<tr><td>Jeff Thompson, Pioneer Hi-Bred</td><td>Soybean Germplasm Committee Report</td></tr>
+			<tr><td>Istvan Rajcan, Univ. Guelph</td><td>Soybean Genetics Committee Report</td></tr>
+			<tr><td>David Grant, USDA-ARS, Ames</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Grant.pdf">SoyBase Update &amp; Tutorials</a></td></tr>
+			<tr><td>Group Discussion from the Floor to David Grant</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Grant2.pdf">Resequencing Data</a><br>
 			How will soybean breeders use resequencing data?</br>
-				What tools are needed to enable this?</td></tr>
-</body>
-</table>
+				What tools are needed to enable this?
+			</td></tr>
+		</body>
+	</table>
 </div>	
 
 

--- a/community/sbw/SBW/SBW_2012.html
+++ b/community/sbw/SBW/SBW_2012.html
@@ -1,42 +1,55 @@
 ---
 layout: default
-title: Soybean Breeders Workshop 
+title: 2012 Soybean Breeders Workshop - Presentations and Reports 
 sitemap: community/sbw
 ---
 
-			<div class ="top_bar">
-				<h2>2012 SOYBEAN BREEDERS/ENTOMOLOGISTS WORKSHOP</h2>
-        <hr >
-			</div>
-			<br>
-			<div class="head_link"><h3>Workshop Coordinatiors</h3></div>
-			<div class="setin">
-				Katy Martin Rainey (Public Breeder), Purdue Univ. - Overall planning and coordination<br>
-				Hari Ramasubramaniam (Plant Pathologist), Syngenta Seeds Inc. - Hotel arrangements<br>
-				Jerry Lubich, Pioneer Hi-Bred - website<br>
-				Andrea Cardinal, NC State Univ. - Program Chair, Tuesday General Session
-			</div>
-			<br>
-			<div class="head_link"><h3>Monday, February 27</h3></div>
-			<div class="setin">
-				Henry Nguyen, Univ. Missouri - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Nguyen.pdf">Large-scale Genome Re-sequencing</a><br>
-				Peter Morrell, Univ. Minnesota - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Morrell.pdf">Nextgen Pops, Genetic Load, and Other Advances and Applications in Crop Genomics</a><br>
-				Scott Sebastian, Pioneer Hi-Bred - Context Specific MAS<br>
-				Matt O'Neal, IA State Univ. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/ONeal.pdf">Insect Pollinators in Soybeans</a><br>
-				Maria Ortega &amp; Wayne Parrott, Univ. Georgia - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Ortega.pdf">De-bugging Soybean: A Story of Nano-spears and QTLs</a><br>
-				M.A. Saghai Maroof, Virginia Tech - Overview of $9.2 million AFRI Phytophthora Project<br>
-				Rich Joost, Production Research Pgm. Director, USB/SmithBucklin - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Joost.pdf">Future Directions for United Soybean Board Breeding Funding</a><br>
-			</div>
-      <br>
-			<div class="head_link"><h3>Tuesday, February 28</h3></div>
-<!--			<div class="sub_link">Session I</div><br> -->
-			<div class="setin">
-				<u>Stink Bug</u>, Chair: Ames Herbert, Virginia Tech<br>
-				Galen dively, Univ. Maryland - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Dively.pdf">Mid-Atlantic: Brown Marmorated Stink Bug</a><br>
-				Ames Herbert, Virginia Tech - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Herbert.pdf">Mid-Atlantic: Brown Marmorated Stink Bug</a><br>
-				Jeff Davis, LA State Univ. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Davis.pdf">Deep South: Redshouldered/redbanded Stink Bugs</a><br>
-			<br>
-				<u>Kudzu Bug</u>, Chair: Ames Herbert, Virginia Tech<br>
+<h2>2012 SOYBEAN BREEDERS/ENTOMOLOGISTS WORKSHOP</h2>
+<hr>
+
+<h3>Workshop Coordinatiors:</h3>
+<p><strong>Katy Martin Rainey</strong> (Public Breeder), Purdue Univ. - Overall planning and coordination<br>
+<strong>Hari Ramasubramaniam</strong> (Plant Pathologist), Syngenta Seeds Inc. - Hotel arrangements<br>
+<strong>Jerry Lubich</strong>, Pioneer Hi-Bred - website<br>
+<strong>Andrea Cardinal</strong>, NC State Univ. - Program Chair, Tuesday General Session
+			
+<h3>Monday, February 27</h3>
+	
+<div class="uk-overflow-auto">
+<table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
+    <thead>
+        <tr>
+            <th class="uk-table-expand">Speaker</th>
+            <th class="uk-table-expand">Topic</th>
+        </tr>
+    </thead>
+<body>
+	<tr><td>Henry Nguyen, Univ. Missouri</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Nguyen.pdf">Large-scale Genome Re-sequencing</a></td></tr>
+	<tr><td>Peter Morrell, Univ. Minnesota</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Morrell.pdf">Nextgen Pops, Genetic Load, and Other Advances and Applications in Crop Genomics</a></td></tr>
+	<tr><td>Scott Sebastian, Pioneer Hi-Bred</td><td>Context Specific MAS</td></tr>
+	<tr><td>Matt O'Neal, IA State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/ONeal.pdf">Insect Pollinators in Soybeans</a></td></tr>
+	<tr><td>Maria Ortega &amp; Wayne Parrott, Univ. Georgia</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Ortega.pdf">De-bugging Soybean: A Story of Nano-spears and QTLs</a></td></tr>
+	<tr><td>M.A. Saghai Maroof, Virginia Tech</td><td>Overview of $9.2 million AFRI Phytophthora Project</td></tr>
+	<tr><td>Rich Joost, Production Research Pgm. Director, USB/SmithBucklin</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Joost.pdf">Future Directions for United Soybean Board Breeding Funding</a></td></tr>
+</body>
+</table>
+</div>
+
+<h3>Tuesday, February 28</h3></div>
+<div class="uk-overflow-auto">
+<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+    <thead>
+        <tr>
+            <th class="uk-table-expand">Speaker</th>
+            <th class="uk-table-expand">Topic</th>
+        </tr>
+    </thead>
+<body>
+	<tr><th colspan='4'>Session I: Stick Bug | Chair: Ames Herbert, Virginia Tech </th></tr>
+	<tr><td>Galen dively, Univ. Maryland</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Dively.pdf">Mid-Atlantic: Brown Marmorated Stink Bug</a></td></tr>
+	<tr><td>Ames Herbert, Virginia Tech</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Herbert.pdf">Mid-Atlantic: Brown Marmorated Stink Bug</a></td></tr>
+	<tr><td>Jeff Davis, LA State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Davis.pdf">Deep South: Redshouldered/redbanded Stink Bugs</a></td></tr>
+	<tr><th colspan='4'>Sesion II: Kudzu Bug | Chair: Ames Herbert, Virginia Tech</th></tr>
 				Phillip Roberts, Univ. Georgia - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Roberts.pdf">Southeast: Kudzu Bug</a><br>
 				<ul class="uk-list uk-margin-small-left uk-margin-remove-vertical">
 					<li class="uk-margin-remove"><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/VID_20110930_143901.m4v">Video 1</a></li>

--- a/community/sbw/SBW/SBW_2012.html
+++ b/community/sbw/SBW/SBW_2012.html
@@ -13,7 +13,7 @@ sitemap: community/sbw
 <strong>Jerry Lubich</strong>, Pioneer Hi-Bred - website<br>
 <strong>Andrea Cardinal</strong>, NC State Univ. - Program Chair, Tuesday General Session
 			
-<h3>Monday, February 27</h3>
+<h3>Monday, February 27, 2012</h3>
 	
 <div class="uk-overflow-auto">
 <table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
@@ -35,7 +35,7 @@ sitemap: community/sbw
 </table>
 </div>
 
-<h3>Tuesday, February 28</h3></div>
+<h3>Tuesday, February 28, 2012</h3>
 <div class="uk-overflow-auto">
 <table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
     <thead>
@@ -45,40 +45,48 @@ sitemap: community/sbw
         </tr>
     </thead>
 <body>
-	<tr><th colspan='4'>Session I: Stick Bug | Chair: Ames Herbert, Virginia Tech </th></tr>
+	<tr><th colspan='4'>Session: Stick Bug | Chair: Ames Herbert, Virginia Tech </th></tr>
 	<tr><td>Galen dively, Univ. Maryland</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Dively.pdf">Mid-Atlantic: Brown Marmorated Stink Bug</a></td></tr>
 	<tr><td>Ames Herbert, Virginia Tech</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Herbert.pdf">Mid-Atlantic: Brown Marmorated Stink Bug</a></td></tr>
 	<tr><td>Jeff Davis, LA State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Davis.pdf">Deep South: Redshouldered/redbanded Stink Bugs</a></td></tr>
-	<tr><th colspan='4'>Sesion II: Kudzu Bug | Chair: Ames Herbert, Virginia Tech</th></tr>
-				Phillip Roberts, Univ. Georgia - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Roberts.pdf">Southeast: Kudzu Bug</a><br>
-				<ul class="uk-list uk-margin-small-left uk-margin-remove-vertical">
-					<li class="uk-margin-remove"><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/VID_20110930_143901.m4v">Video 1</a></li>
-					<li class="uk-margin-remove"><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/VID_20110930_143943.m4v">Video 2</a> </li>
-				</ul>
-				Jeremy Greene, Clemson Univ. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Greene.pdf">Southeast: Kudzu Bug</a><br>
-				Andrea Cardinal, North Carolina State Univ. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Cardinal.pdf">Stink Bugs White Paper</a><br>
-				<br>
-				<u>Aphids</u>, Chair: Dechun Wang, Michigan State Univ.<br>
-				Susannah Cooper, Monsanto Co. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Cooper.pdf">Soybean Aphid Biotypes: Understanding Geographic Distribution (2008-2010)</a><br>
-				Matt O'Neal, IA State Univ. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/ONeal2.pdf">Is One Enough?: Combining Rag Genes Improves Aphid Resistance in Soybeans</a><br>
-				Brian Diers, Univ. Illinois at Urbana-Champaign - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Diers.pdf">Fine Mapping Rag1 and Rag2 and the Evaluation of New Aphid Resistance Sources</a><br>
-				Dechun Wang, Michigan State Univ. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Wang.pdf">Fine Mapping Rag3 and Rag4 Aphid Resistance Genes</a><br>
-				Rouf Mian, USDA-ARS, Ohio State Univ. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Mian.pdf">Mapping and Characterization of a New Soybean Aphid Resistant Gene in PI 567301B</a><br>
-				Andy Michel, Ohio State Univ. - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Michel.pdf">Molecular Interactions Between Soybean Aphid and Resistant Soybean</a><br>
-			</div>
-      <br>
-			<div class="head_link"><h3>Wednesday, February 29</h3></div>
-<!--			<div class="sub_link">Public Breeder Coordination Session</div><br> -->
-			<div class="setin">
-				Perry Cregan, USDA-ARS, Beltsville - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Cregan.pdf">Update on SNP Genotyping of the USDA Soybean Germplasm Collection</a><br>
-				George Graef, Univ. Nebraska - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Graef.pdf">Soybean Genomics Strategic Plan: Accomplishments and Updates</a><br>
-				Tommy Carter, USDA-ARS, Raleigh - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Carter.pdf">ARS Update (Including Status of Analytical Services)</a><br>
-				Jeff Thompson, Pioneer Hi-Bred - Soybean Germplasm Committee Report<br>
-				Istvan Rajcan, Univ. Guelph - Soybean Genetics Committee Report<br>
-				David Grant, USDA-ARS, Ames - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Grant.pdf">SoyBase Update &amp; Tutorials</a><br>
-				Group Discussion from the Floor to David Grant - <a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Grant2.pdf">Resequencing Data</a><br>
-				<p class="uk-margin-small-left uk-margin-remove-vertical">How will soybean breeders use resequencing data?</p>
-				<p class="uk-margin-small-left uk-margin-remove-vertical">What tools are needed to enable this?</p>
-			</div>
+	<tr><th colspan='4'>Sesion: Kudzu Bug | Chair: Ames Herbert, Virginia Tech</th></tr>
+	<tr><td>Phillip Roberts, Univ. Georgia</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Roberts.pdf">Southeast: Kudzu Bug</a><br><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/VID_20110930_143901.m4v">Video 1</a><br><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/VID_20110930_143943.m4v">Video 2</a></td></tr>
+	<tr><td>Jeremy Greene, Clemson Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Greene.pdf">Southeast: Kudzu Bug</a></td></tr>
+	<tr><td>Andrea Cardinal, North Carolina State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Cardinal.pdf">Stink Bugs White Paper</a></td></tr>
+	<tr><th colspan='4'>Sesion: Aphids | Chair: Dechun Wang, Michigan State Univ.</th></tr>
+	<tr><td>Susannah Cooper, Monsanto Co.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Cooper.pdf">Soybean Aphid Biotypes: Understanding Geographic Distribution (2008-2010)</a></td></tr>
+	<tr><td>Matt O'Neal, IA State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/ONeal2.pdf">Is One Enough?: Combining Rag Genes Improves Aphid Resistance in Soybeans</a></td></tr>
+	<tr><td>Brian Diers, Univ. Illinois at Urbana-Champaign</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Diers.pdf">Fine Mapping Rag1 and Rag2 and the Evaluation of New Aphid Resistance Sources</a></td></tr>
+	<tr><td>Dechun Wang, Michigan State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Wang.pdf">Fine Mapping Rag3 and Rag4 Aphid Resistance Genes</a></td></tr>
+	<tr><td>Rouf Mian, USDA-ARS, Ohio State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Mian.pdf">Mapping and Characterization of a New Soybean Aphid Resistant Gene in PI 567301B</a></td></tr>
+	<tr><td>Andy Michel, Ohio State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Michel.pdf">Molecular Interactions Between Soybean Aphid and Resistant Soybean</a></td></tr>
+</body>
+</table>
+</div>			
+
+
+<h3>Wednesday, February 29, 2012</h3>
+<div class="uk-overflow-auto">
+<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+    <thead>
+        <tr>
+            <th class="uk-table-expand">Speaker</th>
+            <th class="uk-table-expand">Topic</th>
+        </tr>
+    </thead>
+<body>
+	<tr><th colspan='4'>Session: Public Breeder Coordination Session</th></tr>
+	<tr><td>Perry Cregan, USDA-ARS, Beltsville</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Cregan.pdf">Update on SNP Genotyping of the USDA Soybean Germplasm Collection</a></td></tr>
+	<tr><td>George Graef, Univ. Nebraska</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Graef.pdf">Soybean Genomics Strategic Plan: Accomplishments and Updates</a></td></tr>
+	<tr><td>Tommy Carter, USDA-ARS, Raleigh</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Carter.pdf">ARS Update (Including Status of Analytical Services)</a></td></tr>
+	<tr><td>Jeff Thompson, Pioneer Hi-Bred</td><td>Soybean Germplasm Committee Report</td></tr>
+	<tr><td>Istvan Rajcan, Univ. Guelph</td><td>Soybean Genetics Committee Report</td></tr>
+	<tr><td>David Grant, USDA-ARS, Ames</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Grant.pdf">SoyBase Update &amp; Tutorials</a></td></tr>
+	<tr><td>Group Discussion from the Floor to David Grant</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2012/Grant2.pdf">Resequencing Data</a><br>
+			How will soybean breeders use resequencing data?</br>
+				What tools are needed to enable this?</td></tr>
+</body>
+</table>
+</div>	
 
 

--- a/community/sbw/SBW/SBW_2013.html
+++ b/community/sbw/SBW/SBW_2013.html
@@ -6,115 +6,83 @@ sitemap: community/sbw
 
 <h2>2013 SOYBEAN BREEDERS & PHYSIOLOGISTS WORKSHOP</h2>
 <hr >
-<h3 class="uk-margin-remove-bottom">Monday, February 11</h3>
 
-<table class="uk-table uk-table-small uk-table-hover uk-table-responsive uk-table-divider">
-<thead>
-    <tr>
-        <th class="uk-table-shrink"></th>
-        <th class="uk-table-shrink"></th>
-        <th class="uk-table-expand"></th>
-        <th class="uk-table-expand"></th>
-    </tr>
-</thead>
-<tbody>
-    <tr><td class="uk-padding-small "><span class="uk-margin-right">1:30</span><span>1:40</span></td><td class="uk-width-large uk-padding-small uk-padding-remove-bottom">Katy Martin Rainey, Purdue Univ.</td><td class="uk-width-large uk-padding-small uk-padding-remove-bottom">Welcome and announcements</td></tr>
-    <tr><td class="uk-padding-small "><span class="uk-margin-right">1:40</span><span>2:10</span></td><td class="uk-width-large uk-padding-small ">Rich Joost, United Soybean Board</td><td class="uk-width-large uk-padding-small "><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_mon_Joost.pdf">Update on USB Restructuring</a></td></tr>
-    <tr><td class="uk-padding-small "><span class="uk-margin-right">2:10</span><span>2:50</span></td><td class="uk-width-large uk-padding-small ">Michelle Graham, USDA-ARS, Ames</td><td class="uk-width-large uk-padding-small ">Analysis of Rpp-4-like genes in legumes</td></tr>
-    <tr><td class="uk-padding-small "><span class="uk-margin-right">3:10</span><span>3:25</span></td><td class="uk-width-large uk-padding-small ">Wayne Parrott (Univ. Georgia)</td><td  class="uk-width-large uk-padding-small "><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_mon_Parrot.pdf">Outline for Genetic Stocks Repository</a></td></tr>
-    <tr><td class="uk-padding-small "><span class="uk-margin-right">3:25</span><span>4:05</span></td><td class="uk-width-large uk-padding-small ">Andrew Bent, Univ. Wisconsin</td><td  class="uk-width-large uk-padding-small "><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_mon_Bent.pdf">Copy Number Variation of Multiple Genes at Rhg1 Mediates<br> Nematode Resistance in Soybean</a></td></tr>
-    <tr><td class="uk-padding-small "><span class="uk-margin-right">4:05</span><span>4:45</span></td><td class="uk-width-large uk-padding-small ">Barbara Campbell & James Weatherly<div>Patent Attorneys, Cochran Freund & Young LLC Denver, CO</div></td><td class="uk-width-large uk-padding-small ">Bowman vs. Monsanto and new challenges for plant IP</tr>
-    <tr><td class="uk-padding-small "><span class="uk-margin-right">4:45</span><span>5:15</span></td><td class="uk-width-large uk-padding-small ">Group Discussion from the Floor:</td></td><td class="uk-width-large uk-padding-small ">Expiration of the SCN MAS patents: When and Where? </td></tr>
-</tbody>
-</table> 
+<h3>Monday, February 11, 2013</h3>
+<div class="uk-overflow-auto">
+	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+    	<thead>
+        	<tr>
+            	<th class="uk-table-expand">Speaker</th>
+            	<th class="uk-table-expand">Topic</th>
+        	</tr>
+    	</thead>
+		<body>
+            <tr><td>Katy Martin Rainey, Purdue Univ.</td><td>Welcome and announcements</td></tr>
+            <tr><td>Rich Joost, United Soybean Board</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_mon_Joost.pdf">Update on USB Restructuring</a></td></tr>
+            <tr><td>Michelle Graham, USDA-ARS, Ames</td><td>Analysis of Rpp-4-like genes in legumes</td></tr>
+            <tr><td>Wayne Parrott, Univ. Georgia</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_mon_Parrot.pdf">Outline for Genetic Stocks Repository</a></td></tr>
+            <tr><td>Andrew Bent, Univ. Wisconsin</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_mon_Bent.pdf">Copy Number Variation of Multiple Genes at Rhg1 Mediates<br> Nematode Resistance in Soybean</a></td></tr>
+            <tr><td>Barbara Campbell & James Weatherly, Patent Attorneys, Cochran Freund & Young LLC Denver, CO</td><td>Bowman vs. Monsanto and new challenges for plant IP</td></tr>
+            <tr><td>Group Discussion from the Floor:</td></td><td>Expiration of the SCN MAS patents: When and Where? </td></tr>
+        </body>
+    </table>
+</div>
 
-<h3 >Tuesday, February 12</h3>
-General Session<br>
+
+<h3 >Tuesday, February 12, 2013</h3>
+<!-- General Session<br>
 <p class="uk-margin-left uk-margin-remove-vertical">Chair, Public Breeder: Andrew Scaboo, Univ. Missouri</p>
 <p class="uk-margin-left uk-margin-remove-vertical">Co-Chair, Public Pathologist:  Kiersten Wise, Purdue Univ.</p>
-<br>
-SESSION I: Soybean Viruses (Chair:  Leigh Ann Harrison, Monsanto Co.)
-<table  class="uk-table uk-table-small uk-table-hover uk-table-responsive uk-table-divider">
-    <thead>
-        <tr>
-            <th class="uk-table-shrink"></th>
-            <th class="uk-table-shrink"></th>
-            <th class="uk-table-expand"></th>
-            <th class="uk-table-expand"></th>
-        </tr>
-    </thead>
-<tbody>
-    <tr><td class="uk-padding-small"><span class="uk-margin-right">8:05</span><span>8:30</span></td><td class="uk-width-large uk-padding-small">Pengyin Chen, Univ. Arkansas</td><td class="uk-width-large uk-padding-small"><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_tues_Chen.pdf">Genetics Of SMV Resistance</a></td></tr>
-    <tr><td class="uk-padding-small"><span class="uk-margin-right">8:30</span><span>8:55</span></td><td class="uk-width-large uk-padding-small">Ioaniss Tzanetakis, Univ Arkansas</td><td class="uk-width-large uk-padding-small">SVNV</td></tr>
-    <tr><td class="uk-padding-small"><span class="uk-margin-right">8:55</span><span>9:20</span></td><td class="uk-width-large uk-padding-small">Said Ghabrial, Univ. Kentucky</td><td class="uk-width-large uk-padding-small">TSV and BPMV-based VIGS</td></tr>
-    <tr><td class="uk-padding-small"><span class="uk-margin-right">9:20</span><span>9:45</span></td><td class="uk-width-large uk-padding-small">John Hill, Univ. Iowa</td><td class="uk-width-large uk-padding-small"><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_tues_Hill.pdf">BPMV</a></td></tr>
-</tbody>
-</table>
-<br>
-SESSION II: Charcoal Rot (Chair:  Terri Hughes, USDA-ARS, West Lafayette)
-<table class="uk-table uk-table-small uk-table-hover uk-table-responsive uk-table-divider">
-    <thead>
-        <tr>
-            <th class="uk-table-shrink"></th>
-            <th class="uk-table-shrink"></th>
-        </tr>
-    </thead>
-<tbody>
-<tr><td class="uk-padding-small">Terri Hughes</td><td class="uk-width-large uk-padding-small"><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_tues_Hughes.pdf">Pathogen Diversity In Northern States</a></td></tr>
-<tr><td class="uk-padding-small">Chris Little, Kansas State University</td><td class="uk-width-large uk-padding-small"><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_Tues_Little.pdf">Evaluating Cultivar Resistance To Charcoal Rot</a></td></tr>
-<tr><td class="uk-padding-small">John Rupe, Univ. Arkansas</td><td class="uk-width-large uk-padding-small"><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_tues_Rupe.pdf">Charcoal Rot</a></td></tr>
-</tbody>
-</table>
-<table>
-<br>
-SESSION III: Sudden Death Syndrome (Chair:  Leonor Leandro, Iowa State Univ.)
-<table class="uk-table uk-table-small uk-table-hover uk-table-responsive uk-table-divider">
-    <thead>
-        <tr>
-            <th class="uk-table-shrink"></th>
-            <th class="uk-table-shrink"></th>
-        </tr>
-    </thead>
-<tbody>
-    <tr><td class="uk-padding-small">Ahmad Fakhoury, So. Illinois Univ.</td><td class="uk-width-large uk-padding-small">Genetics Of F. virguliforme</td></tr>
-    <tr><td class="uk-padding-small">Glen Hartman, USDA-ARS, Urbana</td><td class="uk-width-large uk-padding-small">Improved Culture Filtrate Assay Screening</td></tr>
-    <tr><td class="uk-padding-small">Marty Chilvers, Mi State Univ.</td><td class="uk-width-large uk-padding-small"><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_tues_Chilvers.pdf">Improved Diagnostic Assays For SDS</a></td></tr>
-    <tr><td class="uk-padding-small">Silvia Cianzio, Iowa State Univ.</td><td class="uk-width-large uk-padding-small">Update On SDS Resistance</td></tr>
-</tbody>
-</table><br>
-SESSION IV: Soybean Nematodes (Chair:  Prakash Arelli, USDA-ARS, Jackson)
-<table class="uk-table uk-table-small uk-table-hover uk-table-responsive uk-table-divider">
-    <thead>
-        <tr>
-            <th class="uk-table-shrink"></th>
-            <th class="uk-table-shrink"></th> 
-        </tr>
-    </thead>
-<tbody>
-    <tr><td class="uk-padding-small">Brian Diers, Univ. Illinois</td><td class="uk-width-large uk-padding-small"><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_tues_Diers.pdf">Breeding For SCN Resistance In The Midwest</a></td></tr>
-    <tr><td class="uk-padding-small">Grover Shannon, Univ. Missouri</td><td class="uk-width-large uk-padding-small"><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_tues_Shannon.pdf">Breeding For SCN Resistance In The South</a></td></tr>
-    <tr><td class="uk-padding-small">Floyd Hancock, Monsanto Co.</td><td class="uk-width-large uk-padding-small">Breeding For SCN Resistance: Private Sector</td></tr>
-    <tr><td class="uk-padding-small">Zenglu Li, Univ. Of Georgia</td><td class="uk-width-large uk-padding-small">Root Knot Nematodes</td></tr>
-    <tr><td class="uk-padding-small">Bob Robbins, Univ. Of Arkansas</td><td class="uk-width-large uk-padding-small"><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_tues_Robbins.pdf">Reniform Nematode, A Southern Problem</a></td></tr>
-</tbody>
-</table>
+-->
+<div class="uk-overflow-auto">
+	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+    	<thead>
+        	<tr>
+            	<th class="uk-table-expand">Speaker</th>
+            	<th class="uk-table-expand">Topic</th>
+        	</tr>
+    	</thead>
+		<body>
+            <tr><th colspan='2'>SESSION I: Soybean Viruses | Chair:  Leigh Ann Harrison, Monsanto Co.</th></tr>
+            <tr><td>Pengyin Chen, Univ. Arkansas</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_tues_Chen.pdf">Genetics Of SMV Resistance</a></td></tr>
+            <tr><td>Ioaniss Tzanetakis, Univ Arkansas</td><td>SVNV</td></tr>
+            <tr><td>Said Ghabrial, Univ. Kentucky</td><td>TSV and BPMV-based VIGS</td></tr>
+            <tr><td>John Hill, Univ. Iowa</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_tues_Hill.pdf">BPMV</a></td></tr>
+            <tr><th colspan='2'>SESSION II: Charcoal Rot | Chair:  Terri Hughes, USDA-ARS, West Lafayette</th></tr>
+            <tr><td>Terri Hughes</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_tues_Hughes.pdf">Pathogen Diversity In Northern States</a></td></tr>
+            <tr><td>Chris Little, Kansas State Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_Tues_Little.pdf">Evaluating Cultivar Resistance To Charcoal Rot</a></td></tr>
+            <tr><td>John Rupe, Univ. Arkansas</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_tues_Rupe.pdf">Charcoal Rot</a></td></tr>
+            <tr><th colspan='2'>SESSION III: Sudden Death Syndrome | Chair:  Leonor Leandro, Iowa State Univ.</th></tr>
+            <tr><td>Ahmad Fakhoury, So. Illinois Univ.</td><td>Genetics Of F. virguliforme</td></tr>
+            <tr><td>Glen Hartman, USDA-ARS, Urbana</td><td>Improved Culture Filtrate Assay Screening</td></tr>
+            <tr><td>Marty Chilvers, Mi State Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_tues_Chilvers.pdf">Improved Diagnostic Assays For SDS</a></td></tr>
+            <tr><td>Silvia Cianzio, Iowa State Univ.</td><td>Update On SDS Resistance</td></tr>
+            <tr><th colspan='2'>SESSION IV: Soybean Nematodes | Chair:  Prakash Arelli, USDA-ARS, Jackson</th></tr>
+            <tr><td>Brian Diers, Univ. Illinois</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_tues_Diers.pdf">Breeding For SCN Resistance In The Midwest</a></td></tr>
+            <tr><td>Grover Shannon, Univ. Missouri</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_tues_Shannon.pdf">Breeding For SCN Resistance In The South</a></td></tr>
+            <tr><td>Floyd Hancock, Monsanto Co.</td><td>Breeding For SCN Resistance: Private Sector</td></tr>
+            <tr><td>Zenglu Li, Univ. Of Georgia</td><td>Root Knot Nematodes</td></tr>
+            <tr><td>Bob Robbins, Univ. Of Arkansas</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_tues_Robbins.pdf">Reniform Nematode, A Southern Problem</a></td></tr>
+        </body>
+    </table>
+</div>
 
-<h3>Wednesday, February 13</h3>
-<table class="uk-table uk-table-small uk-table-hover uk-table-responsive uk-table-divider">
-    <thead>
-        <tr>
-            <th class="uk-table-shrink"></th>
-            <th class="uk-table-shrink"></th>
-            <th class="uk-table-expand"></th>
-            <th class="uk-table-expand"></th>
-        </tr>
-    </thead>
-<tbody>
-    <tr><td class="uk-padding-small"><span class="uk-margin-right">8:05</span><span>8:35</span></td><td class="uk-width-large uk-padding-small">Ben Fallen, Univ. Tennessee</td><td class="uk-width-large uk-padding-small"><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_Wed_Fallen.pdf">Selective Genotyping For MAS Strategies For Soybean Yield Improvement</a></td></tr>
-    <tr><td class="uk-padding-small"><span class="uk-margin-right">8:50</span><span>9:10</span></td><td class="uk-width-large uk-padding-small">From The Floor</td><td class="uk-width-large uk-padding-small">Retirements & Announcements</td></tr>
-    <tr><td class="uk-padding-small"><span class="uk-margin-right">9:10</span><span>9:20</span></td><td class="uk-width-large uk-padding-small">Committee Member</td><td class="uk-width-large uk-padding-small">Soybean Germplasm Committee Report</td></tr>
-    <tr><td class="uk-padding-small"><span class="uk-margin-right">9:20</span><span>9:30</span></td><td class="uk-width-large uk-padding-small">Committee Member</td><td class="uk-width-large uk-padding-small">Soybean Genetics Committee Report</td></tr>
-    <tr><td class="uk-padding-small"><span class="uk-margin-right">9:30</span><span>9:45</span></td><td class="uk-width-large uk-padding-small">David Grant, USDA-ARS, Ames</td><td class="uk-width-large uk-padding-small">SoyBase Update</td></tr>
-</tbody>
-</table>
 
+<h3>Wednesday, February 13, 2013</h3>
+<div class="uk-overflow-auto">
+	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+    	<thead>
+        	<tr>
+            	<th class="uk-table-expand">Speaker</th>
+            	<th class="uk-table-expand">Topic</th>
+        	</tr>
+    	</thead>
+		<body>
+            <tr><td>Ben Fallen, Univ. Tennessee</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_Wed_Fallen.pdf">Selective Genotyping For MAS Strategies For Soybean Yield Improvement</a></td></tr>
+            <tr><td colspan='2'>From The Floor: Retirements & Announcements</td></tr>
+            <tr><td>Committee Member</td><td>Soybean Germplasm Committee Report</td></tr>
+            <tr><td>Committee Member</td><td>Soybean Genetics Committee Report</td></tr>
+            <tr><td>David Grant, USDA-ARS, Ames</td><td>SoyBase Update</td></tr>
+        </body>
+    </table>
+</div>

--- a/community/sbw/SBW/SBW_2013.html
+++ b/community/sbw/SBW/SBW_2013.html
@@ -30,10 +30,6 @@ sitemap: community/sbw
 
 
 <h3 >Tuesday, February 12, 2013</h3>
-<!-- General Session<br>
-<p class="uk-margin-left uk-margin-remove-vertical">Chair, Public Breeder: Andrew Scaboo, Univ. Missouri</p>
-<p class="uk-margin-left uk-margin-remove-vertical">Co-Chair, Public Pathologist:  Kiersten Wise, Purdue Univ.</p>
--->
 <div class="uk-overflow-auto">
 	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
     	<thead>
@@ -78,7 +74,7 @@ sitemap: community/sbw
         	</tr>
     	</thead>
 		<body>
-            <tr><td>Ben Fallen, Univ. Tennessee</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_Wed_Fallen.pdf">Selective Genotyping For MAS Strategies For Soybean Yield Improvement</a></td></tr>
+            <tr><td>Ben Fallen, Univ. Tennessee</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2013/presentations/13SBW_Wed_Fallen.pdf">Selective Genotyping For MAS Strategies For Soybean Yield Improvement</a></td></tr>
             <tr><td colspan='2'>From The Floor: Retirements & Announcements</td></tr>
             <tr><td>Committee Member</td><td>Soybean Germplasm Committee Report</td></tr>
             <tr><td>Committee Member</td><td>Soybean Genetics Committee Report</td></tr>

--- a/community/sbw/SBW/SBW_2014.html
+++ b/community/sbw/SBW/SBW_2014.html
@@ -27,13 +27,13 @@ Seth Naeve (Public Agronomist/Physiologist), Univ. Minnesota, Co-Chair, Tuesday 
 <tbody>
     <tr><td class="uk-padding-small">1:30</td><td class="uk-padding-small">1:40</td><td>Katy Martin Rainey</td><td>Welcome and announcements</td></tr>
     <tr><td class="uk-padding-small">1:40</td><td class="uk-padding-small">2:10</td><td>Kristin Bilyeu &amp; Tiffany Langewisch, USDA-ARS, Columbia, MO</td><td>Developing an E Gene Molecular Model for Soybean Maturity Groups</td></tr>
-    <tr><td class="uk-padding-small">2:10</td><td class="uk-padding-small">2:40</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Diers_SBW2014.pdf'>Brian Diers, Univ. Illinois</a></td><td>SoyNAM Project Update</td></tr>
-    <tr><td class="uk-padding-small">2:40</td><td class="uk-padding-small">2:50</td><td colspan='2' style='font-weight:bold;'>Coffee Break</td></tr>
-    <tr><td class="uk-padding-small">2:50</td><td class="uk-padding-small">3:20</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Yong-qiang_SBW2014.pdf'>Yong-qiang Charles An</a>,<br />USDA-ARS, St. Louis, MO</td><td>Exploring Soybean Transcript Polymorphisms to Identify Gene Variants and Functional Markers for Seed Quality Improvement</td></tr>
+    <tr><td class="uk-padding-small">2:10</td><td class="uk-padding-small">2:40</td><td>Brian Diers, Univ. Illinois</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Diers_SBW2014.pdf'>SoyNAM Project Update</a></td></tr>
+    <tr><td class="uk-padding-small">2:40</td><td class="uk-padding-small">2:50</td><td colspan='2'> Coffee Break</td></tr>
+    <tr><td class="uk-padding-small">2:50</td><td class="uk-padding-small">3:20</td><td>Yong-qiang Charles An,<br />USDA-ARS, St. Louis, MO</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Yong-qiang_SBW2014.pdf'>Exploring Soybean Transcript Polymorphisms to Identify Gene Variants and Functional Markers for Seed Quality Improvement</a></td></tr>
     <tr><td class="uk-padding-small">3:20</td><td class="uk-padding-small">3:50</td><td>Jianxin Ma, Purdue Univ.</td><td>Genetic Basis of Soybean Stem Growth Habit and its Potential Application for Development of High-yielding, Climate-resilient Soybean</td></tr>
     <tr><td class="uk-padding-small">3:50</td><td class="uk-padding-small">4:20</td><td>Mike Gore, Cornell Univ.</td><td>Genome-Wide Analysis of Metabolic Traits in Maize</td></tr>
-    <tr><td class="uk-padding-small">4:20</td><td class="uk-padding-small">4:50</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Goldsmith_SBW2014.pdf'>Peter Goldsmith, Univ. Illinois</a></td><td>Tropical Soybean Research: USAID's New Soybean Innovation Lab</td></tr>
-    <tr><td class="uk-padding-small">4:50</td><td class="uk-padding-small">5:20</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Becherer_SBW2014.pdf'>John Becherer, CEO,</a><br />United Soybean Board</td><td>Considerations in Capturing Soybean Component Value from the Soybean Value Chain</td></tr>
+    <tr><td class="uk-padding-small">4:20</td><td class="uk-padding-small">4:50</td><td>Peter Goldsmith, Univ. Illinois</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Goldsmith_SBW2014.pdf'>Tropical Soybean Research: USAID's New Soybean Innovation Lab</a></td></tr>
+    <tr><td class="uk-padding-small">4:50</td><td class="uk-padding-small">5:20</td><td>John Becherer, CEO,<br />United Soybean Board</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Becherer_SBW2014.pdf'>Considerations in Capturing Soybean Component Value from the Soybean Value Chain</a></td></tr>
     <tr><td class="uk-padding-small">5:20</td><td class="uk-padding-small">&nbsp;</td><td>Katy Martin Rainey</td><td>Announcements and Adjourn</td></tr>
 </tbody>
 </table>
@@ -55,31 +55,31 @@ Co-Chair, Public Agronomist/Physiologist: Seth Naeve, Univ. Minnesota<br />
     </thead>
     <tr><td class="uk-padding-small">7:00</td><td>8:00</td><td colspan='2'>Continental Breakfast, Versailles Foyer</td></tr>
     <tr><td class="uk-padding-small">8:00</td><td>8:05</td><td>Danny Singh</td><td>General Introduction</td></tr>
-    <tr><th colspan='4'>SESSION I: Soybean Drought Stress  (Chairs: Tommy Carter, USDA-ARS, Raleigh  &amp; George Graef, Univ. Nebraska)</th></tr>
+    <tr><th colspan='4'>SESSION I: Soybean Drought Stress | Chairs: Tommy Carter, USDA-ARS, Raleigh  &amp; George Graef, Univ. Nebraska</th></tr>
     <tr><td class="uk-padding-small">8:05</td><td>8:35</td><td>Tom Sinclair, NC State</td><td>Physiological Input for Improved Soybean Drought Tolerance</td></tr>
-    <tr><td class="uk-padding-small">8:35</td><td>9:05</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Specht_SBW2014.pdf'>Jim Specht, Univ. Nebraska</a></td><td>Soybean Yield Response to Scarce or Abundant Water- Retrospect and Prospect</td></tr>
-    <tr><td class="uk-padding-small">9:05</td><td>9:30</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Chen_SBW2014.pdf'>Pengyin Chen, Univ. Arkansas</a></td><td>Drought Tolerance Traits for Improving Soybean Yield Under Stress</td></tr>
+    <tr><td class="uk-padding-small">8:35</td><td>9:05</td><td>Jim Specht, Univ. Nebraska</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Specht_SBW2014.pdf'>Soybean Yield Response to Scarce or Abundant Water- Retrospect and Prospect</a></td></tr>
+    <tr><td class="uk-padding-small">9:05</td><td>9:30</td><td>Pengyin Chen, Univ. Arkansas</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Chen_SBW2014.pdf'>Drought Tolerance Traits for Improving Soybean Yield Under Stress</a></td></tr>
     <tr><td class="uk-padding-small">9:30</td><td>9:55</td><td>Charlie Messina, Pioneer</td><td>Developing Drought Tolerant Maize Hybrids for the US Corn-belt: Discovery to Product</td></tr>
-    <tr><td class="uk-padding-small">9:55</td><td>10:10</td><td colspan=2' style='font-weight:bold;'>Coffee Break</td></tr>
-    <tr><th colspan='4'>SESSION II: Phenotyping and Physiology of Soybean Traits  (Chairs: Brian Diers, Univ. Illinois &amp; Jim Specht, Univ. Nebraska)</th></tr>
+    <tr><td class="uk-padding-small">9:55</td><td>10:10</td><td colspan='2'>Coffee Break</td></tr>
+    <tr><th colspan='4'>SESSION II: Phenotyping and Physiology of Soybean Traits | Chairs: Brian Diers, Univ. Illinois &amp; Jim Specht, Univ. Nebraska</th></tr>
     <tr><td class="uk-padding-small">10:10</td><td>10:35</td><td>Mike Gore, Cornell Univ.</td><td>High Throughput Phenotyping: Research and Potential Applications in Crops</td></tr>
     <tr><td class="uk-padding-small">10:35</td><td>11:00</td><td>Felix Fritschi, Univ. Missouri</td><td>Mapping Physiological Traits</td></tr>
-    <tr><td class="uk-padding-small">11:00</td><td>11:25</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Schapaugh_SBW2014.pdf'>Bill Schapaugh, Kansas State Univ.</a></td><td>Physiological and Spectral Parameters in Soybean Associated with Seed Yield</td></tr>
+    <tr><td class="uk-padding-small">11:00</td><td>11:25</td><td>Bill Schapaugh, Kansas State Univ.</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Schapaugh_SBW2014.pdf'>Physiological and Spectral Parameters in Soybean Associated with Seed Yield</a></td></tr>
     <tr><td class="uk-padding-small">11:25</td><td>11:50</td><td>Spyridon Mourtizinis, Univ. Wisconsin</td><td>The Use of Reflectance and Weather Data for in Season Soybean Yield Prediction</td></tr>
     <tr><td class="uk-padding-small">11:50</td><td>12:05</td><td>Carol Fox, Univ. Illinois</td><td>High-throughput Photosynthesis Analysis in SoyNAM</td></tr>
-    <tr><td class="uk-padding-small">12:05</td><td>12:20</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Rainey_SBW2014.pdf'>Katy Martin Rainey, Purdue Univ.</a></td><td>Phenotyping Canopy Closure in SoyNAM Using Digital Imagery</td></tr> 
-    <tr><td class="uk-padding-small">12:20</td><td>1:50</td><td colspan='2' style='font-weight:bold;'>Lunch</td></tr>
+    <tr><td class="uk-padding-small">12:05</td><td>12:20</td><td>Katy Martin Rainey, Purdue Univ.</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Rainey_SBW2014.pdf'>Phenotyping Canopy Closure in SoyNAM Using Digital Imagery</a></td></tr> 
+    <tr><td class="uk-padding-small">12:20</td><td>1:50</td><td colspan='2'>Lunch</td></tr>
     <tr><td class="uk-padding-small">1:50</td><td>1:55</td><td>Seth Naeve</td><td>Introduction and Announcements</td></tr>
-    <tr><th colspan='4'>SESSION III:  Soybean Production Management (Chair: Seth Naeve, Univ. Minnesota)</th></tr>
-    <tr><td class="uk-padding-small">1:55</td><td>2:20</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Conley_SBW2014.pdf'>Shawn Conley, Univ. Wisconsin</a></td><td>Genetic Gain X Management Interactions</td></tr>
+    <tr><th colspan='4'>SESSION III:  Soybean Production Management | Chair: Seth Naeve, Univ. Minnesota</th></tr>
+    <tr><td class="uk-padding-small">1:55</td><td>2:20</td><td>Shawn Conley, Univ. Wisconsin</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Conley_SBW2014.pdf'>Genetic Gain X Management Interactions</a></td></tr>
     <tr><td class="uk-padding-small">2:20</td><td>2:45</td><td>Seth Naeve</td><td>Max Yields Through Crop Inputs: A National Project</td></tr>
-    <tr><td class="uk-padding-small">2:45</td><td>3:10</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Purcell_SBW2014.pdf'>Larry Purcell, Univ. Arkansas</a></td><td>The Physiology Behind 100+ Bushel Yields in Arkansas</td></tr>
+    <tr><td class="uk-padding-small">2:45</td><td>3:10</td><td>Larry Purcell, Univ. Arkansas</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Purcell_SBW2014.pdf'>The Physiology Behind 100+ Bushel Yields in Arkansas</a></td></tr>
     <tr><td class="uk-padding-small">3:10</td><td>3:35</td><td>TBD-Pioneer</td><td>Prescriptions for Farmers: Field 360</td></tr>
-    <tr><td class="uk-padding-small">3:35</td><td>3:50</td><td colspan='2' style='font-weight:bold;'>Break</td></tr>
-    <tr><th colspan='4'>SESSION IV:  Soybean Seed Composition (Chair: Clem Weidbrenner, HAPI-Ohio)</th></tr>
+    <tr><td class="uk-padding-small">3:35</td><td>3:50</td><td colspan='2'>Break</td></tr>
+    <tr><th colspan='4'>SESSION IV:  Soybean Seed Composition | Chair: Clem Weidbrenner, HAPI-Ohio</th></tr>
     <tr><td class="uk-padding-small">3:50</td><td>4:15</td><td>Rouf Mian, Ohio State Univ.</td><td>Increasing soybean seed protein without negative effect on yield</td></tr>
     <tr><td class="uk-padding-small">4:15</td><td>4:35</td><td>Jim Sutter, CEO,<br />US Soybean Export Council</td><td>What our international purchasers are requesting</td></tr>
-    <tr><td class="uk-padding-small">4:35</td><td>&nbsp;</td><td colspan='2' style='font-weight:bold;'>Announcements &amp; Adjourn</td></tr>
+    <tr><td class="uk-padding-small">4:35</td><td>&nbsp;</td><td colspan='2'>Announcements &amp; Adjourn</td></tr>
 </table>
 
 <h3>Wednesday, February 19</h3>
@@ -96,10 +96,10 @@ Co-Chair, Public Agronomist/Physiologist: Seth Naeve, Univ. Minnesota<br />
 <tr><td class="uk-padding-small">8:10</td><td>8:25</td><td>Rich Joost,<br />SmithBucklin/United Soybean Board</td><td>The USB/Monsanto/Pioneer International High-Oleic Soy Collaboration</td></tr>
 <tr><td class="uk-padding-small">8:25</td><td>8:35</td><td></td><td>The cross commodity ASTA protocol for establishing and maintaining genetic integrity in breeding materials</td></tr>
 <tr><td class="uk-padding-small">8:35</td><td>9:00</td><td>Jiaoping Zhang, South Dakota State Univ.</td><td>Genome-wide Association Study of Agronomic and Seed Quality Traits for Early Mature Soybean Germplasm</td></tr>
-<tr><td class="uk-padding-small">9:00</td><td>9:20</td><td style='font-style:italic;'>From the Floor</td><td style='font-style:italic;'>Retirements &amp; Announcements</td></tr>
+<tr><td class="uk-padding-small">9:00</td><td>9:20</td><td>From the Floor</td><td>Retirements &amp; Announcements</td></tr>
 <tr><td class="uk-padding-small">9:20</td><td>9:35</td><td>Gary Stacey, Univ. Missouri</td><td>Novel germplasm resources for soybean breeding and genetics</td></tr>
 <tr><td class="uk-padding-small">9:35</td><td>9:50</td><td>Perry Cregan, USDA-ARS, Beltsville</td><td>Status of the 50K SNP genotyping of germplasm collection</td></tr>
-<tr><td class="uk-padding-small">9:50</td><td>10:05</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Grant_SBW2014.pdf'>David Grant, USDA-ARS, Ames</a></td><td>SoyBase Update</td></tr>
+<tr><td class="uk-padding-small">9:50</td><td>10:05</td><td>David Grant, USDA-ARS, Ames, IA</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Grant_SBW2014.pdf'>SoyBase Update</a></td></tr>
 <tr><td class="uk-padding-small">10:05</td><td>10:20</td><td>Committee Member</td><td>Soybean Germplasm Committee Report</td></tr>
 <tr><td class="uk-padding-small">10:20</td><td>10:35</td><td>David Wooten</td><td>Soybean Genetics Committee Report</td></tr>
 <tr><td class="uk-padding-small">10:35</td><td>10:50</td><td>Kristin Bilyeu, USDA-ARS, Columbia</td><td>SoyGEC report</td></tr>

--- a/community/sbw/SBW/SBW_2014.html
+++ b/community/sbw/SBW/SBW_2014.html
@@ -51,58 +51,59 @@ sitemap: community/sbw
             </tr>
          </thead>
          <body>
-
-    <tr><td>Danny Singh</td><td>General Introduction</td></tr>
-    <tr><th colspan='2'>SESSION I: Soybean Drought Stress | Chairs: Tommy Carter, USDA-ARS  &amp; George Graef, Univ. Nebraska</th></tr>
-    <tr><td>Tom Sinclair, NC State</td><td>Physiological Input for Improved Soybean Drought Tolerance</td></tr>
-    <tr><td>Jim Specht, Univ. Nebraska</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Specht_SBW2014.pdf'>Soybean Yield Response to Scarce or Abundant Water- Retrospect and Prospect</a></td></tr>
-    <tr><td>Pengyin Chen, Univ. Arkansas</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Chen_SBW2014.pdf'>Drought Tolerance Traits for Improving Soybean Yield Under Stress</a></td></tr>
-    <tr><td>Charlie Messina, Pioneer</td><td>Developing Drought Tolerant Maize Hybrids for the US Corn-belt: Discovery to Product</td></tr>
-    <tr><td class="uk-padding-small">9:55</td><td>10:10</td><td colspan='2'>Coffee Break</td></tr>
-    <tr><th colspan='4'>SESSION II: Phenotyping and Physiology of Soybean Traits | Chairs: Brian Diers, Univ. Illinois &amp; Jim Specht, Univ. Nebraska</th></tr>
-    <tr><td class="uk-padding-small">10:10</td><td>10:35</td><td>Mike Gore, Cornell Univ.</td><td>High Throughput Phenotyping: Research and Potential Applications in Crops</td></tr>
-    <tr><td class="uk-padding-small">10:35</td><td>11:00</td><td>Felix Fritschi, Univ. Missouri</td><td>Mapping Physiological Traits</td></tr>
-    <tr><td class="uk-padding-small">11:00</td><td>11:25</td><td>Bill Schapaugh, Kansas State Univ.</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Schapaugh_SBW2014.pdf'>Physiological and Spectral Parameters in Soybean Associated with Seed Yield</a></td></tr>
-    <tr><td class="uk-padding-small">11:25</td><td>11:50</td><td>Spyridon Mourtizinis, Univ. Wisconsin</td><td>The Use of Reflectance and Weather Data for in Season Soybean Yield Prediction</td></tr>
-    <tr><td class="uk-padding-small">11:50</td><td>12:05</td><td>Carol Fox, Univ. Illinois</td><td>High-throughput Photosynthesis Analysis in SoyNAM</td></tr>
-    <tr><td class="uk-padding-small">12:05</td><td>12:20</td><td>Katy Martin Rainey, Purdue Univ.</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Rainey_SBW2014.pdf'>Phenotyping Canopy Closure in SoyNAM Using Digital Imagery</a></td></tr> 
-    <tr><td class="uk-padding-small">12:20</td><td>1:50</td><td colspan='2'>Lunch</td></tr>
-    <tr><td class="uk-padding-small">1:50</td><td>1:55</td><td>Seth Naeve</td><td>Introduction and Announcements</td></tr>
-    <tr><th colspan='4'>SESSION III:  Soybean Production Management | Chair: Seth Naeve, Univ. Minnesota</th></tr>
-    <tr><td class="uk-padding-small">1:55</td><td>2:20</td><td>Shawn Conley, Univ. Wisconsin</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Conley_SBW2014.pdf'>Genetic Gain X Management Interactions</a></td></tr>
-    <tr><td class="uk-padding-small">2:20</td><td>2:45</td><td>Seth Naeve</td><td>Max Yields Through Crop Inputs: A National Project</td></tr>
-    <tr><td class="uk-padding-small">2:45</td><td>3:10</td><td>Larry Purcell, Univ. Arkansas</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Purcell_SBW2014.pdf'>The Physiology Behind 100+ Bushel Yields in Arkansas</a></td></tr>
-    <tr><td class="uk-padding-small">3:10</td><td>3:35</td><td>TBD-Pioneer</td><td>Prescriptions for Farmers: Field 360</td></tr>
-    <tr><td class="uk-padding-small">3:35</td><td>3:50</td><td colspan='2'>Break</td></tr>
-    <tr><th colspan='4'>SESSION IV:  Soybean Seed Composition | Chair: Clem Weidbrenner, HAPI-Ohio</th></tr>
-    <tr><td class="uk-padding-small">3:50</td><td>4:15</td><td>Rouf Mian, Ohio State Univ.</td><td>Increasing soybean seed protein without negative effect on yield</td></tr>
-    <tr><td class="uk-padding-small">4:15</td><td>4:35</td><td>Jim Sutter, CEO,<br />US Soybean Export Council</td><td>What our international purchasers are requesting</td></tr>
-    <tr><td class="uk-padding-small">4:35</td><td>&nbsp;</td><td colspan='2'>Announcements &amp; Adjourn</td></tr>
-</table>
-</body>
+            <tr><td>Danny Singh</td><td>General Introduction</td></tr>
+            <tr><th colspan='2'>SESSION I: Soybean Drought Stress | Chairs: Tommy Carter, USDA-ARS  &amp; George Graef, Univ. Nebraska</th></tr>
+            <tr><td>Tom Sinclair, NC State</td><td>Physiological Input for Improved Soybean Drought Tolerance</td></tr>
+            <tr><td>Jim Specht, Univ. Nebraska</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Specht_SBW2014.pdf'>Soybean Yield Response to Scarce or Abundant Water- Retrospect and Prospect</a></td></tr>
+            <tr><td>Pengyin Chen, Univ. Arkansas</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Chen_SBW2014.pdf'>Drought Tolerance Traits for Improving Soybean Yield Under Stress</a></td></tr>
+            <tr><td>Charlie Messina, Pioneer</td><td>Developing Drought Tolerant Maize Hybrids for the US Corn-belt: Discovery to Product</td></tr>
+            <tr><td colspan='2'>Coffee Break</td></tr>
+            <tr><th colspan='2'>SESSION II: Phenotyping and Physiology of Soybean Traits | Chairs: Brian Diers, Univ. Illinois &amp; Jim Specht, Univ. Nebraska</th></tr>
+            <tr><td>Mike Gore, Cornell Univ.</td><td>High Throughput Phenotyping: Research and Potential Applications in Crops</td></tr>
+            <tr><td>Felix Fritschi, Univ. Missouri</td><td>Mapping Physiological Traits</td></tr>
+            <tr><td>Bill Schapaugh, Kansas State Univ.</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Schapaugh_SBW2014.pdf'>Physiological and Spectral Parameters in Soybean Associated with Seed Yield</a></td></tr>
+            <tr><td>Spyridon Mourtizinis, Univ. Wisconsin</td><td>The Use of Reflectance and Weather Data for in Season Soybean Yield Prediction</td></tr>
+            <tr><td>Carol Fox, Univ. Illinois</td><td>High-throughput Photosynthesis Analysis in SoyNAM</td></tr>
+            <tr><td>Katy Martin Rainey, Purdue Univ.</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Rainey_SBW2014.pdf'>Phenotyping Canopy Closure in SoyNAM Using Digital Imagery</a></td></tr> 
+            <tr><td colspan='2'>Lunch</td></tr>
+            <tr><td>Seth Naeve</td><td>Introduction and Announcements</td></tr>
+            <tr><th colspan='2'>SESSION III:  Soybean Production Management | Chair: Seth Naeve, Univ. Minnesota</th></tr>
+            <tr><td>Shawn Conley, Univ. Wisconsin</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Conley_SBW2014.pdf'>Genetic Gain X Management Interactions</a></td></tr>
+            <tr><td>Seth Naeve</td><td>Max Yields Through Crop Inputs: A National Project</td></tr>
+            <tr><td>Larry Purcell, Univ. Arkansas</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Purcell_SBW2014.pdf'>The Physiology Behind 100+ Bushel Yields in Arkansas</a></td></tr>
+            <tr><td>TBD-Pioneer</td><td>Prescriptions for Farmers: Field 360</td></tr>
+            <tr><td colspan='2'>Break</td></tr>
+            <tr><th colspan='2'>SESSION IV:  Soybean Seed Composition | Chair: Clem Weidbrenner, HAPI-Ohio</th></tr>
+            <tr><td>Rouf Mian, Ohio State Univ.</td><td>Increasing soybean seed protein without negative effect on yield</td></tr>
+            <tr><td>Jim Sutter, US Soybean Export Council</td><td>What our international purchasers are requesting</td></tr>
+            <tr><td colspan='2'>Announcements &amp; Adjourn</td></tr>
+        </body>
+    </table>
 </div>
 
 <h3>Wednesday, February 19</h3>
-<table class="uk-table uk-table-small uk-table-hover uk-table-responsive uk-table-divider">
-    <thead>
-        <tr>
-            <th class="uk-table-shrink">Start</th>
-            <th class="uk-table-shrink">End</th>
-            <th class="uk-table-expand">Speaker</th>
-            <th class="uk-table-expand">Topic</th>
-        </tr>
-    </thead>
-<tr><td class="uk-padding-small">8:00</td><td>8:10</td><td>Katy M. Rainey, Purdue Univ.<br />Poster Committee</td><td>Welcome and Announcements<br />A brief explanation of how the SBW operates<br />Poster Winners Announced</td></tr>
-<tr><td class="uk-padding-small">8:10</td><td>8:25</td><td>Rich Joost,<br />SmithBucklin/United Soybean Board</td><td>The USB/Monsanto/Pioneer International High-Oleic Soy Collaboration</td></tr>
-<tr><td class="uk-padding-small">8:25</td><td>8:35</td><td></td><td>The cross commodity ASTA protocol for establishing and maintaining genetic integrity in breeding materials</td></tr>
-<tr><td class="uk-padding-small">8:35</td><td>9:00</td><td>Jiaoping Zhang, South Dakota State Univ.</td><td>Genome-wide Association Study of Agronomic and Seed Quality Traits for Early Mature Soybean Germplasm</td></tr>
-<tr><td class="uk-padding-small">9:00</td><td>9:20</td><td>From the Floor</td><td>Retirements &amp; Announcements</td></tr>
-<tr><td class="uk-padding-small">9:20</td><td>9:35</td><td>Gary Stacey, Univ. Missouri</td><td>Novel germplasm resources for soybean breeding and genetics</td></tr>
-<tr><td class="uk-padding-small">9:35</td><td>9:50</td><td>Perry Cregan, USDA-ARS, Beltsville</td><td>Status of the 50K SNP genotyping of germplasm collection</td></tr>
-<tr><td class="uk-padding-small">9:50</td><td>10:05</td><td>David Grant, USDA-ARS, Ames, IA</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Grant_SBW2014.pdf'>SoyBase Update</a></td></tr>
-<tr><td class="uk-padding-small">10:05</td><td>10:20</td><td>Committee Member</td><td>Soybean Germplasm Committee Report</td></tr>
-<tr><td class="uk-padding-small">10:20</td><td>10:35</td><td>David Wooten</td><td>Soybean Genetics Committee Report</td></tr>
-<tr><td class="uk-padding-small">10:35</td><td>10:50</td><td>Kristin Bilyeu, USDA-ARS, Columbia</td><td>SoyGEC report</td></tr>
-<tr><td class="uk-padding-small">&nbsp;</td><td>&nbsp;</td><td>Katy Martin Rainey</td><td>Adjourn</td></tr>
-</table>
+<div class="uk-overflow-auto">
+	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+        <thead>
+            <tr>
+                <th class="uk-table-expand">Speaker</th>
+                <th class="uk-table-expand">Topic</th>
+            </tr>
+         </thead>
+         <body>
+            <tr><td>Katy M. Rainey, Purdue Univ.</td><td>Welcome and Announcements<br />A brief explanation of how the SBW operates<br />Poster Winners Announced</td></tr>
+            <tr><td>Rich Joost, SmithBucklin/United Soybean Board</td><td>The USB/Monsanto/Pioneer International High-Oleic Soy Collaboration</td></tr>
+            <tr><td colspan='2'>The cross commodity ASTA protocol for establishing and maintaining genetic integrity in breeding materials</td></tr>
+            <tr><td>Jiaoping Zhang, South Dakota State Univ.</td><td>Genome-wide Association Study of Agronomic and Seed Quality Traits for Early Mature Soybean Germplasm</td></tr>
+            <tr><td colspan='2'>From the Floor: Retirements &amp; Announcements</td></tr>
+            <tr><td>Gary Stacey, Univ. Missouri</td><td>Novel germplasm resources for soybean breeding and genetics</td></tr>
+            <tr><td>Perry Cregan, USDA-ARS</td><td>Status of the 50K SNP genotyping of germplasm collection</td></tr>
+            <tr><td>David Grant, USDA-ARS</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Grant_SBW2014.pdf'>SoyBase Update</a></td></tr>        
+            <tr><td>Committee Member</td><td>Soybean Germplasm Committee Report</td></tr>
+            <tr><td>David Wooten</td><td>Soybean Genetics Committee Report</td></tr>
+            <tr><td>Kristin Bilyeu, USDA-ARS</td><td>SoyGEC report</td></tr>
+            <tr><td>Katy Martin Rainey</td><td>Adjourn</td></tr>
+        </body>
+    </table>
+</div>
 

--- a/community/sbw/SBW/SBW_2014.html
+++ b/community/sbw/SBW/SBW_2014.html
@@ -10,10 +10,10 @@ sitemap: community/sbw
 <div>
 <h4>Workshop Coordinators:</h4>
     <p>
-        <strong>Katy Martin Rainey</strong> (Public Breeder), Purdue Univ. - Overall planning and coordination<br /> 
-        <strong>Hari Ramasubramaniam</strong> (Plant Pathologist), Syngenta Seeds Inc. - Hotel arrangements<br />
-        <strong>Danny Singh</strong> (Public Breeder), Iowa State Univ. - Program Chair, Tuesday General Session<br />
-        <strong>Seth Naeve</strong> (Public Agronomist/Physiologist), Univ. Minnesota, Co-Chair, Tuesday General Session
+        <strong>Katy Martin Rainey</strong> (Chair), Purdue Univ.;
+        <strong>Hari Ramasubramaniam</strong>, Syngenta Seeds Inc.;
+        <strong>Danny Singh</strong>, Iowa State Univ.;
+        <strong>Seth Naeve</strong>, Univ. Minnesota
     </p>
 </div>
 
@@ -98,7 +98,7 @@ sitemap: community/sbw
             <tr><td colspan='2'>From the Floor: Retirements &amp; Announcements</td></tr>
             <tr><td>Gary Stacey, Univ. Missouri</td><td>Novel germplasm resources for soybean breeding and genetics</td></tr>
             <tr><td>Perry Cregan, USDA-ARS</td><td>Status of the 50K SNP genotyping of germplasm collection</td></tr>
-            <tr><td>David Grant, USDA-ARS</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Grant_SBW2014.pdf'>SoyBase Update</a></td></tr>        
+            <tr><td>David Grant, USDA-ARS</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Grant_SBW2014.pdf'>SoyBase Update</a></td></tr>        
             <tr><td>Committee Member</td><td>Soybean Germplasm Committee Report</td></tr>
             <tr><td>David Wooten</td><td>Soybean Genetics Committee Report</td></tr>
             <tr><td>Kristin Bilyeu, USDA-ARS</td><td>SoyGEC report</td></tr>

--- a/community/sbw/SBW/SBW_2014.html
+++ b/community/sbw/SBW/SBW_2014.html
@@ -5,61 +5,59 @@ sitemap: community/sbw
 ---
 
 
-<h2>2014 SOYBEAN BREEDERS', PHYSIOLOGISTS', &amp; AGRONOMISTS' WORKSHOP</h2>
-
+<h2>2014 SOYBEAN BREEDERS', PHYSIOLOGISTS' &amp; AGRONOMISTS' WORKSHOP</h2>
 <hr />
-<h3>Workshop Coordinators:</h3>
-Katy Martin Rainey (Public Breeder), Purdue Univ. - Overall planning and coordination<br /> 
-Hari Ramasubramaniam (Plant Pathologist), Syngenta Seeds Inc. - Hotel arrangements<br />
-Danny Singh (Public Breeder), Iowa State Univ. - Program Chair, Tuesday General Session<br />
-Seth Naeve (Public Agronomist/Physiologist), Univ. Minnesota, Co-Chair, Tuesday General Session<br />
-
-<h3>Monday, February 17</h3>
-<table class="uk-table uk-table-small uk-table-hover uk-table-responsive uk-table-divider">
-    <thead>
-        <tr>
-            <th class="uk-table-shrink">Start</th>
-            <th class="uk-table-shrink">End</th>
-            <th class="uk-table-expand">Speaker</th>
-            <th class="uk-table-expand">Topic</th>
-        </tr>
-    </thead>
-<tbody>
-    <tr><td class="uk-padding-small">1:30</td><td class="uk-padding-small">1:40</td><td>Katy Martin Rainey</td><td>Welcome and announcements</td></tr>
-    <tr><td class="uk-padding-small">1:40</td><td class="uk-padding-small">2:10</td><td>Kristin Bilyeu &amp; Tiffany Langewisch, USDA-ARS, Columbia, MO</td><td>Developing an E Gene Molecular Model for Soybean Maturity Groups</td></tr>
-    <tr><td class="uk-padding-small">2:10</td><td class="uk-padding-small">2:40</td><td>Brian Diers, Univ. Illinois</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Diers_SBW2014.pdf'>SoyNAM Project Update</a></td></tr>
-    <tr><td class="uk-padding-small">2:40</td><td class="uk-padding-small">2:50</td><td colspan='2'> Coffee Break</td></tr>
-    <tr><td class="uk-padding-small">2:50</td><td class="uk-padding-small">3:20</td><td>Yong-qiang Charles An,<br />USDA-ARS, St. Louis, MO</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Yong-qiang_SBW2014.pdf'>Exploring Soybean Transcript Polymorphisms to Identify Gene Variants and Functional Markers for Seed Quality Improvement</a></td></tr>
-    <tr><td class="uk-padding-small">3:20</td><td class="uk-padding-small">3:50</td><td>Jianxin Ma, Purdue Univ.</td><td>Genetic Basis of Soybean Stem Growth Habit and its Potential Application for Development of High-yielding, Climate-resilient Soybean</td></tr>
-    <tr><td class="uk-padding-small">3:50</td><td class="uk-padding-small">4:20</td><td>Mike Gore, Cornell Univ.</td><td>Genome-Wide Analysis of Metabolic Traits in Maize</td></tr>
-    <tr><td class="uk-padding-small">4:20</td><td class="uk-padding-small">4:50</td><td>Peter Goldsmith, Univ. Illinois</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Goldsmith_SBW2014.pdf'>Tropical Soybean Research: USAID's New Soybean Innovation Lab</a></td></tr>
-    <tr><td class="uk-padding-small">4:50</td><td class="uk-padding-small">5:20</td><td>John Becherer, CEO,<br />United Soybean Board</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Becherer_SBW2014.pdf'>Considerations in Capturing Soybean Component Value from the Soybean Value Chain</a></td></tr>
-    <tr><td class="uk-padding-small">5:20</td><td class="uk-padding-small">&nbsp;</td><td>Katy Martin Rainey</td><td>Announcements and Adjourn</td></tr>
-</tbody>
-</table>
-
-<h3>Tuesday, February 18, General Session</h3>
-
-<div class="uk-text-center">
-Chair, Public Breeder: Danny Singh, Iowa State<br />
-Co-Chair, Public Agronomist/Physiologist: Seth Naeve, Univ. Minnesota<br />
+<div>
+<h4>Workshop Coordinators:</h4>
+    <p>
+        <strong>Katy Martin Rainey</strong> (Public Breeder), Purdue Univ. - Overall planning and coordination<br /> 
+        <strong>Hari Ramasubramaniam</strong> (Plant Pathologist), Syngenta Seeds Inc. - Hotel arrangements<br />
+        <strong>Danny Singh</strong> (Public Breeder), Iowa State Univ. - Program Chair, Tuesday General Session<br />
+        <strong>Seth Naeve</strong> (Public Agronomist/Physiologist), Univ. Minnesota, Co-Chair, Tuesday General Session
+    </p>
 </div>
-<table class="uk-table uk-table-small uk-table-hover uk-table-responsive uk-table-divider">
-    <thead>
-        <tr>
-            <th class="uk-table-shrink">Start</th>
-            <th class="uk-table-shrink">End</th>
-            <th class="uk-table-expand">Speaker</th>
-            <th class="uk-table-expand">Topic</th>
-        </tr>
-    </thead>
-    <tr><td class="uk-padding-small">7:00</td><td>8:00</td><td colspan='2'>Continental Breakfast, Versailles Foyer</td></tr>
-    <tr><td class="uk-padding-small">8:00</td><td>8:05</td><td>Danny Singh</td><td>General Introduction</td></tr>
-    <tr><th colspan='4'>SESSION I: Soybean Drought Stress | Chairs: Tommy Carter, USDA-ARS, Raleigh  &amp; George Graef, Univ. Nebraska</th></tr>
-    <tr><td class="uk-padding-small">8:05</td><td>8:35</td><td>Tom Sinclair, NC State</td><td>Physiological Input for Improved Soybean Drought Tolerance</td></tr>
-    <tr><td class="uk-padding-small">8:35</td><td>9:05</td><td>Jim Specht, Univ. Nebraska</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Specht_SBW2014.pdf'>Soybean Yield Response to Scarce or Abundant Water- Retrospect and Prospect</a></td></tr>
-    <tr><td class="uk-padding-small">9:05</td><td>9:30</td><td>Pengyin Chen, Univ. Arkansas</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Chen_SBW2014.pdf'>Drought Tolerance Traits for Improving Soybean Yield Under Stress</a></td></tr>
-    <tr><td class="uk-padding-small">9:30</td><td>9:55</td><td>Charlie Messina, Pioneer</td><td>Developing Drought Tolerant Maize Hybrids for the US Corn-belt: Discovery to Product</td></tr>
+
+<h3>Monday, February 17, 2014</h3>
+<div class="uk-overflow-auto">
+	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+        <thead>
+            <tr>
+                <th class="uk-table-expand">Speaker</th>
+                <th class="uk-table-expand">Topic</th>
+            </tr>
+        </thead>
+        <body>
+            <tr><td>Katy Martin Rainey, Purdue Univ.</td><td>Welcome and announcements</td></tr>
+            <tr><td>Kristin Bilyeu &amp; Tiffany Langewisch, USDA-ARS</td><td>Developing an E Gene Molecular Model for Soybean Maturity Groups</td></tr>
+            <tr><td>Brian Diers, Univ. Illinois</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Diers_SBW2014.pdf'>SoyNAM Project Update</a></td></tr>
+            <tr><td colspan='2'> Coffee Break</td></tr>
+            <tr><td>Yong-qiang Charles An, USDA-ARS</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Yong-qiang_SBW2014.pdf'>Exploring Soybean Transcript Polymorphisms to Identify Gene Variants and Functional Markers for Seed Quality Improvement</a></td></tr>
+            <tr><td>Jianxin Ma, Purdue Univ.</td><td>Genetic Basis of Soybean Stem Growth Habit and its Potential Application for Development of High-yielding, Climate-resilient Soybean</td></tr>
+            <tr><td>Mike Gore, Cornell Univ.</td><td>Genome-Wide Analysis of Metabolic Traits in Maize</td></tr>
+            <tr><td>Peter Goldsmith, Univ. Illinois</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Goldsmith_SBW2014.pdf'>Tropical Soybean Research: USAID's New Soybean Innovation Lab</a></td></tr>
+            <tr><td>John Becherer, United Soybean Board</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Becherer_SBW2014.pdf'>Considerations in Capturing Soybean Component Value from the Soybean Value Chain</a></td></tr>
+            <tr><td>Katy Martin Rainey</td><td>Announcements and Adjourn</td></tr>
+        </body>
+    </table>
+</div>
+
+<h3>Tuesday, February 18, 2014</h3>
+<div class="uk-overflow-auto">
+	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+        <thead>
+            <tr>
+                <th class="uk-table-expand">Speaker</th>
+                <th class="uk-table-expand">Topic</th>
+            </tr>
+         </thead>
+         <body>
+
+    <tr><td>Danny Singh</td><td>General Introduction</td></tr>
+    <tr><th colspan='2'>SESSION I: Soybean Drought Stress | Chairs: Tommy Carter, USDA-ARS  &amp; George Graef, Univ. Nebraska</th></tr>
+    <tr><td>Tom Sinclair, NC State</td><td>Physiological Input for Improved Soybean Drought Tolerance</td></tr>
+    <tr><td>Jim Specht, Univ. Nebraska</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Specht_SBW2014.pdf'>Soybean Yield Response to Scarce or Abundant Water- Retrospect and Prospect</a></td></tr>
+    <tr><td>Pengyin Chen, Univ. Arkansas</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2014/Chen_SBW2014.pdf'>Drought Tolerance Traits for Improving Soybean Yield Under Stress</a></td></tr>
+    <tr><td>Charlie Messina, Pioneer</td><td>Developing Drought Tolerant Maize Hybrids for the US Corn-belt: Discovery to Product</td></tr>
     <tr><td class="uk-padding-small">9:55</td><td>10:10</td><td colspan='2'>Coffee Break</td></tr>
     <tr><th colspan='4'>SESSION II: Phenotyping and Physiology of Soybean Traits | Chairs: Brian Diers, Univ. Illinois &amp; Jim Specht, Univ. Nebraska</th></tr>
     <tr><td class="uk-padding-small">10:10</td><td>10:35</td><td>Mike Gore, Cornell Univ.</td><td>High Throughput Phenotyping: Research and Potential Applications in Crops</td></tr>
@@ -81,6 +79,8 @@ Co-Chair, Public Agronomist/Physiologist: Seth Naeve, Univ. Minnesota<br />
     <tr><td class="uk-padding-small">4:15</td><td>4:35</td><td>Jim Sutter, CEO,<br />US Soybean Export Council</td><td>What our international purchasers are requesting</td></tr>
     <tr><td class="uk-padding-small">4:35</td><td>&nbsp;</td><td colspan='2'>Announcements &amp; Adjourn</td></tr>
 </table>
+</body>
+</div>
 
 <h3>Wednesday, February 19</h3>
 <table class="uk-table uk-table-small uk-table-hover uk-table-responsive uk-table-divider">

--- a/community/sbw/SBW/SBW_2016.html
+++ b/community/sbw/SBW/SBW_2016.html
@@ -135,7 +135,7 @@ sitemap: community/sbw
 			<tr><td>Jennifer Jones</td><td>Soybean Genomics Executive Committee</td></tr>
 			<tr><td>Troy Cary</td><td>Technicians Workshop</td></tr>
 			<tr><td>Chris Tinius</td><td>Commercial Soybean Breeders' Business Meeting</td></tr>
-			<tr><td>Andrew Scaboo</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Soybean_Genetics_Committee.pdf">Soybean Genetics Committee</td></tr>
+			<tr><td>Andrew Scaboo</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Soybean_Genetics_Committee.pdf">Soybean Genetics Committee</td></tr>
 			<tr><td>Kelly Whiting and Cate Newberg</td><td>Soybean Research Database Orientation</td></tr>
 			<tr><td>George Graef</td><td>Quality Traits</td></tr>
 		</body>

--- a/community/sbw/SBW/SBW_2016.html
+++ b/community/sbw/SBW/SBW_2016.html
@@ -34,13 +34,13 @@ Public Plant Pathologist - <strong>John Rupe</strong>, Univ. of Arkansas - Gener
 	<tr><td>1:00</td><td>1:05</td><td>Andrew Scaboo, Univ. of Missouri</td><td>Welcome and announcements</td></tr>
 	<tr><th colspan='4'>SESSION I: Genetic Diversity</th></tr>
 	<tr><td>1:05</td><td>1:55</td><td>Steve Tanksley, Nature Source Genetics</td><td>Combining genomics and mathematical optimization in the exploitation of natural genetic diversity in plant breeding</td></tr>
-	<tr><td>1:55</td><td>2:35</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Singh.pdf">Ram Singh, USDA-ARS</a></td><td>Methodology to exploit Glycine tomentella for broadening the genetic base of modern soybean</td></tr>
+	<tr><td>1:55</td><td>2:35</td><td>Ram Singh, USDA-ARS</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Singh.pdf">Methodology to exploit Glycine tomentella for broadening the genetic base of modern soybean</a></td></tr>
 	<tr><td>2:35</td><td>3:05</td><td>David Price, Monsanto Co.</td><td>Utilization of genetic diversity with a commercial soybean breeding pipeline</td></tr>
 	<tr><td>3:05</td><td>3:25</td><td class="uk-text-bold">Break</td></tr>
 	<tr><th colspan='4'>SESSION II: Commodity Funding Agencies Update</th></tr>
-	<tr><td>3:25</td><td>3:55</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Anderson.pdf">Ed Anderson, NCSRP</a></td><td>North Central Soybean Research programs update</td></tr>
-	<tr><td>3:55</td><td>4:25</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Joost.pdf">Rich Joost, USB</a></td><td>USB Strategic Direction FY17 - FY21</td></tr>
-	<tr><td>4:25</td><td>4:55</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Whiting.pdf">Kelly Whiting, USB and<br />Cate Newberg, Iowa Soybean Assoc.</a></td><td>National Soybean Research Database: How it impacts check-off project researchers</td></tr>
+	<tr><td>3:25</td><td>3:55</td><td>Ed Anderson, NCSRP</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Anderson.pdf">North Central Soybean Research programs update</a></td></tr>
+	<tr><td>3:55</td><td>4:25</td><td>Rich Joost, USB</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Joost.pdf">USB Strategic Direction FY17 - FY21</a></td></tr>
+	<tr><td>4:25</td><td>4:55</td><td>Kelly Whiting, USB and<br />Cate Newberg, Iowa Soybean Assoc.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Whiting.pdf">National Soybean Research Database: How it impacts check-off project researchers</a></td></tr>
 	<tr><td>4:55</td><td>5:00</td><td>Andrew Scaboo, Univ. of Missouri</td><td>Announcements and Adjourn</td></tr>
 </tbody>
 </table>
@@ -67,27 +67,27 @@ Co-Chair, Public Plant Pathologist:  John Rupe, Univ. of Arkansas</p>
 <body>
 	<tr><td>8:00</td><td>8:05</td><td>Aaron Lorenz, Univ. of Minnesota</td><td>Announcements and Introduction</td></tr>
 	<tr><th colspan='4'>SESSION I:  Sudden Death Syndrome | John Rupe, USDA-ARS</th></tr>
-	<tr><td>8:05</td><td>8:30</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Bhattacharyya_v2.pdf">Madan Bhattacharyya, Iowa State Univ.</a></td><td>Novel biotech. approaches in fighting sudden death syndrome in soybean</td></tr>
-	<tr><td>8:30</td><td>8:55</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Leandro.pdf">Leanor Leandro, Iowa State Univ.</a></td><td>SDS Epidemiology</td></tr>
+	<tr><td>8:05</td><td>8:30</td><td>Madan Bhattacharyya, Iowa State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Bhattacharyya_v2.pdf">Novel biotech. approaches in fighting sudden death syndrome in soybean</a></td></tr>
+	<tr><td>8:30</td><td>8:55</td><td>Leanor Leandro, Iowa State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Leandro.pdf">SDS Epidemiology</a></td></tr>
 	<tr><td>8:55</td><td>9:20</td><td>Carl Bradley, Univ. of Kentucky</td><td>Multistate research on management of SDS</td></tr>
-	<tr><td>9:20</td><td>9:45</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Wang.pdf">Dechun Wang, Michigan State Univ.</a></td><td>Breeding for SDS resistance</td></tr>
+	<tr><td>9:20</td><td>9:45</td><td>Dechun Wang, Michigan State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Wang.pdf">Breeding for SDS resistance</a></td></tr>
 	<tr><td>9:45</td><td>10:05</td><th colspan='2'>Coffee Break</th></tr>
 	<tr><th colspan='4'>SESSION II:  Soybean Foliar Diseases | Danny Singh, Iowa State Univ.</th></tr>
 	<tr><td>10:05</td><td>10:30</td><td>Zenglu Li, Univ. of Georgia</td><td>Genetic Improvement of Rust Resistance in Soybean</td></tr>
 	<tr><td>10:30</td><td>10:55</td><td>Ahmad Fakoury, Southern Illinois Univ.</td><td>Management of Cercospora diseases in soybean:  USB Project Update</td></tr>
-	<tr><td>10:55</td><td>11:20</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Lackermann.pdf">Karen Lackermann, DuPont Pioneer</a></td><td>Trends in foliar disease diagnosis for 2015</td></tr>
+	<tr><td>10:55</td><td>11:20</td><td>Karen Lackermann, DuPont Pioneer</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Lackermann.pdf">Trends in foliar disease diagnosis for 2015</a></td></tr>
 	<tr><td>11:25</td><td>12:55</td><th colspan='2'>Lunch (on your own)</th></tr>
 	<tr><td>1:00</td><td>1:05</td><td>Aaron Lorenz, Univ. of Minnesota</td><td>Announcements and Introduction</td></tr>
 	<tr><th colspan='4'>SESSION III:  Soybean Nematode | Zenglu Li, Univ. of Georgia</th></tr>
-	<tr><td>1:05</td><td>1:30</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Diers_v2.pdf">Brian Diers, Univ. of Illinois</a></td><td>Impact of SCN resistance on nematode reproduction and yield</td></tr>
-	<tr><td>1:30</td><td>1:55</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Parrott_v2.pdf">Wayne Parrott, Univ. of Georgia</a></td><td>Untangling the knot: Identifying a gene for root-knot nematode resistance</td></tr>
-	<tr><td>1:55</td><td>2:20</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Arelli.pdf">Prakash Arelli, USDA-ARS</a></td><td>Improved methods for breeding soybean for more durable resistance to SCN</td></tr>
+	<tr><td>1:05</td><td>1:30</td><td>Brian Diers, Univ. of Illinois</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Diers_v2.pdf">Impact of SCN resistance on nematode reproduction and yield</a></td></tr>
+	<tr><td>1:30</td><td>1:55</td><td>Wayne Parrott, Univ. of Georgia</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Parrott_v2.pdf">Untangling the knot: Identifying a gene for root-knot nematode resistance</a></td></tr>
+	<tr><td>1:55</td><td>2:20</td><td>Prakash Arelli, USDA-ARS</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Arelli.pdf">Improved methods for breeding soybean for more durable resistance to SCN</a></td></tr>
 	<tr><td>2:20</td><td>2:45</td><td>Melissa Mitchum, Univ. of Missouri</td><td>The shifting sands of the soybean cyst nematode-soybean interaction</td></tr>
 	<tr><td>2:45</td><td>3:05</td><td colspan='2'>Snack Break</td></tr>
 	<tr><th colspan='4'>SESSION IV:  Soybean Seedling Diseases | Leah Mchale, Ohio State Univ.</th></tr>
 	<tr><td>3:05</td><td>3:30</td><td>Anne Dorrance, Ohio State Univ.</td><td>Seedling pathogens of soybean, their diversity and best practices for breeding for resistance</td></tr>
 	<tr><td>3:30</td><td>3:55</td><td>Jianxin Ma, Purdue Univ.</td><td>Molecular mapping and characterization of novel Rps genes</td></tr>
-	<tr><td>3:55</td><td>4:20</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Chilvers.pdf">Martin Chilvers, Michigan State Univ.</a></td><td>Oomycetes associated with soybean disease and improved molecular diagnostics</td></tr>
+	<tr><td>3:55</td><td>4:20</td><td>Martin Chilvers, Michigan State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Chilvers.pdf">Oomycetes associated with soybean disease and improved molecular diagnostics</a></td></tr>
 	<tr><td>4:20</td><td>4:45</td><td>John McDowell, Virginia Tech. Univ.</td><td>Effector-directed breeding as a tool to improve soybean resistance to Phytophthora sojae</td></tr>
 	<tr><td>4:50</td><td>5:00</td><td>Aaron Lorenz, Univ. of Minnesota</td><td>Announcements and Adjourn</td></tr>
 	<tr><td>5:30</td><td>6:30</td><td colspan='4' style='text-align:left; font-weight: bold;'>Social Hour &amp; Poster Session, Foyer &amp; Versailles 2</td></tr>
@@ -109,7 +109,7 @@ Co-Chair, Public Plant Pathologist:  John Rupe, Univ. of Arkansas</p>
 <body>
 	<tr><td>6:45</td><td>8:00</td><td colspan='2' style='font-weight:bold;'>Continental Breakfast, Versailles Foyer</td></tr>
 	<tr><td>8:00</td><td>8:05</td><td>Andrew Scaboo, Univ. of Missouri<br />Chris Tinius, Bayer CropScience</td><td>Welcome and Announcements<br />Poster Winners Announced</td></tr>
-	<tr><td>8:05</td><td>8:10</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Soybean_Genetics_Committee.pdf">Andrew Scaboo, Univ. of Missouri</a></td><td>Genetics Committee Report</td></tr>
+	<tr><td>8:05</td><td>8:10</td><td>Andrew Scaboo, Univ. of Missouri</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Soybean_Genetics_Committee.pdf">Genetics Committee Report</a></td></tr>
 	<tr><td>8:10</td><td>8:15</td><td>Silvia Cianzio, Iowa State Univ.</td><td>Germplasm Committee Report</td></tr>
 	<tr><td>8:15</td><td>8:20</td><td>Kristin Bilyeu, USDA-ARS</td><td>SoyGEC Report</td></tr>
 	<tr><td>8:20</td><td>8:40</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Grant.pdf">David Grant, Iowa State Univ.</a></td><td>SoyBase Update</td></tr>

--- a/community/sbw/SBW/SBW_2016.html
+++ b/community/sbw/SBW/SBW_2016.html
@@ -116,6 +116,7 @@ sitemap: community/sbw
 		</body>
 	</table>
 </div>
+<hr >
 
 <h3>SPECIAL MEETINGS and WORKSHOPS</h3>
 
@@ -152,70 +153,82 @@ sitemap: community/sbw
         </thead>
         <body>
 			<tr><td>Meredith Mendola &amp; Susannah Cooper</td><td>Panel Discussion<br />Skills to pay the bills:Success in a modern workplace</td></tr>
+			<tr><td>Troy Cary</td><td>Technicians Workshop</td></tr>
+			<tr><td>Anne Gillen</td><td>South Uniform Regional Testing</td></tr>
+			<tr><td>Gary Nowling</td><td>North Uniform Regional Testing</td></tr>
+			<tr><td>Troy Cary</td><td>SCN Regional Testing</td></tr>
+		</body>
+	</table>
+</div>
+
+
+<h4>Wednesday 02/24/2016</h4>
+<div class="uk-overflow-auto">
+	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+        <thead>
+            <tr>
+                <th class="uk-table-expand">Speaker</th>
+                <th class="uk-table-expand">Topic</th>
+            </tr>
+        </thead>
+        <body>
+			<tr><td>Tommy Carter</td><td>Public-Private Southern Breeders' Meeting</td></tr>
+			<tr><td>Kelly Whiting</td><td>USB Composition Workshop</td>
+		</body>
+	</table>
+</div>		
+
+<hr >
 
 
 
 
-Technicians Workshop, Troy Cary | 8:00 am - 12:00 pm | St. Moritz and Bern room<br />
-Social Hour | 5:30 pm - 6:30 pm | Versailles Foyer<br />
-Poster Session | 5:30 pm - 6:30 pm | Versailles 2 room<br />
-Uniform Regional Testing: South, Anne Gillen | 7:00 pm - 8:00 pm | Davos room<br />
-Uniform Regional Testing: North, Gary Nowling | 7:00 pm - 7:30 pm | Alpine II room<br />
-SCN Regional Testing, Troy Cary | 7:30 pm - 8:00 pm | Alpine II room<br />
-
-<h3>Wednesday 02/24/2016</h3>
-Continental Breakfast | 6:45 am - 8:00 am | Versailles Foyer<br />
-Public-Private Southern Breeders' Meeting, Tommy Carter | 7:00 am - 8:00 am | Alpine II room<br />
-USB Composition Workshop, Kelly Whiting | 11:00 am - 11:00 am Thursday Feb. 25th | St. Moritz room<br />
 
 <h3>Agenda for USB Seed Composition Workshop</h3>
 <h4>February 24th and 25th, 2016 | St. Louis, MO | Sheraton Westport Chalet Hotel</h4>
-
 <p>The 2016 USB Seed Composition Workshop highlights current research on soybean seed composition and quality traits and presentations on the value and delivery of soybean quality traits to the market.  The workshop will begin immediately after the Soybean Breeders' Workshop and thus begin Wednesday February 24th, 2016 at 11:00 am.  It will be in the St Moritz/Bern conference room of the Sheraton Chalet Hotel.</p>
+<hr >
 
-<h3>Wednesday February 24th, 2016</h3>
-<table class="uk-table uk-table-small uk-table-hover uk-table-responsive uk-table-divider">
-	<thead>
-        <tr>
-            <th class="uk-table-expand">Start</th>
-            <th class="uk-table-expand">End</th>
-            <th class="uk-table-expand">Speaker</th>
-            <th class="uk-table-expand">Topic</th>
-        </tr>
-    </thead>
-<tbody>
-	<tr><td>11:00am</td><td>11:05am</td><td> Mark Leitman, USB staff</td><td>Welcome and Introduction to Session</td></tr>
-	<tr><td>11:05am</td><td>11:35am</td><td> John Brake, North Carolina State University</td><td>Update on development of a tool for carbohydrate breeding: Sucrose content index relative to metabolizable energy content of animal feed</td></tr> 
-	<tr><td>11:35am</td><td>12:00pm</td><td> Zenglu Li, University of Georgia</td><td>Prospect of simultaneous genetic gains in yield and protein content in soybean </td></tr>
+<h4>Wednesday February 24th, 2016</h4>
+<div class="uk-overflow-auto">
+	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+        <thead>
+            <tr>
+                <th class="uk-table-expand">Speaker</th>
+                <th class="uk-table-expand">Topic</th>
+            </tr>
+        </thead>
+        <body>
+			<tr><td>Mark Leitman, USB staff</td><td>Welcome and Introduction to Session</td></tr>
+			<tr><td>John Brake, North Carolina State Univ.</td><td>Update on development of a tool for carbohydrate breeding: Sucrose content index relative to metabolizable energy content of animal feed</td></tr> 
+			<tr><td>Zenglu Li, Univ. of Georgia</td><td>Prospect of simultaneous genetic gains in yield and protein content in soybean </td></tr>
+			<tr><td colspan='2'>Lunch (on your own)</td></tr>
+			<tr><td colspan='2'>USB Carbohydrate Traits project update</td></tr>
+			<tr><td colspan='2'>USB Increased Oil Content project update</td></tr>
+			<tr><td colspan='2'>Break</td></tr>
+			<tr><td colspan='2'>USB Increased Protein Content and Amino Acids project update</td></tr>
+			<tr><td colspan='2'>USB Stearic Acid project update</td></tr>
+			<tr><td colspan='2'>Dinner for USB composition project researchers (only)</td></tr>
+		</body>
+	</table>
+</div>	
 
-	<tr><td>12:00pm</td><td>1:20pm</td><td colspan='2'>Lunch (on your own)</td></tr>
-
-	<tr><td>1:20pm</td><td>2:20pm</td><td colspan='2'>USB Carbohydrate Traits project update</td></tr>
-	<tr><td>2:20pm</td><td>3:20pm</td><td colspan='2'>USB Increased Oil Content project update</td></tr>
-	<tr><td>3:20pm</td><td>3:40pm</td><td colspan='2'>Break</td></tr>
-	<tr><td>3:40pm</td><td>4:40pm</td><td colspan='2'>USB Increased Protein Content and Amino Acids project update</td></tr>
-	<tr><td>4:40pm</td><td>5:40 pm</td><td colspan='2'>USB Stearic Acid project update</td></tr>
-
-	<tr><td>6:15pm</td><td> </td><td colspan='2'>Dinner for USB composition project researchers (only)</td></tr><br />
-				
-</tbody>
-</table>
-<h3>Thursday February 25th, 2016</h3>
-<table class="uk-table uk-table-small uk-table-hover uk-table-responsive uk-table-divider">
-	<thead>
-        <tr>
-            <th class="uk-table-expand">Start</th>
-            <th class="uk-table-expand">End</th>
-            <th class="uk-table-expand">Speaker</th>
-            <th class="uk-table-expand">Topic</th>
-        </tr>
-    </thead>
-<tbody>
-	<tr><td>8:00am</td><td>8:05am</td><td>Kelly Whiting, USB staff</td><td>Welcome &amp; Introduction to Session </td></tr>
-	<tr><td>8:05am</td><td>9:05am</td><td colspan='2'>USB High Oleic Breeding project update</td></tr>
-	<tr><td>9:05am</td><td>9:50am</td><td>Chris Schroeder, Centrec Consulting Group, LLC</td><td>Market Considerations for Extracting Value from Soybean Compositional Enhancement</td></tr>
-	<tr><td>9:50am</td><td>10:10am</td><td colspan='2'>Break</td></tr>
-	<tr><td>10:10am</td><td>10:25am</td><td>Dan Corcoran, USB Farmer-Director</td><td>Update on USB Value Task Force</td></tr>	
-	<tr><td>10:25am</td><td>11:00am</td><td>Gordon Denny, Consultant, Denny LLC</td><td>What Will it Take to Introduce into the Market Soybean Meal Derived from Varieties with Improved Meal Traits</td></tr>
-</tbody>
-</table>
+<h4>Thursday February 25th, 2016</h4>
+<div class="uk-overflow-auto">
+	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+        <thead>
+            <tr>
+                <th class="uk-table-expand">Speaker</th>
+                <th class="uk-table-expand">Topic</th>
+            </tr>
+        </thead>
+        <body>
+			<tr><td>Kelly Whiting, USB staff</td><td>Welcome &amp; Introduction to Session </td></tr>
+			<tr><td colspan='2'>USB High Oleic Breeding project update</td></tr>
+			<tr><td>Chris Schroeder, Centrec Consulting Group, LLC</td><td>Market Considerations for Extracting Value from Soybean Compositional Enhancement</td></tr>
+			<tr><td colspan='2'>Break</td></tr>
+			<tr><td>Dan Corcoran, USB Farmer-Director</td><td>Update on USB Value Task Force</td></tr>	
+			<tr><td>Gordon Denny, Consultant, Denny LLC</td><td>What Will it Take to Introduce into the Market Soybean Meal Derived from Varieties with Improved Meal Traits</td></tr>
+		</body>
+	</table>
+</div>	

--- a/community/sbw/SBW/SBW_2016.html
+++ b/community/sbw/SBW/SBW_2016.html
@@ -13,7 +13,9 @@ sitemap: community/sbw
 	<strong>Clint Mapel</strong>, Dupont Pioneer;
 	<strong>Andrew Scaboo</strong>, Univ. of Missouri;
 	<strong>Aaron Lorenz</strong>, Univ. of Minnesota;
-	<strong>John Rupe</strong>, Univ. of Arkansas	
+	<strong>John Rupe</strong>, Univ. of Arkansas
+	<br >
+	<a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/2016_SBW_Agenda_for_SoyBase.pdf">View the published 2017 SBW Agenda</a>
 </p>
 
 

--- a/community/sbw/SBW/SBW_2016.html
+++ b/community/sbw/SBW/SBW_2016.html
@@ -6,140 +6,156 @@ sitemap: community/sbw
 
 <h2>2016 SOYBEAN BREEDERS &amp; PATHOLOGISTS WORKSHOP</h2>
 <hr >
-
-<h4>Workshop Coordinators:</h4>
 <div>
+<h4>Workshop Coordinators:</h4>
 	<p>
-    	<strong>Chris Tinius</stong> (chair), Bayer CropScience<br>
-		<strong>Curtis Scherder</strong> Monsanto Co.<br>
-		<strong>Leandro Mozzoni</strong> Monsanto Co.<br>
-		<strong>Clint Mapel</strong> Dupont Pioneer<br>
-		<strong>Andrew Scaboo</strong> Univ. of Missouri<br>
-		<strong>Aaron Lorenz</strong>, Univ. of Minnesota<br />
-		<strong>John Rupe</strong>, Univ. of Arkansas	
+    	Chris Tinius (chair), Bayer CropScience<br /> 
+		Curtis Scherder, Monsanto Co.<br /> 
+		Leandro Mozzoni Monsanto Co.<br /> 
+		Clint Mapel Dupont Pioneer<br /> 
+		Andrew Scaboo Univ. of Missouri<br /> 
+		Aaron Lorenz, Univ. of Minnesota<br />
+		John Rupe, Univ. of Arkansas	
 	</p>
 </div>
 
 
 <h3>Monday February 22nd, 2016</h3>
+<div class="uk-overflow-auto">
+	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+        <thead>
+            <tr>
+                <th class="uk-table-expand">Speaker</th>
+                <th class="uk-table-expand">Topic</th>
+            </tr>
+        </thead>
+        <body>
+			<tr><td>Andrew Scaboo, Univ. of Missouri</td><td>Welcome and announcements</td></tr>
+			<tr><th colspan='2'>SESSION I: Genetic Diversity</th></tr>
+			<tr><td>Steve Tanksley, Nature Source Genetics</td><td>Combining genomics and mathematical optimization in the exploitation of natural genetic diversity in plant breeding</td></tr>
+			<tr><td>Ram Singh, USDA-ARS</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Singh.pdf">Methodology to exploit Glycine tomentella for broadening the genetic base of modern soybean</a></td></tr>
+			<tr><td>David Price, Monsanto Co.</td><td>Utilization of genetic diversity with a commercial soybean breeding pipeline</td></tr>
+			<tr><td colspan='2'>Break</td></tr>
+			<tr><th colspan='2'>SESSION II: Commodity Funding Agencies Update</th></tr>
+			<tr><td>Ed Anderson, NCSRP</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Anderson.pdf">North Central Soybean Research programs update</a></td></tr>
+			<tr><td>Rich Joost, USB</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Joost.pdf">USB Strategic Direction FY17 - FY21</a></td></tr>
+			<tr><td>Kelly Whiting, USB and<br />Cate Newberg, Iowa Soybean Assoc.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Whiting.pdf">National Soybean Research Database: How it impacts check-off project researchers</a></td></tr>
+			<tr><td>Andrew Scaboo, Univ. of Missouri</td><td>Announcements and Adjourn</td></tr>
+		</body>
+	</table>
+</div>
+		
 
-<table class="uk-table uk-table-small uk-table-hover uk-table-responsive uk-table-divider">
-	<thead>
-        <tr>
-            <th class="uk-table-shrink">Start</th>
-            <th class="uk-table-shrink">End</th>
-            <th class="uk-table-expand">Speaker</th>
-            <th class="uk-table-expand">Topic</th>
-        </tr>
-    </thead>
-<tbody>
-	<tr><td>1:00</td><td>1:05</td><td>Andrew Scaboo, Univ. of Missouri</td><td>Welcome and announcements</td></tr>
-	<tr><th colspan='4'>SESSION I: Genetic Diversity</th></tr>
-	<tr><td>1:05</td><td>1:55</td><td>Steve Tanksley, Nature Source Genetics</td><td>Combining genomics and mathematical optimization in the exploitation of natural genetic diversity in plant breeding</td></tr>
-	<tr><td>1:55</td><td>2:35</td><td>Ram Singh, USDA-ARS</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Singh.pdf">Methodology to exploit Glycine tomentella for broadening the genetic base of modern soybean</a></td></tr>
-	<tr><td>2:35</td><td>3:05</td><td>David Price, Monsanto Co.</td><td>Utilization of genetic diversity with a commercial soybean breeding pipeline</td></tr>
-	<tr><td>3:05</td><td>3:25</td><td class="uk-text-bold">Break</td></tr>
-	<tr><th colspan='4'>SESSION II: Commodity Funding Agencies Update</th></tr>
-	<tr><td>3:25</td><td>3:55</td><td>Ed Anderson, NCSRP</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Anderson.pdf">North Central Soybean Research programs update</a></td></tr>
-	<tr><td>3:55</td><td>4:25</td><td>Rich Joost, USB</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Joost.pdf">USB Strategic Direction FY17 - FY21</a></td></tr>
-	<tr><td>4:25</td><td>4:55</td><td>Kelly Whiting, USB and<br />Cate Newberg, Iowa Soybean Assoc.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Whiting.pdf">National Soybean Research Database: How it impacts check-off project researchers</a></td></tr>
-	<tr><td>4:55</td><td>5:00</td><td>Andrew Scaboo, Univ. of Missouri</td><td>Announcements and Adjourn</td></tr>
-</tbody>
-</table>
+
 <h3>Tuesday Morning February 23rd, 2016</h3>
-<h4>Panel Discussion | 6:45 am - 7:45 am | Alpine I Room</h4>
-<p>Skills to pay the bills:  Success in a modern workplace<br />
-Hosted by Meredith Mendola, Susannah Cooper, and the Monsanto Women in Plant Breeding Network</p>
-<h4>Continental Breakfast | 6:30 am - 8:00 am | Versailles Foyer</h4>
-Hosted by the Commercial Soybean Breeders
-<h3>Tuesday February 23rd, 2016 | Versailles 1 Room</h3>
-<h4>General Session</h4>
-<p>Chair, Public Soybean Breeder:  Aaron Lorenz, Univ. of Minnesota<br />
-Co-Chair, Public Plant Pathologist:  John Rupe, Univ. of Arkansas</p>
-
-<table class="uk-table uk-table-small uk-table-hover uk-table-responsive uk-table-divider">
-	<thead>
-        <tr>
-            <th class="uk-table-shrink">Start</th>
-            <th class="uk-table-shrink">End</th>
-            <th class="uk-table-expand">Speaker</th>
-            <th class="uk-table-expand">Topic</th>
-        </tr>
-    </thead>
-<body>
-	<tr><td>8:00</td><td>8:05</td><td>Aaron Lorenz, Univ. of Minnesota</td><td>Announcements and Introduction</td></tr>
-	<tr><th colspan='4'>SESSION I:  Sudden Death Syndrome | John Rupe, USDA-ARS</th></tr>
-	<tr><td>8:05</td><td>8:30</td><td>Madan Bhattacharyya, Iowa State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Bhattacharyya_v2.pdf">Novel biotech. approaches in fighting sudden death syndrome in soybean</a></td></tr>
-	<tr><td>8:30</td><td>8:55</td><td>Leanor Leandro, Iowa State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Leandro.pdf">SDS Epidemiology</a></td></tr>
-	<tr><td>8:55</td><td>9:20</td><td>Carl Bradley, Univ. of Kentucky</td><td>Multistate research on management of SDS</td></tr>
-	<tr><td>9:20</td><td>9:45</td><td>Dechun Wang, Michigan State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Wang.pdf">Breeding for SDS resistance</a></td></tr>
-	<tr><td>9:45</td><td>10:05</td><th colspan='2'>Coffee Break</th></tr>
-	<tr><th colspan='4'>SESSION II:  Soybean Foliar Diseases | Danny Singh, Iowa State Univ.</th></tr>
-	<tr><td>10:05</td><td>10:30</td><td>Zenglu Li, Univ. of Georgia</td><td>Genetic Improvement of Rust Resistance in Soybean</td></tr>
-	<tr><td>10:30</td><td>10:55</td><td>Ahmad Fakoury, Southern Illinois Univ.</td><td>Management of Cercospora diseases in soybean:  USB Project Update</td></tr>
-	<tr><td>10:55</td><td>11:20</td><td>Karen Lackermann, DuPont Pioneer</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Lackermann.pdf">Trends in foliar disease diagnosis for 2015</a></td></tr>
-	<tr><td>11:25</td><td>12:55</td><th colspan='2'>Lunch (on your own)</th></tr>
-	<tr><td>1:00</td><td>1:05</td><td>Aaron Lorenz, Univ. of Minnesota</td><td>Announcements and Introduction</td></tr>
-	<tr><th colspan='4'>SESSION III:  Soybean Nematode | Zenglu Li, Univ. of Georgia</th></tr>
-	<tr><td>1:05</td><td>1:30</td><td>Brian Diers, Univ. of Illinois</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Diers_v2.pdf">Impact of SCN resistance on nematode reproduction and yield</a></td></tr>
-	<tr><td>1:30</td><td>1:55</td><td>Wayne Parrott, Univ. of Georgia</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Parrott_v2.pdf">Untangling the knot: Identifying a gene for root-knot nematode resistance</a></td></tr>
-	<tr><td>1:55</td><td>2:20</td><td>Prakash Arelli, USDA-ARS</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Arelli.pdf">Improved methods for breeding soybean for more durable resistance to SCN</a></td></tr>
-	<tr><td>2:20</td><td>2:45</td><td>Melissa Mitchum, Univ. of Missouri</td><td>The shifting sands of the soybean cyst nematode-soybean interaction</td></tr>
-	<tr><td>2:45</td><td>3:05</td><td colspan='2'>Snack Break</td></tr>
-	<tr><th colspan='4'>SESSION IV:  Soybean Seedling Diseases | Leah Mchale, Ohio State Univ.</th></tr>
-	<tr><td>3:05</td><td>3:30</td><td>Anne Dorrance, Ohio State Univ.</td><td>Seedling pathogens of soybean, their diversity and best practices for breeding for resistance</td></tr>
-	<tr><td>3:30</td><td>3:55</td><td>Jianxin Ma, Purdue Univ.</td><td>Molecular mapping and characterization of novel Rps genes</td></tr>
-	<tr><td>3:55</td><td>4:20</td><td>Martin Chilvers, Michigan State Univ.</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Chilvers.pdf">Oomycetes associated with soybean disease and improved molecular diagnostics</a></td></tr>
-	<tr><td>4:20</td><td>4:45</td><td>John McDowell, Virginia Tech. Univ.</td><td>Effector-directed breeding as a tool to improve soybean resistance to Phytophthora sojae</td></tr>
-	<tr><td>4:50</td><td>5:00</td><td>Aaron Lorenz, Univ. of Minnesota</td><td>Announcements and Adjourn</td></tr>
-	<tr><td>5:30</td><td>6:30</td><td colspan='4' style='text-align:left; font-weight: bold;'>Social Hour &amp; Poster Session, Foyer &amp; Versailles 2</td></tr>
-</body>
-</table>
+<div class="uk-overflow-auto">
+	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+        <thead>
+            <tr>
+                <th class="uk-table-expand">Speaker</th>
+                <th class="uk-table-expand">Topic</th>
+            </tr>
+        </thead>
+        <body>
+			<tr><th colspan='2'>Special session: Hosted by Meredith Mendola, Susannah Cooper, <br />and the Monsanto Women in Plant Breeding Network</th></tr>
+			<tr><td>Panel Discussion</td><td>Skills to pay the bills:  Success in a modern workplace</td></tr>
+			<tr><th colspan='2'>General Session</th></tr>
+			<tr><td>Aaron Lorenz, Univ. of Minnesota</td><td>Announcements and Introduction</td></tr>
+			<tr><th colspan='2'>SESSION I:  Sudden Death Syndrome | Chair: ohn Rupe, USDA-ARS</th></tr>
+			<tr><td>Madan Bhattacharyya, Iowa State Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Bhattacharyya_v2.pdf">Novel biotech. approaches in fighting sudden death syndrome in soybean</a></td></tr>
+			<tr><td>Leanor Leandro, Iowa State Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Leandro.pdf">SDS Epidemiology</a></td></tr>
+			<tr><td>Carl Bradley, Univ. of Kentucky</td><td>Multistate research on management of SDS</td></tr>
+			<tr><td>Dechun Wang, Michigan State Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Wang.pdf">Breeding for SDS resistance</a></td></tr>
+			<tr><td colspan='2'>Coffee Break</td></tr>
+			<tr><th colspan='2'>SESSION II:  Soybean Foliar Diseases | Chair: Danny Singh, Iowa State Univ.</th></tr>
+			<tr><td>Zenglu Li, Univ. of Georgia</td><td>Genetic Improvement of Rust Resistance in Soybean</td></tr>
+			<tr><td>Ahmad Fakoury, Southern Illinois Univ.</td><td>Management of Cercospora diseases in soybean:  USB Project Update</td></tr>
+			<tr><td>Karen Lackermann, DuPont Pioneer</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Lackermann.pdf">Trends in foliar disease diagnosis for 2015</a></td></tr>
+			<tr><td colspan='2'>Lunch (on your own)</td></tr>
+			<tr><td>Aaron Lorenz, Univ. of Minnesota</td><td>Announcements and Introduction</td></tr>
+			<tr><th colspan='2'>SESSION III:  Soybean Nematode | Chair: Zenglu Li, Univ. of Georgia</th></tr>
+			<tr><td>Brian Diers, Univ. of Illinois</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Diers_v2.pdf">Impact of SCN resistance on nematode reproduction and yield</a></td></tr>
+			<tr><td>Wayne Parrott, Univ. of Georgia</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Parrott_v2.pdf">Untangling the knot: Identifying a gene for root-knot nematode resistance</a></td></tr>
+			<tr><td>Prakash Arelli, USDA-ARS</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Arelli.pdf">Improved methods for breeding soybean for more durable resistance to SCN</a></td></tr>
+			<tr><td>Melissa Mitchum, Univ. of Missouri</td><td>The shifting sands of the soybean cyst nematode-soybean interaction</td></tr>
+			<tr><td colspan='2'>Snack Break</td></tr>
+			<tr><th colspan='2'>SESSION IV:  Soybean Seedling Diseases | Chair: Leah Mchale, Ohio State Univ.</th></tr>
+			<tr><td>Anne Dorrance, Ohio State Univ.</td><td>Seedling pathogens of soybean, their diversity and best practices for breeding for resistance</td></tr>
+			<tr><td>Jianxin Ma, Purdue Univ.</td><td>Molecular mapping and characterization of novel Rps genes</td></tr>
+			<tr><td>Martin Chilvers, Michigan State Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Chilvers.pdf">Oomycetes associated with soybean disease and improved molecular diagnostics</a></td></tr>
+			<tr><td>John McDowell, Virginia Tech. Univ.</td><td>Effector-directed breeding as a tool to improve soybean resistance to Phytophthora sojae</td></tr>
+			<tr><td>Aaron Lorenz, Univ. of Minnesota</td><td>Announcements and Adjourn</td></tr>
+			<tr><<td colspan='2' >Social Hour &amp; Poster Session</td></tr>
+		</body>
+	</table>
+</div>
 
 
 <h3>Wednesday February 24th, 2016 | Versailles 1 Room</h3>
-
-<table class="uk-table uk-table-small uk-table-hover uk-table-responsive uk-table-divider">
-	<thead>
-        <tr>
-            <th class="uk-table-shrink">Start</th>
-            <th class="uk-table-shrink">End</th>
-            <th class="uk-table-expand">Speaker</th>
-            <th class="uk-table-expand">Topic</th>
-        </tr>
-    </thead>
-<body>
-	<tr><td>6:45</td><td>8:00</td><td colspan='2' style='font-weight:bold;'>Continental Breakfast, Versailles Foyer</td></tr>
-	<tr><td>8:00</td><td>8:05</td><td>Andrew Scaboo, Univ. of Missouri<br />Chris Tinius, Bayer CropScience</td><td>Welcome and Announcements<br />Poster Winners Announced</td></tr>
-	<tr><td>8:05</td><td>8:10</td><td>Andrew Scaboo, Univ. of Missouri</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Soybean_Genetics_Committee.pdf">Genetics Committee Report</a></td></tr>
-	<tr><td>8:10</td><td>8:15</td><td>Silvia Cianzio, Iowa State Univ.</td><td>Germplasm Committee Report</td></tr>
-	<tr><td>8:15</td><td>8:20</td><td>Kristin Bilyeu, USDA-ARS</td><td>SoyGEC Report</td></tr>
-	<tr><td>8:20</td><td>8:40</td><td>David Grant, USDA-ARS</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Grant.pdf">SoyBase Update</a></td></tr>
-	<tr><td>8:40</td><td>8:55</td><td>From the Floor</td><td>Retirements and Announcements</td></tr>
-	<tr><td>8:55</td><td>9:10</td><td>Ling Li, Iowa State Univ.</a></td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Li_v2.pdf">A molecular tool to increase protein content and broad disease resistance in soybeans</a></td></tr>
-	<tr><td>9:10</td><td>9:25</td><td>Alencar Xavier, Purdue Univ.</a></td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Xavier.pdf">Learning from data: GxE analysis on multiple populations</a></td></tr>
-	<tr><td>9:25</td><td>9:40</td><td>Justin Vaughn, Univ. of Georgia</td><td>Genomic signatures of North American soybean improvement</td></tr>
-	<tr><td>9:40</td><td>10:10</td><td>Henry Nguyen, Univ. of Missouri</td><td>The 1000+ soybean genomes and beyond</td></tr>
-	<tr><td>10:10</td><td>10:40</td><td>Randall Nelson, USDA-ARS</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Nelson.pdf">USAID Soybean Innovation Lab:  Increasing soybean production in sub-Saharan Africa</a></td></tr>
-	<tr><td>10:45</td><td>10:45</td><td colspan='2'>Andrew Scaboo, Univ. of Missouri - Adjourn</td></tr>
-</body>
-</table>
+<div class="uk-overflow-auto">
+	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+        <thead>
+            <tr>
+                <th class="uk-table-expand">Speaker</th>
+                <th class="uk-table-expand">Topic</th>
+            </tr>
+        </thead>
+        <body>
+			<tr><td>Andrew Scaboo, Univ. of Missouri<br />Chris Tinius, Bayer CropScience</td><td>Welcome and Announcements<br />Poster Winners Announced</td></tr>
+			<tr><td>Andrew Scaboo, Univ. of Missouri</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Soybean_Genetics_Committee.pdf">Genetics Committee Report</a></td></tr>
+			<tr><td>Silvia Cianzio, Iowa State Univ.</td><td>Germplasm Committee Report</td></tr>
+			<tr><td>Kristin Bilyeu, USDA-ARS</td><td>SoyGEC Report</td></tr>
+			<tr><td>David Grant, USDA-ARS</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Grant.pdf">SoyBase Update</a></td></tr>
+			<tr><td>From the Floor</td><td>Retirements and Announcements</td></tr>
+			<tr><td>Ling Li, Iowa State Univ.</a></td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Li_v2.pdf">A molecular tool to increase protein content and broad disease resistance in soybeans</a></td></tr>
+			<tr><td>Alencar Xavier, Purdue Univ.</a></td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Xavier.pdf">Learning from data: GxE analysis on multiple populations</a></td></tr>
+			<tr><td>Justin Vaughn, Univ. of Georgia</td><td>Genomic signatures of North American soybean improvement</td></tr>
+			<tr><td>Henry Nguyen, Univ. of Missouri</td><td>The 1000+ soybean genomes and beyond</td></tr>
+			<tr><td>Randall Nelson, USDA-ARS</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Nelson.pdf">USAID Soybean Innovation Lab:  Increasing soybean production in sub-Saharan Africa</a></td></tr>
+			<tr><td>Andrew Scaboo, Univ. of Missouri</td><td>Adjourn</td></tr>
+		</body>
+	</table>
+</div>
 
 <h3>SPECIAL MEETINGS and WORKSHOPS</h3>
 
-<h3>Monday 02/22/2016</h3>
-<a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/SoyBase_tutorial.pdf">SoyBase Workshop, David Grant | 8:30 am - 10:00 am | Alpine II room</a><br />
-Soybean Germplasm Committee, Silvia Cianzio | 9:00 am - 10:30 am | Alpine I room<br />
-Soybean Genomics Executive Committee, Jennifer Jones | 10:00 am - 12:00 pm | Zermatt Room<br />
-Technicians Workshop, Troy Cary | 1:00 pm - 5:00 pm | St. Moritz and Bern room <br />
-Commercial Soybean Breeders' Business Meeting, Chris Tinius | 5:30 pm - 6:30 pm | Alpine I room<br />
-<a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Soybean_Genetics_Committee.pdf">Soybean Genetics Committee, Andrew Scaboo | 7:00 pm - 8:00 pm | Davos room </a><br />
-Soybean Research Database Orientation, Kelly Whiting/Cate Newberg | 7:00 pm - 8:00 pm | Zermatt Room<br /> 
-Quality Traits, George Graef | 8:00 pm - 9:00 pm | St. Moritz and Bern room<br />
+<h4>Monday 02/22/2016</h4>
+<div class="uk-overflow-auto">
+	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+        <thead>
+            <tr>
+                <th class="uk-table-expand">Speaker</th>
+                <th class="uk-table-expand">Topic</th>
+            </tr>
+        </thead>
+        <body>
+			<tr><td>David Grant, USDA-ARS</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/SoyBase_tutorial.pdf">Soybean Workshop</a></td></tr>
+			<tr><td>Silvia Cianzio</td><td>Soybean Germplasm Committee</td></tr>
+			<tr><td>Jennifer Jones</td><td>Soybean Genomics Executive Committee</td></tr>
+			<tr><td>Troy Cary</td><td>Technicians Workshop</td></tr>
+			<tr><td>Chris Tinius</td><td>Commercial Soybean Breeders' Business Meeting</td></tr>
+			<tr><td>Andrew Scaboo</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Soybean_Genetics_Committee.pdf">Soybean Genetics Committee</td></tr>
+			<tr><td>Kelly Whiting and Cate Newberg</td><td>Soybean Research Database Orientation</td></tr>
+			<tr><td>George Graef</td><td>Quality Traits</td></tr>
+		</body>
+	</table>
+</div>
 
-<h3>Tuesday 02/23/2016</h3>
-Continental Breakfast | 6:30 am - 8:00 am | Versailles Foyer<br />
-Panel Discussion, Meredith Mendola &amp; Susannah Cooper | 6:45 am - 7:45 am | Alpine I room<br />
+<h4>Tuesday 02/23/2016</h4>
+<div class="uk-overflow-auto">
+	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+        <thead>
+            <tr>
+                <th class="uk-table-expand">Speaker</th>
+                <th class="uk-table-expand">Topic</th>
+            </tr>
+        </thead>
+        <body>
+			<tr><td>Meredith Mendola &amp; Susannah Cooper</td><td>Panel Discussion<br />Skills to pay the bills:Success in a modern workplace</td></tr>
+
+
+
+
 Technicians Workshop, Troy Cary | 8:00 am - 12:00 pm | St. Moritz and Bern room<br />
 Social Hour | 5:30 pm - 6:30 pm | Versailles Foyer<br />
 Poster Session | 5:30 pm - 6:30 pm | Versailles 2 room<br />

--- a/community/sbw/SBW/SBW_2016.html
+++ b/community/sbw/SBW/SBW_2016.html
@@ -6,20 +6,22 @@ sitemap: community/sbw
 
 <h2>2016 SOYBEAN BREEDERS &amp; PATHOLOGISTS WORKSHOP</h2>
 <hr >
-<h3>Registration, Versailles Foyer:</h3>
-Monday, Feb. 22nd, 10:30 am - 5 pm | Tuesday, Feb. 23rd, 7 am - 5 pm | Wednesday, Feb. 24th, 7 am - 10:30 am
-<hr />
-<h3>Workshop Coordinators:</h3>
-<p>Commercial Soybean Breeders' Committee members - <strong>Chris Tinius</strong> (chair), Bayer CropScience; 
-	<strong>Curtis Scherder</strong> Monsanto Co.; 
-	<strong>Leandro Mozzoni</strong> Monsanto Co.; 
-	<strong>Clint Mapel</strong> Dupont Pioneer</p>
 
-<p>Public Soybean Breeder - <strong>Andrew Scaboo</strong> Univ. of Missouri - Soybean Breeders' Workshop Chair<br />
-Public Soybean Breeder - <strong>Aaron Lorenz</strong>, Univ. of Minnesota - General Session Chair<br />
-Public Plant Pathologist - <strong>John Rupe</strong>, Univ. of Arkansas - General Session Co-Chair</p>
+<h4>Workshop Coordinators:</h4>
+<div>
+	<p>
+    	<strong>Chris Tinius</stong> (chair), Bayer CropScience<br>
+		<strong>Curtis Scherder</strong> Monsanto Co.<br>
+		<strong>Leandro Mozzoni</strong> Monsanto Co.<br>
+		<strong>Clint Mapel</strong> Dupont Pioneer<br>
+		<strong>Andrew Scaboo</strong> Univ. of Missouri<br>
+		<strong>Aaron Lorenz</strong>, Univ. of Minnesota<br />
+		<strong>John Rupe</strong>, Univ. of Arkansas	
+	</p>
+</div>
 
-<h3>Monday February 22nd, 2016 | Versailles 1 Room</h3>
+
+<h3>Monday February 22nd, 2016</h3>
 
 <table class="uk-table uk-table-small uk-table-hover uk-table-responsive uk-table-divider">
 	<thead>

--- a/community/sbw/SBW/SBW_2016.html
+++ b/community/sbw/SBW/SBW_2016.html
@@ -5,22 +5,20 @@ sitemap: community/sbw
 ---
 
 <h2>2016 SOYBEAN BREEDERS &amp; PATHOLOGISTS WORKSHOP</h2>
-<hr >
-<div>
 <h4>Workshop Coordinators:</h4>
-	<p>
-    	Chris Tinius (chair), Bayer CropScience<br /> 
-		Curtis Scherder, Monsanto Co.<br /> 
-		Leandro Mozzoni Monsanto Co.<br /> 
-		Clint Mapel Dupont Pioneer<br /> 
-		Andrew Scaboo Univ. of Missouri<br /> 
-		Aaron Lorenz, Univ. of Minnesota<br />
-		John Rupe, Univ. of Arkansas	
-	</p>
-</div>
+<p>
+    <strong>Chris Tinius</strong>, (chair), Bayer CropScience;
+	<strong>Curtis Scherder</strong>, Monsanto Co.;
+	<strong>Leandro Mozzoni</strong>, Monsanto Co.;
+	<strong>Clint Mapel</strong>, Dupont Pioneer;
+	<strong>Andrew Scaboo</strong>, Univ. of Missouri;
+	<strong>Aaron Lorenz</strong>, Univ. of Minnesota;
+	<strong>John Rupe</strong>, Univ. of Arkansas	
+</p>
 
 
-<h3>Monday February 22nd, 2016</h3>
+<hr >
+<h3>Monday, February 22nd, 2016</h3>
 <div class="uk-overflow-auto">
 	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
         <thead>
@@ -47,7 +45,7 @@ sitemap: community/sbw
 		
 
 
-<h3>Tuesday Morning February 23rd, 2016</h3>
+<h3>Tuesday, February 23rd, 2016</h3>
 <div class="uk-overflow-auto">
 	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
         <thead>
@@ -85,13 +83,13 @@ sitemap: community/sbw
 			<tr><td>Martin Chilvers, Michigan State Univ.</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Chilvers.pdf">Oomycetes associated with soybean disease and improved molecular diagnostics</a></td></tr>
 			<tr><td>John McDowell, Virginia Tech. Univ.</td><td>Effector-directed breeding as a tool to improve soybean resistance to Phytophthora sojae</td></tr>
 			<tr><td>Aaron Lorenz, Univ. of Minnesota</td><td>Announcements and Adjourn</td></tr>
-			<tr><<td colspan='2' >Social Hour &amp; Poster Session</td></tr>
+			<tr><td colspan='2' >Social Hour &amp; Poster Session</td></tr>
 		</body>
 	</table>
 </div>
 
 
-<h3>Wednesday February 24th, 2016 | Versailles 1 Room</h3>
+<h3>Wednesday February 24th, 2016</h3>
 <div class="uk-overflow-auto">
 	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
         <thead>
@@ -120,7 +118,7 @@ sitemap: community/sbw
 
 <h3>SPECIAL MEETINGS and WORKSHOPS</h3>
 
-<h4>Monday 02/22/2016</h4>
+<h4>Monday, February 22, 2016</h4>
 <div class="uk-overflow-auto">
 	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
         <thead>
@@ -142,7 +140,7 @@ sitemap: community/sbw
 	</table>
 </div>
 
-<h4>Tuesday 02/23/2016</h4>
+<h4>Tuesday, February, 2016</h4>
 <div class="uk-overflow-auto">
 	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
         <thead>
@@ -162,7 +160,7 @@ sitemap: community/sbw
 </div>
 
 
-<h4>Wednesday 02/24/2016</h4>
+<h4>Wednesday, February 24, 2016</h4>
 <div class="uk-overflow-auto">
 	<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
         <thead>
@@ -187,7 +185,7 @@ sitemap: community/sbw
 <h3>Agenda for USB Seed Composition Workshop</h3>
 <h4>February 24th and 25th, 2016 | St. Louis, MO | Sheraton Westport Chalet Hotel</h4>
 <p>The 2016 USB Seed Composition Workshop highlights current research on soybean seed composition and quality traits and presentations on the value and delivery of soybean quality traits to the market.  The workshop will begin immediately after the Soybean Breeders' Workshop and thus begin Wednesday February 24th, 2016 at 11:00 am.  It will be in the St Moritz/Bern conference room of the Sheraton Chalet Hotel.</p>
-<hr >
+
 
 <h4>Wednesday February 24th, 2016</h4>
 <div class="uk-overflow-auto">

--- a/community/sbw/SBW/SBW_2016.html
+++ b/community/sbw/SBW/SBW_2016.html
@@ -112,13 +112,13 @@ Co-Chair, Public Plant Pathologist:  John Rupe, Univ. of Arkansas</p>
 	<tr><td>8:05</td><td>8:10</td><td>Andrew Scaboo, Univ. of Missouri</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Soybean_Genetics_Committee.pdf">Genetics Committee Report</a></td></tr>
 	<tr><td>8:10</td><td>8:15</td><td>Silvia Cianzio, Iowa State Univ.</td><td>Germplasm Committee Report</td></tr>
 	<tr><td>8:15</td><td>8:20</td><td>Kristin Bilyeu, USDA-ARS</td><td>SoyGEC Report</td></tr>
-	<tr><td>8:20</td><td>8:40</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Grant.pdf">David Grant, Iowa State Univ.</a></td><td>SoyBase Update</td></tr>
+	<tr><td>8:20</td><td>8:40</td><td>David Grant, USDA-ARS</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Grant.pdf">SoyBase Update</a></td></tr>
 	<tr><td>8:40</td><td>8:55</td><td>From the Floor</td><td>Retirements and Announcements</td></tr>
-	<tr><td>8:55</td><td>9:10</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Li_v2.pdf">Ling Li, Iowa State Univ.</a></td><td>A molecular tool to increase protein content and broad disease resistance in soybeans</td></tr>
-	<tr><td>9:10</td><td>9:25</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Xavier.pdf">Alencar Xavier, Purdue Univ.</a></td><td>Learning from data: GxE analysis on multiple populations</td></tr>
+	<tr><td>8:55</td><td>9:10</td><td>Ling Li, Iowa State Univ.</a></td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Li_v2.pdf">A molecular tool to increase protein content and broad disease resistance in soybeans</a></td></tr>
+	<tr><td>9:10</td><td>9:25</td><td>Alencar Xavier, Purdue Univ.</a></td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Xavier.pdf">Learning from data: GxE analysis on multiple populations</a></td></tr>
 	<tr><td>9:25</td><td>9:40</td><td>Justin Vaughn, Univ. of Georgia</td><td>Genomic signatures of North American soybean improvement</td></tr>
 	<tr><td>9:40</td><td>10:10</td><td>Henry Nguyen, Univ. of Missouri</td><td>The 1000+ soybean genomes and beyond</td></tr>
-	<tr><td>10:10</td><td>10:40</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Nelson.pdf">Randall Nelson, USDA-ARS</a></td><td>USAID Soybean Innovation Lab:  Increasing soybean production in sub-Saharan Africa</td></tr>
+	<tr><td>10:10</td><td>10:40</td><td>Randall Nelson, USDA-ARS</td><td><a href="https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2016/Nelson.pdf">USAID Soybean Innovation Lab:  Increasing soybean production in sub-Saharan Africa</a></td></tr>
 	<tr><td>10:45</td><td>10:45</td><td colspan='2'>Andrew Scaboo, Univ. of Missouri - Adjourn</td></tr>
 </body>
 </table>
@@ -166,19 +166,19 @@ USB Composition Workshop, Kelly Whiting | 11:00 am - 11:00 am Thursday Feb. 25th
         </tr>
     </thead>
 <tbody>
-	<tr><td>11:00 am</td><td>11:05 am</td><td>Welcome and Introduction to Session </td><td> Mark Leitman, USB staff</td></tr>
-	<tr><td>11:05 am</td><td>11:35 am</td><td> John Brake, North Carolina State University</td><td>Update on development of a tool for carbohydrate breeding: Sucrose content index relative to metabolizable energy content of animal feed </td></tr> 
-	<tr><td>11:35 am</td><td>12:00 pm</td><td> Zenglu Li, University of Georgia</td><td>Prospect of simultaneous genetic gains in yield and protein content in soybean </td></tr>
+	<tr><td>11:00am</td><td>11:05am</td><td> Mark Leitman, USB staff</td><td>Welcome and Introduction to Session</td></tr>
+	<tr><td>11:05am</td><td>11:35am</td><td> John Brake, North Carolina State University</td><td>Update on development of a tool for carbohydrate breeding: Sucrose content index relative to metabolizable energy content of animal feed</td></tr> 
+	<tr><td>11:35am</td><td>12:00pm</td><td> Zenglu Li, University of Georgia</td><td>Prospect of simultaneous genetic gains in yield and protein content in soybean </td></tr>
 
-	<tr><td>12:00 pm</td><td>1:20 pm</td><td>Lunch (on your own)</td></tr>
+	<tr><td>12:00pm</td><td>1:20pm</td><td colspan='2'>Lunch (on your own)</td></tr>
 
-	<tr><td>1:20 pm</td><td>2:20 pm</td><td></td><td>USB Carbohydrate Traits project update</td></tr>
-	<tr><td>2:20 pm</td><td>3:20 pm</td><td></td><td>USB Increased Oil Content project update</td></tr>
-	<tr><td>3:20 pm</td><td>3:40 pm</td><td>Break</td></tr>
-	<tr><td>3:40 pm</td><td>4:40 pm</td><td></td><td>USB Increased Protein Content and Amino Acids project update</td></tr>
-	<tr><td>4:40 pm</td><td>5:40 pm</td><td></td><td>USB Stearic Acid project update</td></tr>
+	<tr><td>1:20pm</td><td>2:20pm</td><td colspan='2'>USB Carbohydrate Traits project update</td></tr>
+	<tr><td>2:20pm</td><td>3:20pm</td><td colspan='2'>USB Increased Oil Content project update</td></tr>
+	<tr><td>3:20pm</td><td>3:40pm</td><td colspan='2'>Break</td></tr>
+	<tr><td>3:40pm</td><td>4:40pm</td><td colspan='2'>USB Increased Protein Content and Amino Acids project update</td></tr>
+	<tr><td>4:40pm</td><td>5:40 pm</td><td colspan='2'>USB Stearic Acid project update</td></tr>
 
-	<tr><td>6:15 pm</td><td></td></td><td>Zermatt Room</td><td>Dinner for USB composition project researchers (only) <div>(Please inform if a vegetarian meal is requested)</div></td></tr><br />
+	<tr><td>6:15pm</td><td> </td><td colspan='2'>Dinner for USB composition project researchers (only)</td></tr><br />
 				
 </tbody>
 </table>
@@ -193,11 +193,11 @@ USB Composition Workshop, Kelly Whiting | 11:00 am - 11:00 am Thursday Feb. 25th
         </tr>
     </thead>
 <tbody>
-	<tr><td>8:00</td><td>8:05 am</td><td>Kelly Whiting, USB staff</td><td>Welcome &amp; Introduction to Session </td></tr>
-	<tr><td>8:05</td><td>9:05 am</td><td>USB High Oleic Breeding project update</td><td></td></tr>
-	<tr><td>9:05</td><td>9:50 am</td><td>Chris Schroeder, Centrec Consulting Group, LLC</td><td>Market Considerations for Extracting Value from Soybean Compositional Enhancement</td></tr>
-	<tr><td>9:50</td><td>10:10 am</td><td>Break</td></tr>
-	<tr><td>10:10</td><td>10:25 am</td><td>Dan Corcoran, USB Farmer-Director</td><td>Update on USB Value Task Force</td></tr>	
-	<tr><td>10:25</td><td>11:00 am</td><td>Gordon Denny, Consultant, Denny LLC</td><td>What Will it Take to Introduce into the Market Soybean Meal Derived from Varieties with Improved Meal Traits</td></tr>
+	<tr><td>8:00am</td><td>8:05am</td><td>Kelly Whiting, USB staff</td><td>Welcome &amp; Introduction to Session </td></tr>
+	<tr><td>8:05am</td><td>9:05am</td><td colspan='2'>USB High Oleic Breeding project update</td></tr>
+	<tr><td>9:05am</td><td>9:50am</td><td>Chris Schroeder, Centrec Consulting Group, LLC</td><td>Market Considerations for Extracting Value from Soybean Compositional Enhancement</td></tr>
+	<tr><td>9:50am</td><td>10:10am</td><td colspan='2'>Break</td></tr>
+	<tr><td>10:10am</td><td>10:25am</td><td>Dan Corcoran, USB Farmer-Director</td><td>Update on USB Value Task Force</td></tr>	
+	<tr><td>10:25am</td><td>11:00am</td><td>Gordon Denny, Consultant, Denny LLC</td><td>What Will it Take to Introduce into the Market Soybean Meal Derived from Varieties with Improved Meal Traits</td></tr>
 </tbody>
 </table>

--- a/community/sbw/SBW/SBW_2017.html
+++ b/community/sbw/SBW/SBW_2017.html
@@ -6,75 +6,62 @@ sitemap: community/sbw
 ---
 
 <h2>2017 SOYBEAN BREEDERS & PHYSIOLOGISTS WORKSHOP</h2>
-<hr >
-<h3>Registration in Versailles Foyer:</h3>
-Monday, Feb. 13th, 10:30AM - 5PM | Tuesday, Feb. 14th, 7AM - 5PM | Wednesday, Feb. 15th, 7 - 10:30AM
 
+<h4>Workshop Coordinators:</h4>
+<p>
+    <strong>Andrew Scaboo</strong>,(Chair) Univ. of Missouri; 
+    <strong>Evelyn Ortiz-Perez</strong>, Dow AgroSciences;
+    <strong>Curtis Scherder</strong>, Monsanto Co.; 
+    <strong>Leandro Mozzoni</strong>, Monsanto Co.; 
+    <strong>Clint Mapel</strong>, Pioneer; 
+    <strong>Luciano Jaureguy</strong>, Dow AgroSciences;
+    <strong>Bo Zhang</strong>, Virginia Tech.;
+    <strong>Felix Fritschi</strong>, Univ. of Missouri
+</p>
 <hr />
-<h3>Workshop Coordinators:</h3>
-<p><strong>Andrew Scaboo</strong> (Soybean Breeder), Univ. of Missouri - Overall planning and coordination <br />
-Commercial Soybean Breeders - <strong>Evelyn Ortiz-Perez</strong> (Dow AgroSciences), <strong>Curtis Scherder</strong> (Monsanto Co.), <strong>Leandro Mozzoni</strong> (Monsanto Co.), <strong>Clint Mapel</strong> (Pioneer), <strong>Luciano Jaureguy</strong> (Dow AgroSciences)<br />
-<strong>Bo Zhang</strong> (Soybean Breeder), Virginia Tech. - Program Chair, Tuesday General Session<br />
-<strong>Felix Fritschi</strong> (Crop Physiologist), Univ. of Missouri - Program Co-Chair, Tuesday General Session</p>
 
-
-<h3>Monday February 13th, 2017 | Versailles 1 Room</h3>
-
+<h3>Monday February 13th, 2017</h3>
 <div class="uk-overflow-auto">
-<table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
-    <thead>
-        <tr>
-            <th class="uk-table-shrink">Start</th>
-            <th class="uk-table-shrink">End</th>
-            <th class="uk-table-expand">Speaker</th>
-            <th class="uk-table-expand">Topic</th>
-        </tr>
-    </thead>
-<body>
-    <tr><td>1:00</td><td>1:15</td><td>Andrew Scaboo, Univ. of Missouri</td><td>Welcome and announcements<br />Recognition of SBW organizers and CSB</td></tr>
-    <tr><th colspan='4'>SESSION I: Precision Ag</th></tr>
-    <tr><td>1:15</td><td>2:00</td><td>Alex Barreiro, Climate Corp. </td><td>Using big data and digital ag. to improve decision making for growers</td></tr>
-    <tr><td>2:00</td><td>2:30</td><td>Larry Purcell, Univ. of Arkansas</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Purcell_et_al_SB_Breeders_Workshop_SOYRISK_St._Louis.pdf'>Optimizing returns and decreasing production risks by managing maturity groups and planting dates for specific locations in the Midsouth</a></td></tr>
-    <tr><td>2:30</td><td>2:45</td><td>Roger Boerma, GSDC</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Dr._Arnold_Matson_SBW_Feb_2017.pdf'>Recognition of Arnold Matson</a></td></tr>
-    <tr><td>2:45</td><td>3:10</td><td colspan='2'>Break</td></tr>
-    <tr><th colspan='4'>SESSION II: NIR for Soybean Improvement</th></tr>
-    <tr><td>3:10</td><td>3:30</td><td>George Graef, Univ. of Nebraska</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/GGraef_NIRS_Breeders_workshop_Feb2017.pdf'>NIRS data in breeding, publications, and databases: Needs for standards and equivalency assessment</a></td></tr>
-    <tr><td>3:30</td><td>4:00</td><td>Charlie Hurburgh, Iowa State Univ.</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/USB_2017-02-13.pdf'>How to have an NIR program that gives accurate data for selections</a></td></tr>
-    <tr><td>4:00</td><td>4:30</td><td>Jason Gillman, USDA-ARS</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Gillman_02142016_NIR_presentation.pdf'>Application of NIR spectroscopy for seed composition improvement in soybean</a></td></tr>
-    <tr><td>4:30</td><td>4:55</td><td>Rich Joost, USB</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Joost_2017_USB_Update_Breeders_Workshop.pdf'>USB Update</a></td></tr>
-    <tr><td>4:55</td><td>5:00</td><td>Andrew Scaboo, Univ. of Missouri</td><td>Announcements and Adjourn</td></tr>
-</body>
-</table>
+    <table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
+        <thead>
+            <tr>
+                <th class="uk-table-expand">Speaker</th>
+                <th class="uk-table-expand">Topic</th>
+            </tr>
+        </thead>
+        <body>
+            <tr><td>Andrew Scaboo, Univ. of Missouri</td><td>Welcome and announcements<br />Recognition of SBW organizers and CSB</td></tr>
+            <tr><th colspan='2'>SESSION I: Precision Ag</th></tr>
+            <tr><td>Alex Barreiro, Climate Corp.</td><td>Using big data and digital ag. to improve decision making for growers</td></tr>
+            <tr><td>Larry Purcell, Univ. of Arkansas</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Purcell_et_al_SB_Breeders_Workshop_SOYRISK_St._Louis.pdf'>Optimizing returns and decreasing production risks by managing maturity groups and planting dates for specific locations in the Midsouth</a></td></tr>
+            <tr><td>Roger Boerma, GSDC</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Dr._Arnold_Matson_SBW_Feb_2017.pdf'>Recognition of Arnold Matson</a></td></tr>
+            <tr><td colspan='2'>Break</td></tr>
+            <tr><th colspan='2'>SESSION II: NIR for Soybean Improvement</th></tr>
+            <tr><td>George Graef, Univ. of Nebraska</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/GGraef_NIRS_Breeders_workshop_Feb2017.pdf'>NIRS data in breeding, publications, and databases: Needs for standards and equivalency assessment</a></td></tr>
+            <tr><td>Charlie Hurburgh, Iowa State Univ.</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/USB_2017-02-13.pdf'>How to have an NIR program that gives accurate data for selections</a></td></tr>
+            <tr><td>Jason Gillman, USDA-ARS</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Gillman_02142016_NIR_presentation.pdf'>Application of NIR spectroscopy for seed composition improvement in soybean</a></td></tr>
+            <tr><td>Rich Joost, USB</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Joost_2017_USB_Update_Breeders_Workshop.pdf'>USB Update</a></td></tr>
+            <tr><td>Andrew Scaboo, Univ. of Missouri</td><td>Announcements and Adjourn</td></tr>
+        </body>
+    </table>
 </div>
-<h3>Tuesday Morning February 14th, 2017</h3>
 
-<h4>Continental Breakfast | 7:00 am - 8:00 am| Versailles Foyer</h4>
-Hosted by the Commercial Soybean Breeders
-
-
-<h3>Tuesday February 14th, 2017 | Versailles 1 Room</h3>
-<h4>General Session</h4>
-<p>Chair, Public Soybean Breeder: Bo Zhang - Virginia Tech.<br />
-Co-Chair, Public Crop Physiologist: Felix Fritschi - Univ. of Missouri  </p>
-
+<h3>Tuesday February 14th, 2017</h3>
 <div class="uk-overflow-auto">
-<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
-    <thead>
-        <tr>
-            <th class="uk-table-shrink">Start</th>
-            <th class="uk-table-shrink">End</th>
-            <th class="uk-table-expand">Speaker</th>
-            <th class="uk-table-expand">Topic</th>
-        </tr>
-    </thead>
-<tbody>
-    <tr><td>7:00</td><td>8:00</td><td colspan='2'>Continental Breakfast, Versailles Foyer</td></tr>
-    <tr><td>8:00</td><td>8:05</td><td>Bo Zhang, Virginia Tech. Univ.</td><td>General Introduction</td></tr>
-    <tr><th colspan='4'>SESSION I: Abiotic Stress and Soybean Response Mechanisms<br />Session Chair - Jason Gillman, USDA-ARS</th></tr>
-    <tr><td>8:05</td><td>8:35</td><td>Larry Purcell, Univ. of Arkansas</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Purcell_SB_Breeders_Workshop_Wilting_GWAS_2_14_17.pdf'>Genotypic diversity and GWAS of canopy wilting among maturity group IV accessions</a></td></tr>
-    <tr><td>8:35</td><td>9:05</td><td>Alvaro Sanz Saez De Jauregui, Univ. of Missouri</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Sanz-Saez_et_al.,_2017.pdf'>Identification and introgression of high WUE to improve soybean drought adaptation</a></td></tr>
-    <tr><td>9:05</td><td>9:35</td><td>Patricio Grassini, Univ. of Nebraska</td><td>From plot to field: Technology extrapolation domains in agriculture</td></tr>
-    <tr><td>9:35</td><td>10:05</td><td>Gary Stacey, Univ. of Missouri</td><td>Can biological nitrogen fixation research improve soybean yield?</td></tr>
+    <table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+        <thead>
+            <tr>
+                <th class="uk-table-expand">Speaker</th>
+                <th class="uk-table-expand">Topic</th>
+            </tr>
+        </thead>
+        <body>
+            <tr><td>Bo Zhang, Virginia Tech. Univ.</td><td>General Introduction</td></tr>
+            <tr><th colspan='2'>SESSION I: Abiotic Stress and Soybean Response Mechanisms | Chair: Jason Gillman, USDA-ARS</th></tr>
+            <tr><td>Larry Purcell, Univ. of Arkansas</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Purcell_SB_Breeders_Workshop_Wilting_GWAS_2_14_17.pdf'>Genotypic diversity and GWAS of canopy wilting among maturity group IV accessions</a></td></tr>
+            <tr><td>Alvaro Sanz Saez De Jauregui, Univ. of Missouri</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Sanz-Saez_et_al.,_2017.pdf'>Identification and introgression of high WUE to improve soybean drought adaptation</a></td></tr>
+            <tr><td>Patricio Grassini, Univ. of Nebraska</td><td>From plot to field: Technology extrapolation domains in agriculture</td></tr>
+            <tr><td>Gary Stacey, Univ. of Missouri</td><td>Can biological nitrogen fixation research improve soybean yield?</td></tr>
     <tr><td>10:05</td><td>10:20</td><td colspan='2'>Coffee Break</td></tr>
     <tr><td>10:20</td><td>10:50</td><td>Krishna Jagadish, Kansas State Univ.</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Jagadish_et_al_Soybean_Breeders_meet_FINAL_MO.pdf'>Soybeans resilience to heat and drought stress during flowering and pod filling - current status, challenges and opportunities</a></td></tr>
     <tr><td>10:50</td><td>11:20</td><td>Moldir Orazaly, Univ. of Arkansas</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Screening,_breeding,_and_mapping_for_flood_in_soybean.pdf'>Screening, mapping, and breeding for flood tolerance in soybean</a></td></tr>

--- a/community/sbw/SBW/SBW_2017.html
+++ b/community/sbw/SBW/SBW_2017.html
@@ -122,7 +122,7 @@ sitemap: community/sbw
             <tr><td>Jennifer Jones</td><td>Soybean Genomics Executive Committee</td></tr>
             <tr><td>Troy Cary</td><td>Technicians Workshop</td></tr>
             <tr><td>Evelyn Ortiz-Perez</td><td>Commercial Soybean Breeders’ Business Meeting</td></tr>
-            <tr><td>David Grant</td><td> <a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/SoyGenetComm_SBW_2017.pdf'>Soybean Genetics Committee</a></td></tr>
+            <tr><td>David Grant</td><td> <a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/SoyGenetComm_SBW_2017.pdf'>Soybean Genetics Committee</a></td></tr>
             <tr><td>Kelly Whiting</td><td>Combining QT and Northern/Southern UT</td></tr>
             <tr><td>George Graef</td><td>Quality Traits</td></tr>
         </body>
@@ -130,12 +130,7 @@ sitemap: community/sbw
 </div>
 
 
-
-
-
-
-
-<h4>Tuesday, February, 14, 2017</h4>
+<h4>Tuesday, February 14, 2017</h4>
 <div class="uk-overflow-auto">
     <table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
         <thead>
@@ -155,65 +150,75 @@ sitemap: community/sbw
 
 
 
-<h3>Wednesday 02/15/2017</h3>
-<p>Continental Breakfast | 6:45 am - 8:00 am | Versailles Foyer</p>
-<p>Public-Private Southern Breeders’ Meeting, Zenglu Li | 7:00 am - 8:00 am | Alpine II room</p>
-<p>USB Composition Workshop, Kelly Whiting | 11:00 am - 5:40 pm | St. Moritz and Bern room</p>
+<h4>Wednesday, February 15, 2017</h4>
+<div class="uk-overflow-auto">
+    <table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+        <thead>
+            <tr>
+                <th class="uk-table-expand">Speaker</th>
+                <th class="uk-table-expand">Topic</th>
+            </tr>
+        </thead>
+        <body>
+            <tr><td>Zenglu Li</td><td>Public-Private Southern Breeders’ Meeting</td></tr>
+        </body>
+    </table>
+</div>
 
 
-<h3>Agenda for USB Composition Workshop</h3>
-<h3>February 15th and 16th, 2017 | St. Louis, MO | Sheraton Westport Chalet Hotel</h3>
+<h2>Agenda for USB Composition Workshop</h2>
+<h4>February 15th and 16th, 2017 | St. Louis, MO | Sheraton Westport Chalet Hotel</h4>
 <p>The 2017 USB Composition Workshop highlights current research on soybean seed composition and quality traits and includes presentations on the value and delivery of soybean quality traits to the market. The workshop will begin immediately after the Soybean Breeders’ Workshop and thus begin Wednesday February 15th at 11:00 am.  It will be in the St Moritz/Bern conference room of the Westport Sheraton Chalet Hotel.</p>
-<h3>Wednesday February 15th </h3>
+<hr > 
 
-<table class="uk-table uk-table-small uk-table-hover uk-table-responsive uk-table-divider">
-    <thead>
-        <tr>
-            <th class="uk-table-shrink">Start</th>
-            <th class="uk-table-shrink">End</th>
-            <th class="uk-table-expand">Speaker</th>
-            <th class="uk-table-expand">Topic</th>
-        </tr>
-    </thead>
+<h4>Wednesday, February 15, 2017</h4>
+<div class="uk-overflow-auto">
+    <table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+        <thead>
+            <tr>
+                <th class="uk-table-expand">Speaker</th>
+                <th class="uk-table-expand">Topic</th>
+            </tr>
+        </thead>
+        <body>
+            <tr><td>Kelly Whiting, USB staff</td><td>Welcome and Introduction to Session</td></tr>
+            <tr><td>Don Banks, Edible Oil Technology</td><td>Current and prospective opportunity for development of soybean oil for the saturated/solid fat and baking goods market</td></tr>
+            <tr><td>Jason Gillman, USDA-ARS Columbia Missouri</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Gillman_2017_final_report_soybean_breeders_workshop_Stearic_acid_project.pdf'>Final report of the USB Stearic Acid breeding and genetics project</a></td></tr>
+            <tr><td>Richard Galloway, Galloway and Associates</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Richard_Galloway_2-15-17.pdf'>Status and prospect of applying inter-esterification of soybean oil for the saturated/solid fat and baking goods market</a></td></tr>
+            <tr><td colspan='2'>Lunch (on your own)</td></tr>
+            <tr><td>Leah McHale, Ohio State University</td><td>USB Increased Oil Content project update</td></tr>
+            <tr><td>Rouf Mian, USDA-ARS Raleigh NC</td><td>USB Increased Protein Content and Amino Acids project update</td></tr>
+            <tr><td colspan='2'>Break</td></tr>
+            <tr><td>Katy Rainey, Purdue University</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Rainey_carbohydrate_sources.pdf'>USB Carbohydrate Traits project update</a></td></tr>
+            <tr><td>Kristin Bilyeu, USDA-ARS Columbia, MO</td><td>USB High Oleic Breeding project update</td></tr>
+            <tr><td colspan='2'>Dinner for USB composition project researchers (only)</td></tr>
+        </body>
+    </table>
+</div>
 
-<tbody>
-    <tr><td>11:00am</td><td>11:05am</td><td>Kelly Whiting, USB staff</td><td>Welcome and Introduction to Session</td></tr>
-    <tr><td>11:05am</td><td>11:25am</td><td>Don Banks, Edible Oil Technology</td><td>Current and prospective opportunity for development of soybean oil for the saturated/solid fat and baking goods market</td></tr>
-    <tr><td>11:25am</td><td>11:45</td><td>Jason Gillman, USDA-ARS Columbia Missouri</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Gillman_2017_final_report_soybean_breeders_workshop_Stearic_acid_project.pdf'>Final report of the USB Stearic Acid breeding and genetics project</a></td></tr>
-    <tr><td>11:45am</td><td>12:00pm</td><td>Richard Galloway, Galloway and Associates</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Richard_Galloway_2-15-17.pdf'>Status and prospect of applying inter-esterification of soybean oil for the saturated/solid fat and baking goods market</a></td></tr>
-    <tr><td>12:00pm</td><td>1:20pm</td><td colspan='2'>Lunch (on your own)</td></tr>
-    <tr><td>1:20pm</td><td>2:20pm</td><td>Leah McHale, Ohio State University</td><td>USB Increased Oil Content project update</td></tr>
-    <tr><td>2:20pm</td><td>3:20pm</td><td>Rouf Mian, USDA-ARS Raleigh NC</td><td>USB Increased Protein Content and Amino Acids project update</td></tr>
-    <tr><td>3:20pm</td><td>3:40pm</td><td colspan='2'>Break</td></tr>
-    <tr><td>3:40pm</td><td>4:40pm</td><td>Katy Rainey, Purdue University</td> <a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Rainey_carbohydrate_sources.pdf'>USB Carbohydrate Traits project update</a></td></tr>
-    <tr><td>4:40pm</td><td>5:40pm</td><td>Kristin Bilyeu, USDA-ARS Columbia, MO</td><td>USB High Oleic Breeding project update</td></tr>
-    <tr><td>6:15pm</td><td colspan='3'>Dinner for USB composition project researchers (only) - Zermatt Room</td></tr>
-</tbody>
-</table>
-
-<h3>Thursday February 16th </h3>
-<table class="uk-table uk-table-small uk-table-hover uk-table-responsive uk-table-divider">
-    <thead>
-        <tr>
-            <th class="uk-table-expand">Start</th>
-            <th class="uk-table-expand">End</th>
-            <th class="uk-table-expand">Speaker</th>
-            <th class="uk-table-expand">Topic</th>
-        </tr>
-    </thead>
-    <tbody>
-    <tr><td>8:00am</td><td>8:05am</td><td>Kelly Whiting, USB staff</td><td>Welcome & Introduction to Session</td></tr>
-    <tr><td>8:05am</td><td>8:20am</td><td>Rich Joost, USB staff</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Joost_VTF_Objectives_pre.pdf'>USB Value Task Force Objectives</a></td></tr>
-    <tr><td>8:20am</td><td>8:40am</td><td>Gordon Denny, Gordon Denny LLC</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Seed_St_Louis_Feb162017_G_Denny.pdf'>Feedback from processors: specs., nutrient density, test weight </a></td></tr>
-    <tr><td>8:40am</td><td>9:05am</td><td>Reid Rice, DuPont-Pioneer</td><td>USB project with DuPont Pioneer to increase protein content, and high oleic update</td></tr>
-    <tr><td>9:05am</td><td>9:25am</td><td>Lanny Ashlock, Natural Soy and Grain Alliance, Arkansas</td><td>Marketing high protein varieties: the Arkansas model</td></tr>
-    <tr><td>9:25am</td><td>9:45am </td><td colspan='2'>Future of soybean variety development including quality traits at Bayer Crop Science</td></tr>
-    <tr><td>9:45am</td><td>10:05am</td><td colspan='2'>Break</td></tr>
-    <tr><td>10:05am</td><td>10:35am</td><td>Doug Allen, USDA-ARS, Danforth Plant Science Center, St Louis</td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Breeders_Workshop_2017b.pdf'>Feasibility of drawing carbon for additional protein and oil in soybean seed from soluble or insoluble (fiber) carbohydrates</a></td></tr>
-    <tr><td>10:35am</td><td>10:55am</td><td>John Schillinger, of Schillinger Genetics Inc.</td><td>Development of high oleic soybean varieties at Schillinger Genetics</td></tr>
-    <tr><td>10:55am</td><td>11:10am</td><td>Katy Rainey, Purdue University</td><td>Genetic sources of increased sugar content in soybean</td></tr>
-    <tr><td>11:10am</td><td>11:25am</td><td>Vince Pantalone, University of Tennessee</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Pantalone_2017_Amino_Acid_Genetic_Variation.pdf'>Genetic variation and quantification of amino acids in soybean seed</a></td></tr>
-    <tr><td>11:25am</td><td>11:45am</td><td>Nick Bajjalieh, Integrative Nutrition Inc., Decatur IL</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Bajjalieh_2.16.2017.pdf'>Capturing value of key amino acids of soybean</a></td></tr>
-    <tr><td>11:45am</td><td>12:00pm</td><td>Kelly Whiting, USB staff</td><td>Wrap-up</td></tr>
-</tbody>
-</table>
+<h4>Thursday, February 16, 2017</h4>
+<div class="uk-overflow-auto">
+    <table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+        <thead>
+            <tr>
+                <th class="uk-table-expand">Speaker</th>
+                <th class="uk-table-expand">Topic</th>
+            </tr>
+        </thead>
+        <body>
+            <tr><td>Kelly Whiting, USB staff</td><td>Welcome & Introduction to Session</td></tr>
+            <tr><td>Rich Joost, USB staff</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Joost_VTF_Objectives_pre.pdf'>USB Value Task Force Objectives</a></td></tr>
+            <tr><td>Gordon Denny, Gordon Denny LLC</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Seed_St_Louis_Feb162017_G_Denny.pdf'>Feedback from processors: specs., nutrient density, test weight </a></td></tr>
+            <tr><td>Reid Rice, DuPont-Pioneer</td><td>USB project with DuPont Pioneer to increase protein content, and high oleic update</td></tr>
+            <tr><td>Lanny Ashlock, Natural Soy and Grain Alliance, Arkansas</td><td>Marketing high protein varieties: the Arkansas model</td></tr>
+            <tr><td colspan='2'>Future of soybean variety development including quality traits at Bayer Crop Science</td></tr>
+            <tr><td colspan='2'>Break</td></tr>
+            <tr><td>Doug Allen, USDA-ARS, Danforth Plant Science Center, St Louis</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Breeders_Workshop_2017b.pdf'>Feasibility of drawing carbon for additional protein and oil in soybean seed from soluble or insoluble (fiber) carbohydrates</a></td></tr>
+            <tr><td>John Schillinger, of Schillinger Genetics Inc.</td><td>Development of high oleic soybean varieties at Schillinger Genetics</td></tr>
+            <tr><td>Katy Rainey, Purdue University</td><td>Genetic sources of increased sugar content in soybean</td></tr>
+            <tr><td>Vince Pantalone, University of Tennessee</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Pantalone_2017_Amino_Acid_Genetic_Variation.pdf'>Genetic variation and quantification of amino acids in soybean seed</a></td></tr>
+            <tr><td>Nick Bajjalieh, Integrative Nutrition Inc., Decatur IL</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Bajjalieh_2.16.2017.pdf'>Capturing value of key amino acids of soybean</a></td></tr>
+            <tr><td>Kelly Whiting, USB staff</td><td>Wrap-up</td></tr>
+        </body>
+    </table>
+</div>

--- a/community/sbw/SBW/SBW_2017.html
+++ b/community/sbw/SBW/SBW_2017.html
@@ -62,73 +62,98 @@ sitemap: community/sbw
             <tr><td>Alvaro Sanz Saez De Jauregui, Univ. of Missouri</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Sanz-Saez_et_al.,_2017.pdf'>Identification and introgression of high WUE to improve soybean drought adaptation</a></td></tr>
             <tr><td>Patricio Grassini, Univ. of Nebraska</td><td>From plot to field: Technology extrapolation domains in agriculture</td></tr>
             <tr><td>Gary Stacey, Univ. of Missouri</td><td>Can biological nitrogen fixation research improve soybean yield?</td></tr>
-    <tr><td>10:05</td><td>10:20</td><td colspan='2'>Coffee Break</td></tr>
-    <tr><td>10:20</td><td>10:50</td><td>Krishna Jagadish, Kansas State Univ.</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Jagadish_et_al_Soybean_Breeders_meet_FINAL_MO.pdf'>Soybeans resilience to heat and drought stress during flowering and pod filling - current status, challenges and opportunities</a></td></tr>
-    <tr><td>10:50</td><td>11:20</td><td>Moldir Orazaly, Univ. of Arkansas</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Screening,_breeding,_and_mapping_for_flood_in_soybean.pdf'>Screening, mapping, and breeding for flood tolerance in soybean</a></td></tr>
-    <tr><td>11:20</td><td>11:50</td><td>Carl Bernacchi, Univ. of Illinois</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Bernacchi_Soybean_Breeders_Workshop_2017.pdf'>Understanding soybean responses to global changes: Impacts and adaptations</a></td></tr>
-    <tr><td>11:50</td><td>1:00</td><td colspan='2'>Lunch</td></tr>
-    <tr><td>1:00</td><td>1:05</td><td>Bo Zhang, Virginia Tech. Univ.</td><td>Introduction and Announcements</td></tr>
-    <tr><th colspan='4'>SESSION II:  Phenomics, Genomics, and Crop Management<br />Session Chair - Andrew Scaboo, Univ. of Missouri</th></tr>
-    <tr><td>1:05</td><td>1:35</td><td>Danny Singh, Iowa State Univ.</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Danny_Singh_2017_SBW_Feb_14_FINAL.pdf'>Phenomics tools</a></td></tr>
-    <tr><td>1:35</td><td>2:05</td><td>Montse Salmeron, Univ. of Kentucky</td><td>Analysis of the role of environment in soybean across MG cultivars: Observed and simulated data</td></tr>
-    <tr><td>2:05</td><td>2:35</td><td>Katy Rainey, Purdue Univ.</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Rainey_carbohydrate_sources.pdf'>Genetic Architecture of Phenomic-enabled Canopy Coverage in Soybean</a></td></tr>
-    <tr><td>2:35</td><td>3:05</td><td>Neil Yu, Monsanto Co.</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/SBW_2017_NEIL_YU.pdf'>Using UAV to improve yield estimation and predict maturity in soybean breeding</a></td></tr>
-    <tr><td>3:05</td><td>3:20</td><td colspan='2'>Break</td></tr>
-    <tr><td>3:20</td><td>3:50</td><td>Istvan Rajcan, Univ. of Guelph</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Organic_soybean_breeding_SBW_2017.pdf'>Organic Soybean Breeding</a></td></tr>
-    <tr><td>3:50</td><td>4:20</td><td>Charles An, USDA-ARS</td><td>Functional genomics of soybean seeds and genetic diversity</td></tr>
-    <tr><td>4:20</td><td>4:50</td><td>Qijian Song, USDA-ARS</td><td>BARCSOYSNP6K Beadchip: A breeder’s tool for soybean genetic research</td></tr>
-    <tr><td>4:50</td><td>5:00</td><td>Bo Zhang, Virginia Tech. Univ.</td><td>Announcements and adjourn</td></tr>
-    <tr><td>5:30</td><td>6:30</td><td colspan='2'>Social Hour & Poster Session, Foyer & Versailles 2</td></tr>
-</tbody>
-</table>
+            <tr><td colspan='2'>Coffee Break</td></tr>
+            <tr><td>>Krishna Jagadish, Kansas State Univ.</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Jagadish_et_al_Soybean_Breeders_meet_FINAL_MO.pdf'>Soybeans resilience to heat and drought stress during flowering and pod filling - current status, challenges and opportunities</a></td></tr>
+            <tr><td>Moldir Orazaly, Univ. of Arkansas</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Screening,_breeding,_and_mapping_for_flood_in_soybean.pdf'>Screening, mapping, and breeding for flood tolerance in soybean</a></td></tr>
+            <tr><td>Carl Bernacchi, Univ. of Illinois</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Bernacchi_Soybean_Breeders_Workshop_2017.pdf'>Understanding soybean responses to global changes: Impacts and adaptations</a></td></tr>
+            <tr><td colspan='2'>Lunch</td></tr>
+            <tr><td>Bo Zhang, Virginia Tech. Univ.</td><td>Introduction and Announcements</td></tr>
+            <tr><th colspan='2'>SESSION II:  Phenomics, Genomics, and Crop Management | Chair: Andrew Scaboo, Univ. of Missouri</th></tr>
+            <tr><td>Danny Singh, Iowa State Univ.</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Danny_Singh_2017_SBW_Feb_14_FINAL.pdf'>Phenomics tools</a></td></tr>
+            <tr><td>Montse Salmeron, Univ. of Kentucky</td><td>Analysis of the role of environment in soybean across MG cultivars: Observed and simulated data</td></tr>
+            <tr><td>Katy Rainey, Purdue Univ.</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Rainey_carbohydrate_sources.pdf'>Genetic Architecture of Phenomic-enabled Canopy Coverage in Soybean</a></td></tr>
+            <tr><td>Neil Yu, Monsanto Co.</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/SBW_2017_NEIL_YU.pdf'>Using UAV to improve yield estimation and predict maturity in soybean breeding</a></td></tr>
+            <tr><td colspan='2'>Break</td></tr>
+            <tr><td>Istvan Rajcan, Univ. of Guelph</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Organic_soybean_breeding_SBW_2017.pdf'>Organic Soybean Breeding</a></td></tr>
+            <tr><td>Charles An, USDA-ARS</td><td>Functional genomics of soybean seeds and genetic diversity</td></tr>
+            <tr><td>Qijian Song, USDA-ARS</td><td>BARCSOYSNP6K Beadchip: A breeder’s tool for soybean genetic research</td></tr>
+            <tr><td>Bo Zhang, Virginia Tech. Univ.</td><td>Announcements and adjourn</td></tr>
+            <tr><td colspan='2'>Social Hour & Poster Session</td></tr>
+        </body>
+    </table>
 </div>
 
-<h3>Wednesday February 15th, 2017 | Versailles 1 Room</h3>
-
+<h3>Wednesday February 15th, 2017</h3>
 <div class="uk-overflow-auto">
-<table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
-    <thead>
-        <tr>
-            <th class="uk-table-shrink">Start</th>
-            <th class="uk-table-shrink">End</th>
-            <th class="uk-table-expand">Speaker</th>
-            <th class="uk-table-expand">Topic</th>
-        </tr>
-    </thead>
-<body>
-    <tr><td>7:00</td><td>8:00</td><td colspan='2'>Continental Breakfast, Versailles Foyer</td></tr>
-    <tr><td>8:00</td><td>8:10</td><td>Andrew Scaboo, Univ. of Missouri<br />Evelyn Ortiz Perez, Dow AgroSciences</td><td>Announcements<br />Poster Winners Announced</td></tr>
-    <tr><td>8:10</td><td>8:25</td><td>Zenglu Li, Univ. of Georgia</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Soybean_Germplasm_Committee_Report-Zenglu_Li.pdf'>Germplasm Committee Report</a></td></tr>
-    <tr><td>8:25</td><td>8:40</td><td>Michelle Graham, USDA-ARS</td><td>SoyGEC Report</td></tr>
-    <tr><td>8:40</td><td>9:10</td><td>David Grant, USDA-ARS </td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/SoyGenetComm_SBW_2017.pdf'>Soybean Genetics Committee Report</a> and <a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/SoyBase_update_SBW_2017.pdf'>SoyBase.org update</a></td></tr>
-    <tr><td>9:10</td><td>9:30</td><td>From the Floor</td><td>Retirements and Announcements</td></tr>
-    <tr><td>9:30</td><td>10:00</td><td>Siddhi Bhusal, Univ. of Minnesota</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/SBW_SJBhusal.pdf'>Evaluation and identification of soybean aphid resistance sources and mapping of soybean aphid resistance loci in early maturing soybean germplasm</a></td></tr>
-    <tr><td>10:00</td><td>10:30</td><td>Brian Diers, Univ. of Illinois</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Protein_talk_2017_SBW.pdf'>Protein and oil QTL and their associated impact on agronomic traits</a></td></tr>
-    <tr><td>10:30</td><td>10:35</td><td>Andrew Scaboo, Univ. of Missouri</td><td>Adjourn</td></tr>
-</body>
-</table>
+    <table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+        <thead>
+            <tr>
+                <th class="uk-table-expand">Speaker</th>
+                <th class="uk-table-expand">Topic</th>
+            </tr>
+        </thead>
+        <body>
+            <tr><td>Andrew Scaboo, Univ. of Missouri<br />Evelyn Ortiz Perez, Dow AgroSciences</td><td>Announcements & Poster Winners Announced</td></tr>
+            <tr><td>Zenglu Li, Univ. of Georgia</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Soybean_Germplasm_Committee_Report-Zenglu_Li.pdf'>Germplasm Committee Report</a></td></tr>
+            <tr><td>Michelle Graham, USDA-ARS</td><td>SoyGEC Report</td></tr>
+            <tr><td>David Grant, USDA-ARS </td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/SoyGenetComm_SBW_2017.pdf'>Soybean Genetics Committee Report</a> and <a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/SoyBase_update_SBW_2017.pdf'>SoyBase.org update</a></td></tr>
+            <tr><td>From the Floor</td><td>Retirements and Announcements</td></tr>
+            <tr><td>Siddhi Bhusal, Univ. of Minnesota</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/SBW_SJBhusal.pdf'>Evaluation and identification of soybean aphid resistance sources and mapping of soybean aphid resistance loci in early maturing soybean germplasm</a></td></tr>
+            <tr><td>Brian Diers, Univ. of Illinois</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Protein_talk_2017_SBW.pdf'>Protein and oil QTL and their associated impact on agronomic traits</a></td></tr>
+            <tr><td>Andrew Scaboo, Univ. of Missouri</td><td>Adjourn</td></tr>
+        </body>
+    </table>
 </div>
 
 <h3>SPECIAL MEETINGS and WORKSHOPS</h3>
 
-<h3>Monday 02/13/2017</h3>
-<p>SoyBase Workshop, David Grant | 8:30 am - 10:00 am | Alpine II room</p>
-<p><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Soybean_Germplasm_Committee_Report-Zenglu_Li.pdf'>Soybean Germplasm Committee, Zenglu Li</a> | 8:00 am - 9:30 am | Alpine I room</p>
-<p>Soybean Genomics Executive Committee, Jennifer Jones | 10:00 am - 12:00 pm | Zermatt Room</p>
-<p>Technicians Workshop, Troy Cary | 1:00 pm - 5:00 pm | St. Moritz and Bern room </p>
-<p>Commercial Soybean Breeders’ Business Meeting, Evelyn Ortiz-Perez | 5:30 pm - 6:30 pm | Alpine I room</p>
-<p><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/SoyGenetComm_SBW_2017.pdf'>Soybean Genetics Committee, David Grant</a> | 7:00 pm - 8:00 pm | Davos room </p>
-<p>Combining QT and Northern/Southern UT, Kelly Whiting | 7:00 pm - 8:00 pm | St. Moritz and Bern room</p>
-<p>Quality Traits, George Graef | 8:00 pm - 9:00 pm | St. Moritz and Bern room</p>
+<h4>Monday, February 13, 2017</h4>
+<div class="uk-overflow-auto">
+    <table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+        <thead>
+            <tr>
+                <th class="uk-table-expand">Speaker</th>
+                <th class="uk-table-expand">Topic</th>
+            </tr>
+        </thead>
+        <body>
+            <tr><td>David Grant</td><td>SoyBase Workshop</td></tr>
+            <tr><td>Zenglu Li</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Soybean_Germplasm_Committee_Report-Zenglu_Li.pdf'>Soybean Germplasm Committee</a></td></tr>
+            <tr><td>Jennifer Jones</td><td>Soybean Genomics Executive Committee</td></tr>
+            <tr><td>Troy Cary</td><td>Technicians Workshop</td></tr>
+            <tr><td>Evelyn Ortiz-Perez</td><td>Commercial Soybean Breeders’ Business Meeting</td></tr>
+            <tr><td>David Grant</td><td> <a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/SoyGenetComm_SBW_2017.pdf'>Soybean Genetics Committee</a></td></tr>
+            <tr><td>Kelly Whiting</td><td>Combining QT and Northern/Southern UT</td></tr>
+            <tr><td>George Graef</td><td>Quality Traits</td></tr>
+        </body>
+    </table>
+</div>
 
-<h3>Tuesday 02/14/2017</h3>
-<p>Continental Breakfast | 6:30 am - 8:00 am | Versailles Foyer</p>
-<p>Technicians Workshop, Troy Cary | 8:00 am - 12:00 pm | St. Moritz and Bern room</p>
-<p>Social Hour | 5:30 pm - 6:30 pm | Versailles Foyer</p>
-<p>Poster Session | 5:30 pm - 6:30 pm | Versailles 2 room</p>
-<p>Uniform Regional Testing: South, Anne Gillen | 7:00 pm - 8:00 pm | Davos room</p>
-<p>Uniform Regional Testing: North, Gary Nowling | 7:00 pm - 7:30 pm | Alpine II room</p>
-<p>SCN Regional Testing, Troy Cary | 7:30 pm - 8:00 pm | Alpine II room</p>
+
+
+
+
+
+
+<h4>Tuesday, February, 14, 2017</h4>
+<div class="uk-overflow-auto">
+    <table class="uk-table uk-table-small uk-table-hover uk-table-middle uk-table-divider">
+        <thead>
+            <tr>
+                <th class="uk-table-expand">Speaker</th>
+                <th class="uk-table-expand">Topic</th>
+            </tr>
+        </thead>
+        <body>
+            <tr><td>Troy Cary</td><td>Technicians Workshop</td></tr>
+            <tr><td>Anne Gillen</td><td>South Uniform Regional Testing</td></tr>
+            <tr><td>Gary Nowling</td><td>North Uniform Regional Testing</td></tr>
+            <tr><td>Troy Cary</td><td>SCN Regional Testing</td></tr> 
+        </body>
+    </table>
+</div>
+
+
 
 <h3>Wednesday 02/15/2017</h3>
 <p>Continental Breakfast | 6:45 am - 8:00 am | Versailles Foyer</p>

--- a/community/sbw/SBW/SBW_2017.html
+++ b/community/sbw/SBW/SBW_2017.html
@@ -96,7 +96,7 @@ sitemap: community/sbw
             <tr><td>Andrew Scaboo, Univ. of Missouri<br />Evelyn Ortiz Perez, Dow AgroSciences</td><td>Announcements & Poster Winners Announced</td></tr>
             <tr><td>Zenglu Li, Univ. of Georgia</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Soybean_Germplasm_Committee_Report-Zenglu_Li.pdf'>Germplasm Committee Report</a></td></tr>
             <tr><td>Michelle Graham, USDA-ARS</td><td>SoyGEC Report</td></tr>
-            <tr><td>David Grant, USDA-ARS </td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/SoyGenetComm_SBW_2017.pdf'>Soybean Genetics Committee Report</a> and <a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/SoyBase_update_SBW_2017.pdf'>SoyBase.org update</a></td></tr>
+            <tr><td>David Grant, USDA-ARS </td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/SoyGenetComm_SBW_2017.pdf'>Soybean Genetics Committee Report</a> and <a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/SoyBase_update_SBW_2017.pdf'>SoyBase.org update</a></td></tr>
             <tr><td>From the Floor</td><td>Retirements and Announcements</td></tr>
             <tr><td>Siddhi Bhusal, Univ. of Minnesota</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/SBW_SJBhusal.pdf'>Evaluation and identification of soybean aphid resistance sources and mapping of soybean aphid resistance loci in early maturing soybean germplasm</a></td></tr>
             <tr><td>Brian Diers, Univ. of Illinois</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Protein_talk_2017_SBW.pdf'>Protein and oil QTL and their associated impact on agronomic traits</a></td></tr>
@@ -207,17 +207,17 @@ sitemap: community/sbw
         </thead>
         <body>
             <tr><td>Kelly Whiting, USB staff</td><td>Welcome & Introduction to Session</td></tr>
-            <tr><td>Rich Joost, USB staff</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Joost_VTF_Objectives_pre.pdf'>USB Value Task Force Objectives</a></td></tr>
-            <tr><td>Gordon Denny, Gordon Denny LLC</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Seed_St_Louis_Feb162017_G_Denny.pdf'>Feedback from processors: specs., nutrient density, test weight </a></td></tr>
+            <tr><td>Rich Joost, USB staff</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Joost_VTF_Objectives_pre.pdf'>USB Value Task Force Objectives</a></td></tr>
+            <tr><td>Gordon Denny, Gordon Denny LLC</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Seed_St_Louis_Feb162017_G_Denny.pdf'>Feedback from processors: specs., nutrient density, test weight </a></td></tr>
             <tr><td>Reid Rice, DuPont-Pioneer</td><td>USB project with DuPont Pioneer to increase protein content, and high oleic update</td></tr>
             <tr><td>Lanny Ashlock, Natural Soy and Grain Alliance, Arkansas</td><td>Marketing high protein varieties: the Arkansas model</td></tr>
             <tr><td colspan='2'>Future of soybean variety development including quality traits at Bayer Crop Science</td></tr>
             <tr><td colspan='2'>Break</td></tr>
-            <tr><td>Doug Allen, USDA-ARS, Danforth Plant Science Center, St Louis</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Breeders_Workshop_2017b.pdf'>Feasibility of drawing carbon for additional protein and oil in soybean seed from soluble or insoluble (fiber) carbohydrates</a></td></tr>
+            <tr><td>Doug Allen, USDA-ARS, Danforth Plant Science Center, St Louis</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Breeders_Workshop_2017b.pdf'>Feasibility of drawing carbon for additional protein and oil in soybean seed from soluble or insoluble (fiber) carbohydrates</a></td></tr>
             <tr><td>John Schillinger, of Schillinger Genetics Inc.</td><td>Development of high oleic soybean varieties at Schillinger Genetics</td></tr>
             <tr><td>Katy Rainey, Purdue University</td><td>Genetic sources of increased sugar content in soybean</td></tr>
-            <tr><td>Vince Pantalone, University of Tennessee</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Pantalone_2017_Amino_Acid_Genetic_Variation.pdf'>Genetic variation and quantification of amino acids in soybean seed</a></td></tr>
-            <tr><td>Nick Bajjalieh, Integrative Nutrition Inc., Decatur IL</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Bajjalieh_2.16.2017.pdf'>Capturing value of key amino acids of soybean</a></td></tr>
+            <tr><td>Vince Pantalone, University of Tennessee</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Pantalone_2017_Amino_Acid_Genetic_Variation.pdf'>Genetic variation and quantification of amino acids in soybean seed</a></td></tr>
+            <tr><td>Nick Bajjalieh, Integrative Nutrition Inc., Decatur IL</td><td><a href='https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Bajjalieh_2.16.2017.pdf'>Capturing value of key amino acids of soybean</a></td></tr>
             <tr><td>Kelly Whiting, USB staff</td><td>Wrap-up</td></tr>
         </body>
     </table>

--- a/community/sbw/SBW/SBW_2017.html
+++ b/community/sbw/SBW/SBW_2017.html
@@ -1,7 +1,7 @@
 ---
 
 layout: default
-title: 2017 Soybean Breeders Workshop - Presentations and Reports 
+title: 2024 Soybean Breeders Workshop - Presentations and Reports 
 sitemap: community/sbw
 ---
 

--- a/community/sbw/SBW/SBW_2017.html
+++ b/community/sbw/SBW/SBW_2017.html
@@ -165,17 +165,17 @@ Co-Chair, Public Crop Physiologist: Felix Fritschi - Univ. of Missouri  </p>
     </thead>
 
 <tbody>
-    <tr>11:00 am - 11:05 am	Welcome and Introduction to Session - Kelly Whiting, USB staff</tr>
-    <tr>11:05 am - 11:25 am 	Current and prospective opportunity for development of soybean oil for the saturated/solid fat and baking goods market - Don Banks, Edible Oil Technology</tr>
-    <tr>11:25 am - 11:45 am	<a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Gillman_2017_final_report_soybean_breeders_workshop_Stearic_acid_project.pdf'>Final report of the USB Stearic Acid breeding and genetics project - Jason Gillman, USDA-ARS Columbia Missouri</a></tr>
-    <tr>11:45 am - 12:00 pm	<a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Richard_Galloway_2-15-17.pdf'>Status and prospect of applying inter-esterification of soybean oil for the saturated/solid fat and baking goods market - Richard Galloway, Galloway and Associates</a></tr>
-    <tr>12:00 pm - 1:20 pm	Lunch (on your own)</tr>
-    <tr>1:20 pm - 2:20 pm 	USB Increased Oil Content project update - Leah McHale, Ohio State University</tr>
-    <tr>2:20 pm - 3:20 pm	USB Increased Protein Content and Amino Acids project update - Rouf Mian, USDA-ARS Raleigh NC</tr>
-    <tr>3:20 pm - 3:40 pm 	Break</tr>
-    <tr>3:40 pm - 4:40 pm	<a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Rainey_carbohydrate_sources.pdf'>USB Carbohydrate Traits project update - Katy Rainey, Purdue University</a></tr>
-    <tr>4:40 pm - 5:40 pm	USB High Oleic Breeding project update - Kristin Bilyeu, USDA-ARS Columbia, MO</tr>
-    <tr>6:15 pm		Dinner for USB composition project researchers (only) - Zermatt Room</tr>
+    <tr><td>11:00am</td><td>11:05am</td><td>Kelly Whiting, USB staff</td><td>Welcome and Introduction to Session</td></tr>
+    <tr><td>11:05am</td><td>11:25am</td><td>Don Banks, Edible Oil Technology</td><td>Current and prospective opportunity for development of soybean oil for the saturated/solid fat and baking goods market</td></tr>
+    <tr><td>11:25am</td><td>11:45</td><td>Jason Gillman, USDA-ARS Columbia Missouri</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Gillman_2017_final_report_soybean_breeders_workshop_Stearic_acid_project.pdf'>Final report of the USB Stearic Acid breeding and genetics project</a></td></tr>
+    <tr><td>11:45am</td><td>12:00pm</td><td>Richard Galloway, Galloway and Associates</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Richard_Galloway_2-15-17.pdf'>Status and prospect of applying inter-esterification of soybean oil for the saturated/solid fat and baking goods market</a></td></tr>
+    <tr><td>12:00pm</td><td>1:20pm</td><td colspan='2'>Lunch (on your own)</td></tr>
+    <tr><td>1:20pm</td><td>2:20pm</td><td>Leah McHale, Ohio State University</td><td>USB Increased Oil Content project update</td></tr>
+    <tr><td>2:20pm</td><td>3:20pm</td><td>Rouf Mian, USDA-ARS Raleigh NC</td><td>USB Increased Protein Content and Amino Acids project update</td></tr>
+    <tr><td>3:20pm</td><td>3:40pm</td><td colspan='2'>Break</td></tr>
+    <tr><td>3:40pm</td><td>4:40pm</td><td>Katy Rainey, Purdue University</td> <a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Rainey_carbohydrate_sources.pdf'>USB Carbohydrate Traits project update</a></td></tr>
+    <tr><td>4:40pm</td><td>5:40pm</td><td>Kristin Bilyeu, USDA-ARS Columbia, MO</td><td>USB High Oleic Breeding project update</td></tr>
+    <tr><td>6:15pm</td><td colspan='3'>Dinner for USB composition project researchers (only) - Zermatt Room</td></tr>
 </tbody>
 </table>
 
@@ -190,18 +190,18 @@ Co-Chair, Public Crop Physiologist: Felix Fritschi - Univ. of Missouri  </p>
         </tr>
     </thead>
     <tbody>
-    <tr><td>8:00 am</td><td>8:05 am</td><td>Welcome & Introduction to Session - Kelly Whiting, USB staff</td></tr>
-    <tr><td>8:05 am</td><td>8:20 am</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Joost_VTF_Objectives_pre.pdf'>USB Value Task Force Objectives - Rich Joost, USB staff</a></td></tr>
-    <tr><td>8:20 am</td><td>8:40 am</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Seed_St_Louis_Feb162017_G_Denny.pdf'>Feedback from processors: specs., nutrient density, test weight - Gordon Denny, Gordon Denny LLC</a></td></tr>
-    <tr><td>8:40 am</td><td>9:05 am</td><td>USB project with DuPont Pioneer to increase protein content, and high oleic update - Reid Rice, DuPont-Pioneer</td></tr>
-    <tr><td>9:05 am</td><td>9:25 am</td><td>Marketing high protein varieties: the Arkansas model - Lanny Ashlock, Natural Soy and Grain Alliance, Arkansas</td></tr>
-    <tr><td>9:25 am</td><td>9:45 am </td><td>Future of soybean variety development including quality traits at Bayer Crop Science</td></tr>
-    <tr><td>9:45 am</td><td>10:05 am</td><td>Break</td></tr>
-    <tr><td>10:05 am</td><td>10:35 am</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Breeders_Workshop_2017b.pdf'>Feasibility of drawing carbon for additional protein and oil in soybean seed from soluble or insoluble (fiber) carbohydrates - Doug Allen, USDA-ARS, Danforth Plant Science Center, St Louis</a></td></tr>
-    <tr><td>10:35 am</td><td>10:55 am</td><td>Development of high oleic soybean varieties at Schillinger Genetics - John Schillinger, of Schillinger Genetics Inc. </td></tr>
-    <tr><td>10:55 am</td><td>11:10 am</td><td>	Genetic sources of increased sugar content in soybean- Katy Rainey, Purdue University</td></tr>
-    <tr><td>11:10 am</td><td>11:25 am</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Pantalone_2017_Amino_Acid_Genetic_Variation.pdf'>Genetic variation and quantification of amino acids in soybean seed - Vince Pantalone, University of Tennessee</a></td></tr>
-    <tr><td>11:25 am</td><td>11:45 am</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Bajjalieh_2.16.2017.pdf'>Capturing value of key amino acids of soybean - Nick Bajjalieh, Integrative Nutrition Inc., Decatur IL</a></td></tr>
-    <tr><td>11:45 am</td><td>12:00 pm</td><td>Wrap-up - Kelly Whiting, USB staff</td></tr>
+    <tr><td>8:00am</td><td>8:05am</td><td>Kelly Whiting, USB staff</td><td>Welcome & Introduction to Session</td></tr>
+    <tr><td>8:05am</td><td>8:20am</td><td>Rich Joost, USB staff</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Joost_VTF_Objectives_pre.pdf'>USB Value Task Force Objectives</a></td></tr>
+    <tr><td>8:20am</td><td>8:40am</td><td>Gordon Denny, Gordon Denny LLC</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Seed_St_Louis_Feb162017_G_Denny.pdf'>Feedback from processors: specs., nutrient density, test weight </a></td></tr>
+    <tr><td>8:40am</td><td>9:05am</td><td>Reid Rice, DuPont-Pioneer</td><td>USB project with DuPont Pioneer to increase protein content, and high oleic update</td></tr>
+    <tr><td>9:05am</td><td>9:25am</td><td>Lanny Ashlock, Natural Soy and Grain Alliance, Arkansas</td><td>Marketing high protein varieties: the Arkansas model</td></tr>
+    <tr><td>9:25am</td><td>9:45am </td><td colspan='2'>Future of soybean variety development including quality traits at Bayer Crop Science</td></tr>
+    <tr><td>9:45am</td><td>10:05am</td><td colspan='2'>Break</td></tr>
+    <tr><td>10:05am</td><td>10:35am</td><td>Doug Allen, USDA-ARS, Danforth Plant Science Center, St Louis</td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Breeders_Workshop_2017b.pdf'>Feasibility of drawing carbon for additional protein and oil in soybean seed from soluble or insoluble (fiber) carbohydrates</a></td></tr>
+    <tr><td>10:35am</td><td>10:55am</td><td>John Schillinger, of Schillinger Genetics Inc.</td><td>Development of high oleic soybean varieties at Schillinger Genetics</td></tr>
+    <tr><td>10:55am</td><td>11:10am</td><td>Katy Rainey, Purdue University</td><td>Genetic sources of increased sugar content in soybean</td></tr>
+    <tr><td>11:10am</td><td>11:25am</td><td>Vince Pantalone, University of Tennessee</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Pantalone_2017_Amino_Acid_Genetic_Variation.pdf'>Genetic variation and quantification of amino acids in soybean seed</a></td></tr>
+    <tr><td>11:25am</td><td>11:45am</td><td>Nick Bajjalieh, Integrative Nutrition Inc., Decatur IL</td><td><a href='https://data.legumeinfo.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2017/Bajjalieh_2.16.2017.pdf'>Capturing value of key amino acids of soybean</a></td></tr>
+    <tr><td>11:45am</td><td>12:00pm</td><td>Kelly Whiting, USB staff</td><td>Wrap-up</td></tr>
 </tbody>
 </table>

--- a/community/sbw/SBW/SBW_2024.html
+++ b/community/sbw/SBW/SBW_2024.html
@@ -13,100 +13,96 @@ sitemap: community/sbw
   <a class="uk-text-bold" href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2024/2024Agenda.v2.pdf" target="_blank">View the published 2024 SBW Agenda</a>
 </div>
 
-<h3>Monday February 12th, 2024 | Room: Versailles 1</h3>
+<h3>Monday February 12th, 2024</h3>
 <div class="uk-overflow-auto">
-<table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
+  <table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
     <thead>
         <tr>
-            <th class="uk-table-shrink">Start</th>
             <th class="uk-table-expand">Speaker</th>
             <th class="uk-table-expand">Topic</th>
         </tr>
     </thead>
-<body>
-  <tr><td>1:00 pm</td><td>Brittney Jones, Bayer Crop Science and Aaron Lorenz, University of Minnesota</td><td>Welcome and opening remarks</td></tr>
-  <tr><td>1:10 pm</td><td><i>Keynote speech:</i> Michael Smith, University Distinguished Professor Emeritus, Kansas State University</td><td>A century of insect resistant soybeans: Bussin’ or busted?</td></tr>
-  <tr><th colspan='3'>SESSION 1: Market needs and research opportunities | Chair: Aaron Lorenz, University of Minnesota</th></tr>
-  <tr><td>1:40 pm</td><td>Tom Slunecka, AG Management Solutions</td><td>Inspiring innovation: Ag Innovation Campus provides bridge to success</td></tr>
-  <tr><td>2:10 pm</td><td>Donnell Rehagen, Clean Fuels Alliance America</td><td>Accelerating to New Heights – The expanding role soybean oil plays in the major growth of clean fuels production</td></tr>
-  <tr><td>2:40 pm</td><td>Lisa Weaver, SmithBucklin</td><td>USB Updates</td></tr>
-  <tr><td>2:50 pm</td><td colspan='2'>Coffee Break</td></tr>
-  <tr><th colspan='3'>SESSION 2: Breeding Innovation | Chair: Aaron Lorenz, University of Minnesota</th></tr>
-  <tr><td>3:20 pm</td><td>Diego Jarquin, Univ. of Florida</td><td>Sparse testing designs at the industrial level: An application in soybeans</td></tr>
-  <tr><td>3:50 pm</td><td>Lucia Gutierez, Univ. of Wisconsin</td><td>Optimizing resources for genotypic evaluation: Sparse testing for
-genotype-by-environment interaction modeling</td></tr>
-  <tr><td>4:20 pm</td><td>Scott Jackson, Bayer Crop Science</td><td>Genomics and breeding at scale</td></tr>
-  <tr><td>4:50 pm</td><td colspan='2'>Housekeeping announcements</td></tr>
-  <tr><td>5:00 pm</td><td colspan='2'>Graduate Student and Postdoc Professional Development Event</td></tr>
-</body>
-</table>
+    <body>
+      <tr><td>Brittney Jones, Bayer Crop Science<br />Aaron Lorenz, University of Minnesota</td><td>Welcome and opening remarks</td></tr>
+      <tr><td><i>Keynote speech:</i> Michael Smith<br />University Distinguished Professor Emeritus, Kansas State University</td><td>A century of insect resistant soybeans: Bussin’ or busted?</td></tr>
+      <tr><th colspan='2'>SESSION 1: Market needs and research opportunities | Chair: Aaron Lorenz, University of Minnesota</th></tr>
+      <tr><td>Tom Slunecka, AG Management Solutions</td><td>Inspiring innovation: Ag Innovation Campus provides bridge to success</td></tr>
+      <tr><td>Donnell Rehagen, Clean Fuels Alliance America</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2024/Donnell_Rehagen.pdf">Accelerating to New Heights – The expanding role soybean oil plays in the major growth of clean fuels production</a></td></tr>
+      <tr><td>Lisa Weaver, SmithBucklin</td><td>USB Updates</td></tr>
+      <tr><td colspan='2'>Coffee Break</td></tr>
+      <tr><th colspan='2'>SESSION 2: Breeding Innovation | Chair: Aaron Lorenz, University of Minnesota</th></tr>
+      <tr><td>Diego Jarquin, Univ. of Florida</td><td>Sparse testing designs at the industrial level: An application in soybeans</td></tr>
+      <tr><td>Lucia Gutierez, Univ. of Wisconsin</td><td>Optimizing resources for genotypic evaluation: Sparse testing for genotype-by-environment interaction modeling</td></tr>
+      <tr><td>Scott Jackson, Bayer Crop Science</td><td>Genomics and breeding at scale</td></tr>
+      <tr><td colspan='2'>Housekeeping announcements</td></tr>
+      <tr><td colspan='2'>Graduate Student and Postdoc Professional Development Event</td></tr>
+    </body>
+  </table>
 </div>
 
-<h3>Tuesday February 13th, 2024 | Room: Versailles 1</h3>
+<h3>Tuesday February 13th, 2024</h3>
 <div class="uk-overflow-auto">
 <table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
     <thead>
         <tr>
-            <th class="uk-table-shrink">Start</th>
             <th class="uk-table-expand">Speaker</th>
             <th class="uk-table-expand">Topic</th>
         </tr>
     </thead>
-<body>
-  <tr><th colspan='3'>SESSION 3:  Updates in Soybean Entomology | Chair: Robert Koch, University of Minnesota</th></tr>
-  <tr><td>8:00 am</td><td>Robert Koch, Univ. of Minnesota</td><td>Introduction</td></tr>
-  <tr><td>8:05 am</td><td>Justin McMechan, Univ. of Nebraska</td><td>Soybean gall midge: Understanding a new and emerging pest of soybean in the Midwest</td></tr>
-  <tr><td>8:30 am</td><td>Robert Koch, Univ. of Minnesota</td><td>Biology and management of the soybean tentiform leafminer, a new pest of soybean</td></tr>
-  <tr><td>8:55 am</td><td>Jeff Davis, Louisiana State Univ.</td><td>Biology and management of stink bugs in soybean</td></tr>
-  <tr><td>9:20 am</td><td>Silvana Paula-Moraes, Univ. of Florida</td><td>Biology and management of caterpillar pests of soybean</td></tr>
-  <tr><td>9:45 am</td><td colspan='2'>Coffee Break</td></tr>
-  <tr><td>10:10 am</td><td>Maria Cramer, Univ. of Maryland</td><td>Slugs as pests and prey: Growing practices that impact slugs in soybeans</td></tr>
-  <tr><td>10:35 am</td><td>Raul Villanueva, Univ. of Kentucky</td><td>Comprehensive review of the management of <i>Dectes texanus</i> in soybeans</td></tr>
-  <tr><td>11:00 am</td><td>Ivair Valmorbida, Univ. of Missouri</td><td>Soybean aphid management: Is it becoming more complicated?</td></tr>
-  <tr><td>11:25 am</td><td colspan='2'>Lunch (On your own)</td></tr>
-  <tr><th colspan='3'>SESSION 4: Genetics of host plant resistance | Chair: Jamie O’Rourke, USDA-ARS</th></tr>
-  <tr><td>1:00 pm</td><td>Wayne Parrot, Univ. of Georgia</td><td>Identifying resistance QTL</td></tr>
-  <tr><td>1:25 pm</td><td>Dave Hyten, Univ. of Nebraska</td><td>Stemborer resistance</td></tr>
-  <tr><td>1:50 pm</td><td>Jeff Davis, Louisiana State Univ.</td><td>Host Plant Resistance to a Complex of Stink Bugs: Protecting Yield and Quality in Southern Soybean</td></tr>
-  <tr><td>2:15 pm</td><td>Gustavo MacIntosh, Iowa State Univ.</td><td>Understanding the molecular mechanisms of plant defense suppression deployed by soybean aphids</td></tr>
-  <tr><td>2:40 pm</td><td colspan='2'>Coffee Break</td></tr>
-  <tr><th colspan='3'>SESSION 4: Breeding for host plant resistance | Chair: Ben Fallen, UDSA-ARS</th></tr>
-  <tr><td>3:05 pm</td><td>George Graef, Univ. of Nebraska</td><td>Genetics of soybean host plant reaction to soybean gall midge infestation</td></tr>
-  <tr><td>3:30 pm</td><td>Zenglu Li, Univ. of Georgia</td><td>Breeding for insect resistance in soybean</td></tr>
-  <tr><td>3:55 pm</td><td>Molly Ryan, Corteva</td><td>Corteva insect native traits</td></tr>
-  <tr><td>4:20 pm</td><td colspan='2'>Poster Session & Social Hour<br><a href="/community/sbw/SBW/posters2024.html" target="_blank">2024 Poster Winners</a></td></tr>
-</body>
-</table>
+    <body>
+      <tr><th colspan='2'>SESSION 3:  Updates in Soybean Entomology | Chair: Robert Koch, University of Minnesota</th></tr>
+      <tr><td>Robert Koch, Univ. of Minnesota</td><td>Introduction</td></tr>
+      <tr><td>Justin McMechan, Univ. of Nebraska</td><td>Soybean gall midge: Understanding a new and emerging pest of soybean in the Midwest</td></tr>
+      <tr><td>Robert Koch, Univ. of Minnesota</td><td>Biology and management of the soybean tentiform leafminer, a new pest of soybean</td></tr>
+      <tr><td>Jeff Davis, Louisiana State Univ.</td><td>Biology and management of stink bugs in soybean</td></tr>
+      <tr><td>Silvana Paula-Moraes, Univ. of Florida</td><td>Biology and management of caterpillar pests of soybean</td></tr>
+      <tr><td colspan='2'>Coffee Break</td></tr>
+      <tr><td>Maria Cramer, Univ. of Maryland</td><td>Slugs as pests and prey: Growing practices that impact slugs in soybeans</td></tr>
+      <tr><td>Raul Villanueva, Univ. of Kentucky</td><td>Comprehensive review of the management of <i>Dectes texanus</i> in soybeans</td></tr>
+      <tr><td>Ivair Valmorbida, Univ. of Missouri</td><td>Soybean aphid management: Is it becoming more complicated?</td></tr>
+      <tr><td colspan='2'>Lunch (On your own)</td></tr>
+      <tr><th colspan='2'>SESSION 4: Genetics of host plant resistance | Chair: Jamie O’Rourke, USDA-ARS</th></tr>
+      <tr><td>Wayne Parrot, Univ. of Georgia</td><td>Identifying resistance QTL</td></tr>
+      <tr><td>Dave Hyten, Univ. of Nebraska</td><td>Stemborer resistance</td></tr>
+      <tr><td>Jeff Davis, Louisiana State Univ.</td><td>Host Plant Resistance to a Complex of Stink Bugs: Protecting Yield and Quality in Southern Soybean</td></tr>
+      <tr><td>Gustavo MacIntosh, Iowa State Univ.</td><td>Understanding the molecular mechanisms of plant defense suppression deployed by soybean aphids</td></tr>
+      <tr><td colspan='2'>Coffee Break</td></tr>
+      <tr><th colspan='2'>SESSION 4: Breeding for host plant resistance | Chair: Ben Fallen, UDSA-ARS</th></tr>
+      <tr><td>George Graef, Univ. of Nebraska</td><td>Genetics of soybean host plant reaction to soybean gall midge infestation</td></tr>
+      <tr><td>Zenglu Li, Univ. of Georgia</td><td>Breeding for insect resistance in soybean</td></tr>
+      <tr><td>Molly Ryan, Corteva</td><td>Corteva insect native traits</td></tr>
+      <tr><td colspan='2'>Poster Session & Social Hour<br><a href="/community/sbw/SBW/posters2024.html" target="_blank">2024 Poster Winners</a></td></tr>
+    </body>
+  </table>
 </div>
 
-<h3>Wednesday February 14th, 2024 | Room: Versailles 1</h3>  
+<h3>Wednesday February 14th, 2024</h3>  
 <div class="uk-overflow-auto">
-<table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
+  <table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
     <thead>
         <tr>
-            <th class="uk-table-shrink">Start</th>
             <th class="uk-table-expand">Speaker</th>
             <th class="uk-table-expand">Topic</th>
         </tr>
     </thead>
-<body>
-  <tr><th colspan='3'>SESSION 6: Reports and Announcements | Chair: Aaron Lorenz, University of Minnesota</th></tr>
-  <tr><td>8:00 am</td><td>Cleiton Wartha, Corteva</td><td>Announcement of poster winners</td></tr>
-  <tr><td>8:10 am</td><td>Jamie O’Rourke, USDA-ARS</td><td>Soybean Genomics Executive Committee Report</td></tr>
-  <tr><td>8:25 am</td><td>Elroy Cober, AAFC</td><td>Soybean Genetics Committee Report</td></tr>
-  <tr><td>8:30 am</td><td>Rex Nelson, USDA-ARS</td><td>SoyBase.org Update</td></tr>
-  <tr><td>8:40 am</td><td>Ben Fallen, USDA-ARS</td><td>Soybean Germplasm Committee Report</td></tr>
-  <tr><td>8:55 am</td><td colspan='2'>From the floor: Recognitions, retirements, and announcements</td></tr>
-  <tr><th colspan='3'>SESSION 7: Lightning presentations | Chair: Aaron Lorenz, University of Minnesota</th></tr>
-  <tr><td>9:00 am</td><td colspan='2'>Volunteered presentations</td></tr>
-  <tr><td>10:00 am</td><td colspan='2'>Coffee Break</td></tr>
-  <tr><th colspan='3'>SESSION 8: Highlights from Seed Industry | Chair: Brittney Jones, Bayer Crop Science</th></tr>
-  <tr><td>10:15 am</td><td colspan='2'>Speaker TBD</td></tr>
-  <tr><td>10:15 am</td><td colspan='2'>Speaker TBD</td></tr>
-  <tr><td>10:15 am</td><td colspan='2'>Speaker TBD</td></tr>
-  <tr><td>11:30 am</td><td colspan='2'>Adjourn</td></tr>
-</body>
-</table>
+    <body>
+      <tr><th colspan='2'>SESSION 6: Reports and Announcements | Chair: Aaron Lorenz, University of Minnesota</th></tr>
+      <tr><td>Cleiton Wartha, Corteva</td><td>Announcement of poster winners</td></tr>
+      <tr><td>Jamie O’Rourke, USDA-ARS</td><td>Soybean Genomics Executive Committee Report</td></tr>
+      <tr><td>Elroy Cober, AAFC</td><td>Soybean Genetics Committee Report</td></tr>
+      <tr><td>Rex Nelson, USDA-ARS</td><td>SoyBase.org Update</td></tr>
+      <tr><td>Ben Fallen, USDA-ARS</td><td>Soybean Germplasm Committee Report</td></tr>
+      <tr><td colspan='2'>From the floor: Recognitions, retirements, and announcements</td></tr>
+      <tr><th colspan='2'>SESSION 7: Lightning presentations | Chair: Aaron Lorenz, University of Minnesota</th></tr>
+      <tr><td colspan='2'>Volunteered presentations</td></tr>
+      <tr><td colspan='2'>Coffee Break</td></tr>
+      <tr><th colspan='2'>SESSION 8: Highlights from Seed Industry | Chair: Brittney Jones, Bayer Crop Science</th></tr>
+      <td colspan='2'>Speaker TBD</td></tr>
+      <tr><td colspan='2'>Speaker TBD</td></tr>
+      <tr><td colspan='2'>Speaker TBD</td></tr>
+      <tr><td colspan='2'>Adjourn</td></tr>
+    </body>
+  </table>
 </div>
 
 <h2>2024 Soybean Breeders' Workshop - Special Meetings</h2>
@@ -116,54 +112,50 @@ genotype-by-environment interaction modeling</td></tr>
 <table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
     <thead>
         <tr>
-            <th class="uk-table-shrink">Start</th>
-            <th class="uk-table-shrink">End</th>
-            <th class="uk-table-expand">Meeting</th>
+          <th class="uk-table-expand">Meeting</th>
         </tr>
     </thead>
-<body>
-  <tr><td>8:00 am</td><td>12:00 pm</td><td>Genomics prediction of GxE workshop</td></tr>
-  <tr><td>8:30 am</td><td>10:00 am</td><td>Soybean Germplasm Committee Meeting</td></tr>
-  <tr><td>9:00 am</td><td>10:30 am</td><td>SoyBase Workshop Meeting</td></tr>
-  <tr><td>10:00 am</td><td>12:00 pm</td><td>Soybean Genomics Executive Committee Meeting</td></tr>
-  <tr><td>1:00 pm</td><td>5:00 pm</td><td>Technicians Workshop</td></tr>
-  <tr><td>7:00 pm</td><td>8:00 pm</td><td>Soybean Genetics Committee</td></tr>
-</body>
-</table>
+    <body>
+      <tr><td>Genomics prediction of GxE workshop</td></tr>
+      <tr><td>Soybean Germplasm Committee Meeting</td></tr>
+      <tr><td>SoyBase Workshop Meeting</td></tr>
+      <tr><td>Soybean Genomics Executive Committee Meeting</td></tr>
+      <tr><td>Technicians Workshop</td></tr>
+      <tr><td>Soybean Genetics Committee</td></tr>
+    </body>
+  </table>
 </div>
+
 <h3>Tuesday, February 13th, 2024</h3>  
 <div class="uk-overflow-auto">
-<table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
+  <table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
     <thead>
         <tr>
-            <th class="uk-table-shrink">Start</th>
-            <th class="uk-table-shrink">End</th>
-            <th class="uk-table-expand">Meeting</th>
+          <th class="uk-table-expand">Meeting</th>
         </tr>
     </thead>
-<body>
-  <tr><td>8:00 am</td><td>12:00 pm</td><td>Technicians Workshop</td></tr>
-  <tr><td>7:00 pm</td><td>7:30 pm</td><td>Uniform Regional Testing - North</td></tr>
-  <tr><td>7:00 pm</td><td>8:00 pm</td><td>Uniform Regional Testing - South</td></tr>
-  <tr><td>7:30 pm</td><td>8:00 pm</td><td>SCN Regional Testing</td></tr>
-</body>
-</table>
+    <body>
+      <tr><td>Technicians Workshop</td></tr>
+      <tr><td>North Uniform Regional Testing</td></tr>
+      <tr><td>South Uniform Regional Testing</td></tr>
+      <tr><td>SCN Regional Testing</td></tr>
+    </body>
+  </table>
 </div>
+
 <h3>Wednesday, February 14th, 2024</h3>  
 <div class="uk-overflow-auto">
 <table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
     <thead>
         <tr>
-            <th class="uk-table-shrink">Start</th>
-            <th class="uk-table-shrink">End</th>
-            <th class="uk-table-expand">Meeting</th>
+          <th class="uk-table-expand">Meeting</th>
         </tr>
     </thead>
-<body>
-  <tr><td>12:00 pm</td><td>4:00 pm</td><td>Missouri Soybean Merchandising Coucil</td></tr>
-  <tr><td>12:00 pm</td><td>2:00 pm</td><td>Soybean Breeders' Workshop Planning Committee</td></tr>
-</body>
-</table>
+    <body>
+      <tr><td>Missouri Soybean Merchandising Coucil</td></tr>
+      <tr><td>Soybean Breeders' Workshop Planning Committee</td></tr>
+    </body>
+  </table>
 </div>
 
 

--- a/community/sbw/SBW/SBW_2024.html
+++ b/community/sbw/SBW/SBW_2024.html
@@ -24,9 +24,9 @@ sitemap: community/sbw
     </thead>
     <body>
       <tr><td>Brittney Jones, Bayer Crop Science<br />Aaron Lorenz, University of Minnesota</td><td>Welcome and opening remarks</td></tr>
-      <tr><td><i>Keynote speech:</i> Michael Smith<br />University Distinguished Professor Emeritus, Kansas State University</td><td>A century of insect resistant soybeans: Bussin’ or busted?</td></tr>
+      <tr><td><i>Keynote speech:</i> Michael Smith<br />University Distinguished Professor Emeritus, Kansas State University</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2024/Michael_Smith.pdf">A century of insect resistant soybeans: Bussin’ or busted?</a></td></tr>
       <tr><th colspan='2'>SESSION 1: Market needs and research opportunities | Chair: Aaron Lorenz, University of Minnesota</th></tr>
-      <tr><td>Tom Slunecka, AG Management Solutions</td><td>Inspiring innovation: Ag Innovation Campus provides bridge to success</td></tr>
+      <tr><td>Tom Slunecka, AG Management Solutions</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2024/Tom_Slunecka.pdf">Inspiring innovation: Ag Innovation Campus provides bridge to success</a></td></tr>
       <tr><td>Donnell Rehagen, Clean Fuels Alliance America</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2024/Donnell_Rehagen.pdf">Accelerating to New Heights – The expanding role soybean oil plays in the major growth of clean fuels production</a></td></tr>
       <tr><td>Lisa Weaver, SmithBucklin</td><td>USB Updates</td></tr>
       <tr><td colspan='2'>Coffee Break</td></tr>
@@ -57,9 +57,9 @@ sitemap: community/sbw
       <tr><td>Jeff Davis, Louisiana State Univ.</td><td>Biology and management of stink bugs in soybean</td></tr>
       <tr><td>Silvana Paula-Moraes, Univ. of Florida</td><td>Biology and management of caterpillar pests of soybean</td></tr>
       <tr><td colspan='2'>Coffee Break</td></tr>
-      <tr><td>Maria Cramer, Univ. of Maryland</td><td>Slugs as pests and prey: Growing practices that impact slugs in soybeans</td></tr>
+      <tr><td>Maria Cramer, Univ. of Maryland</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2024/Maria_Cramer.pdf">Slugs as pests and prey: Growing practices that impact slugs in soybeans</a></td></tr>
       <tr><td>Raul Villanueva, Univ. of Kentucky</td><td>Comprehensive review of the management of <i>Dectes texanus</i> in soybeans</td></tr>
-      <tr><td>Ivair Valmorbida, Univ. of Missouri</td><td>Soybean aphid management: Is it becoming more complicated?</td></tr>
+      <tr><td>Ivair Valmorbida, Univ. of Missouri</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2024/Ivair_Valmorbida.pdf">Soybean aphid management: Is it becoming more complicated?</a></td></tr>
       <tr><td colspan='2'>Lunch (On your own)</td></tr>
       <tr><th colspan='2'>SESSION 4: Genetics of host plant resistance | Chair: Jamie O’Rourke, USDA-ARS</th></tr>
       <tr><td>Wayne Parrot, Univ. of Georgia</td><td>Identifying resistance QTL</td></tr>
@@ -68,7 +68,7 @@ sitemap: community/sbw
       <tr><td>Gustavo MacIntosh, Iowa State Univ.</td><td>Understanding the molecular mechanisms of plant defense suppression deployed by soybean aphids</td></tr>
       <tr><td colspan='2'>Coffee Break</td></tr>
       <tr><th colspan='2'>SESSION 4: Breeding for host plant resistance | Chair: Ben Fallen, UDSA-ARS</th></tr>
-      <tr><td>George Graef, Univ. of Nebraska</td><td>Genetics of soybean host plant reaction to soybean gall midge infestation</td></tr>
+      <tr><td>George Graef, Univ. of Nebraska</td><td><a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2024/George_Graef.pdf">Genetics of soybean host plant reaction to soybean gall midge infestation</a></td></tr>
       <tr><td>Zenglu Li, Univ. of Georgia</td><td>Breeding for insect resistance in soybean</td></tr>
       <tr><td>Molly Ryan, Corteva</td><td>Corteva insect native traits</td></tr>
       <tr><td colspan='2'>Poster Session & Social Hour<br><a href="/community/sbw/SBW/posters2024.html" target="_blank">2024 Poster Winners</a></td></tr>

--- a/community/sbw/SBW/SBW_2024.html
+++ b/community/sbw/SBW/SBW_2024.html
@@ -1,0 +1,47 @@
+---
+layout: default
+title: 2017 Soybean Breeders Workshop - Presentations and Reports 
+sitemap: community/sbw
+---
+
+<h2>2024 Soybean Breeders' Workshop - Entomology and Breeding Innovation</h2>
+<hr >
+<div class="uk-margin">
+  <a class="uk-text-bold" href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2024/2024officers.pdf"> <span class="uk-margin-right-small" uk-icon="icon: users; ratio: 1.5"></span> 2024 Soybean Breeders Workshop Planning Committee</a>
+</div>
+
+<h3>Monday February 12th, 2024 | Room: Versailles 1</h3>
+
+<div class="uk-overflow-auto">
+<table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
+    <thead>
+        <tr>
+            <th class="uk-table-shrink">Start</th>
+            <th class="uk-table-expand">Speaker</th>
+            <th class="uk-table-expand">Topic</th>
+        </tr>
+    </thead>
+<body>
+  <tr><td>1:00 pm</td><td>Brittney Jones, Bayer Crop Science and Aaron Lorenz, University of Minnesota</td><td>Welcome and opening remarks</td></tr>
+  <tr><td>1:10 pm</td><td><i>Keynote speech:</i> Michael Smith, University Distinguished Professor Emeritus, Kansas State University</td><td>A century of insect resistant soybeans: Bussin’ or busted?</td></tr>
+  <tr><th colspan='3'>SESSION 1: Market needs and research opportunities | Chair: Aaron Lorenz, University of Minnesota</th></tr>
+  <tr><td>1:40 pm</td><td>Tom Slunecka, AG Management Solutions</td><td>Inspiring innovation: Ag Innovation Campus provides bridge to success</td></tr>
+  <tr><td>2:10 pm</td><td>Donnell Rehagen, Clean Fuels Alliance America</td><td>Accelerating to New Heights – The expanding role soybean oil plays in the major growth of clean fuels production</td></tr>
+  <tr><td>2:40 pm</td><td>Lisa Weaver, SmithBucklin</td><td>USB Updates</td></tr>
+  <tr><td>2:50 pm</td><td colspan='2'>Coffee Break</td></tr>
+  <tr><th colspan='3'>SESSION 2: Breeding Innovation | Chair: Aaron Lorenz, University of Minnesota</th></tr>
+  <tr><td>3:20 pm</td><td>Diego Jarquin, Univ. of Florida</td><td>Sparse testing designs at the industrial level: An application in soybeans</td></tr>
+  <tr><td>3:50 pm</td><td>Lucia Gutierez, Univ. of Wisconsin</td><td>Optimizing resources for genotypic evaluation: Sparse testing for
+genotype-by-environment interaction modeling</td></tr>
+  <tr><td>4:20 pm</td><td>Scott Jackson, Bayer Crop Science</td><td>Genomics and breeding at scale</td></tr>
+  <tr><td>4:50 pm</td><td colspan='2'>Housekeeping announcements</td></tr>
+  <tr><td>5:00 pm</td><td colspan='2'>Graduate Student and Postdoc Professional Development Event</td></tr>
+</body>
+</table>
+</div>
+
+
+
+
+  <h3>Tuesday February 13th, 2024 | Room: Versailles 1</h3>
+  

--- a/community/sbw/SBW/SBW_2024.html
+++ b/community/sbw/SBW/SBW_2024.html
@@ -157,7 +157,11 @@ genotype-by-environment interaction modeling</td></tr>
         </tr>
     </thead>
 <body>
-
+  <tr><td>12:00 pm</td><td>4:00 pm</td><td>Missouri Soybean Merchandising Coucil</td></tr>
+  <tr><td>12:00 pm</td><td>2:00 pm</td><td>Soybean Breeders' Workshop Planning Committee</td></tr>
+</body>
+</table>
+</div>
 
 
   

--- a/community/sbw/SBW/SBW_2024.html
+++ b/community/sbw/SBW/SBW_2024.html
@@ -11,7 +11,6 @@ sitemap: community/sbw
 </div>
 
 <h3>Monday February 12th, 2024 | Room: Versailles 1</h3>
-
 <div class="uk-overflow-auto">
 <table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
     <thead>
@@ -40,8 +39,125 @@ genotype-by-environment interaction modeling</td></tr>
 </table>
 </div>
 
+<h3>Tuesday February 13th, 2024 | Room: Versailles 1</h3>
+<div class="uk-overflow-auto">
+<table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
+    <thead>
+        <tr>
+            <th class="uk-table-shrink">Start</th>
+            <th class="uk-table-expand">Speaker</th>
+            <th class="uk-table-expand">Topic</th>
+        </tr>
+    </thead>
+<body>
+  <tr><th colspan='3'>SESSION 3:  Updates in Soybean Entomology | Chair: Robert Koch, University of Minnesota</th></tr>
+  <tr><td>8:00 am</td><td>Robert Koch, Univ. of Minnesota</td><td>Introduction</td></tr>
+  <tr><td>8:05 am</td><td>Justin McMechan, Univ. of Nebraska</td><td>Soybean gall midge: Understanding a new and emerging pest of soybean in the Midwest</td></tr>
+  <tr><td>8:30 am</td><td>Robert Koch, Univ. of Minnesota</td><td>Biology and management of the soybean tentiform leafminer, a new pest of soybean</td></tr>
+  <tr><td>8:55 am</td><td>Jeff Davis, Louisiana State Univ.</td><td>Biology and management of stink bugs in soybean</td></tr>
+  <tr><td>9:20 am</td><td>Silvana Paula-Moraes, Univ. of Florida</td><td>Biology and management of caterpillar pests of soybean</td></tr>
+  <tr><td>9:45 am</td><td colspan='2'>Coffee Break</td></tr>
+  <tr><td>10:10 am</td><td>Maria Cramer, Univ. of Maryland</td><td>Slugs as pests and prey: Growing practices that impact slugs in soybeans</td></tr>
+  <tr><td>10:35 am</td><td>Raul Villanueva, Univ. of Kentucky</td><td>Comprehensive review of the management of <i>Dectes texanus</i> in soybeans</td></tr>
+  <tr><td>11:00 am</td><td>Ivair Valmorbida, Univ. of Missouri</td><td>Soybean aphid management: Is it becoming more complicated?</td></tr>
+  <tr><td>11:25 am</td><td colspan='2'>Lunch (On your own)</td></tr>
+  <tr><th colspan='3'>SESSION 4: Genetics of host plant resistance | Chair: Jamie O’Rourke, USDA-ARS</th></tr>
+  <tr><td>1:00 pm</td><td>Wayne Parrot, Univ. of Georgia</td><td>Identifying resistance QTL</td></tr>
+  <tr><td>1:25 pm</td><td>Dave Hyten, Univ. of Nebraska</td><td>Stemborer resistance</td></tr>
+  <tr><td>1:50 pm</td><td>Jeff Davis, Louisiana State Univ.</td><td>Host Plant Resistance to a Complex of Stink Bugs: Protecting Yield and Quality in Southern Soybean</td></tr>
+  <tr><td>2:15 pm</td><td>Gustavo MacIntosh, Iowa State Univ.</td><td>Understanding the molecular mechanisms of plant defense suppression deployed by soybean aphids</td></tr>
+  <tr><td>2:40 pm</td><td colspan='2'>Coffee Break</td></tr>
+  <tr><th colspan='3'>SESSION 4: Breeding for host plant resistance | Chair: Ben Fallen, UDSA-ARS</th></tr>
+  <tr><td>3:05 pm</td><td>George Graef, Univ. of Nebraska</td><td>Genetics of soybean host plant reaction to soybean gall midge infestation</td></tr>
+  <tr><td>3:30 pm</td><td>Zenglu Li, Univ. of Georgia</td><td>Breeding for insect resistance in soybean</td></tr>
+  <tr><td>3:55 pm</td><td>Molly Ryan, Corteva</td><td>Corteva insect native traits</td></tr>
+  <tr><td>4:20 pm</td><td colspan='2'>Poster Session & Social Hour<br><a href="/community/sbw/SBW/posters2024.html" target="_blank">2024 Poster Winners</a></td></tr>
+</body>
+</table>
+</div>
+
+<h3>Wednesday February 14th, 2024 | Room: Versailles 1</h3>  
+<div class="uk-overflow-auto">
+<table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
+    <thead>
+        <tr>
+            <th class="uk-table-shrink">Start</th>
+            <th class="uk-table-expand">Speaker</th>
+            <th class="uk-table-expand">Topic</th>
+        </tr>
+    </thead>
+<body>
+  <tr><th colspan='3'>SESSION 6: Reports and Announcements | Chair: Aaron Lorenz, University of Minnesota</th></tr>
+  <tr><td>8:00 am</td><td>Cleiton Wartha, Corteva</td><td>Announcement of poster winners</td></tr>
+  <tr><td>8:10 am</td><td>Jamie O’Rourke, USDA-ARS</td><td>Soybean Genomics Executive Committee Report</td></tr>
+  <tr><td>8:25 am</td><td>Elroy Cober, AAFC</td><td>Soybean Genetics Committee Report</td></tr>
+  <tr><td>8:30 am</td><td>Rex Nelson, USDA-ARS</td><td>SoyBase.org Update</td></tr>
+  <tr><td>8:40 am</td><td>Ben Fallen, USDA-ARS</td><td>Soybean Germplasm Committee Report</td></tr>
+  <tr><td>8:55 am</td><td colspan='2'>From the floor: Recognitions, retirements, and announcements</td></tr>
+  <tr><th colspan='3'>SESSION 7: Lightning presentations | Chair: Aaron Lorenz, University of Minnesota</th></tr>
+  <tr><td>9:00 am</td><td colspan='2'>Volunteered presentations</td></tr>
+  <tr><td>10:00 am</td><td colspan='2'>Coffee Break</td></tr>
+  <tr><th colspan='3'>SESSION 8: Highlights from Seed Industry | Chair: Brittney Jones, Bayer Crop Science</th></tr>
+  <tr><td>10:15 am</td><td colspan='2'>Speaker TBD</td></tr>
+  <tr><td>10:15 am</td><td colspan='2'>Speaker TBD</td></tr>
+  <tr><td>10:15 am</td><td colspan='2'>Speaker TBD</td></tr>
+  <tr><td>11:30 am</td><td colspan='2'>Adjourn</td></tr>
+</body>
+</table>
+</div>
+
+<h2>2024 Soybean Breeders' Workshop - Special Meetings</h2>
+<hr >
+<h3>Monday, February 12th, 2024</h3>  
+<div class="uk-overflow-auto">
+<table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
+    <thead>
+        <tr>
+            <th class="uk-table-shrink">Start</th>
+            <th class="uk-table-shrink">End</th>
+            <th class="uk-table-expand">Meeting</th>
+        </tr>
+    </thead>
+<body>
+  <tr><td>8:00 am</td><td>12:00 pm</td><td>Genomics prediction of GxE workshop</td></tr>
+  <tr><td>8:30 am</td><td>10:00 am</td><td>Soybean Germplasm Committee Meeting</td></tr>
+  <tr><td>9:00 am</td><td>10:30 am</td><td>SoyBase Workshop Meeting</td></tr>
+  <tr><td>10:00 am</td><td>12:00 pm</td><td>Soybean Genomics Executive Committee Meeting</td></tr>
+  <tr><td>1:00 pm</td><td>5:00 pm</td><td>Technicians Workshop</td></tr>
+  <tr><td>7:00 pm</td><td>8:00 pm</td><td>Soybean Genetics Committee</td></tr>
+</body>
+</table>
+</div>
+<h3>Tuesday, February 13th, 2024</h3>  
+<div class="uk-overflow-auto">
+<table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
+    <thead>
+        <tr>
+            <th class="uk-table-shrink">Start</th>
+            <th class="uk-table-shrink">End</th>
+            <th class="uk-table-expand">Meeting</th>
+        </tr>
+    </thead>
+<body>
+  <tr><td>8:00 am</td><td>12:00 pm</td><td>Technicians Workshop</td></tr>
+  <tr><td>7:00 pm</td><td>7:30 pm</td><td>Uniform Regional Testing - North</td></tr>
+  <tr><td>7:00 pm</td><td>8:00 pm</td><td>Uniform Regional Testing - South</td></tr>
+  <tr><td>7:30 pm</td><td>8:00 pm</td><td>SCN Regional Testing</td></tr>
+</body>
+</table>
+</div>
+<h3>Wednesday, February 14th, 2024</h3>  
+<div class="uk-overflow-auto">
+<table class="uk-table uk-table-small uk-table-hover uk-table-divider uk-table-middle">
+    <thead>
+        <tr>
+            <th class="uk-table-shrink">Start</th>
+            <th class="uk-table-shrink">End</th>
+            <th class="uk-table-expand">Meeting</th>
+        </tr>
+    </thead>
+<body>
 
 
 
-  <h3>Tuesday February 13th, 2024 | Room: Versailles 1</h3>
   

--- a/community/sbw/SBW/SBW_2024.html
+++ b/community/sbw/SBW/SBW_2024.html
@@ -9,6 +9,9 @@ sitemap: community/sbw
 <div class="uk-margin">
   <a class="uk-text-bold" href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2024/2024officers.pdf"> <span class="uk-margin-right-small" uk-icon="icon: users; ratio: 1.5"></span> 2024 Soybean Breeders Workshop Planning Committee</a>
 </div>
+<div>
+  <a class="uk-text-bold" href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2024/2024Agenda.v2.pdf" target="_blank">View the published 2024 SBW Agenda</a>
+</div>
 
 <h3>Monday February 12th, 2024 | Room: Versailles 1</h3>
 <div class="uk-overflow-auto">

--- a/community/sbw/index.html
+++ b/community/sbw/index.html
@@ -35,8 +35,9 @@ sitemap: community/sbw
 						<a href="./SBW/SBW_2014.html" target="_blank">2014</a>
 						<a href="./SBW/SBW_2016.html" target="_blank">2016</a>
 						<a href="./SBW/SBW_2017.html" target="_blank">2017</a>
-						<p>2024</p>
-						<p>2025</p>		
+						<a href="./SBW/SBW_2024.html" target="_blank">2024</a>
+						<a href="https://data.soybase.org/annex/Glycine/max/meetings/soybean_breeders_workshop/SBW_2025/SBW2025_Agenda_2025_02_18.pdf">2025</a>
+						<p>2026</p>	
 					</div>
 							
 					<h4>Agenda only; No submitted Presenations</h4>


### PR DESCRIPTION
I noticed a lot of differences between SBW_YEAR.html pages.  Here are the list of things I did to the SBW pages:

1.  /community/sbw/index.html -- added links to 2024 SBW page and 2025 agenda link
2. /community/sbw/SBW/SBW_YEAR.html

- changed all presentation links from data.legumeinfo.org to data.soybase.org
- change the html table format so that all pages have the same layout
