### PR TITLE
Gene symbols synonyms

### DIFF
--- a/_data/gene_symbols.tsv
+++ b/_data/gene_symbols.tsv
@@ -16,36 +16,33 @@ AAH2	allantoate deiminase 2	glyma.Wm82.gnm2.ann1.Glyma.09g050800
 AAT	aspartate aminotransferase glyoxysomal isozyme AAT1 precursor	glyma.Wm82.gnm2.ann1.Glyma.06g082400
 ABA3	molybdenum cofactor sulfurtransferase 3	glyma.Wm82.gnm2.ann1.Glyma.09G002300
 ABCC8	ABC Transporter C8	glyma.Wm82.gnm2.ann1.Glyma.07G011600
-ABF1	ABF1 bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02G131700
-ABF2	ABF2 bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04G039300
-ABI5	protein ABSCISIC ACID-INSENSITIVE 5	glyma.Wm82.gnm2.ann1.Glyma.10g071700
+ABF1, bZIP14	Basic leucine zipper transcription factor-like protein gene 14	glyma.Wm82.gnm2.ann1.Glyma.02G131700
+ABF2, bZIP33	Basic leucine zipper transcription factor-like protein gene 33	glyma.Wm82.gnm2.ann1.Glyma.04G039300
+ABI5, bZIP74	Basic leucine zipper transcription factor-like protein gene 74	glyma.Wm82.gnm2.ann1.Glyma.10G071700
 ACCA-1	alpha-carboxyltransferase aCT-1 precursor	glyma.Wm82.gnm2.ann1.Glyma.18g195700
 ACCA-2	alfa-carboxyltransferase precursor	glyma.Wm82.gnm2.ann1.Glyma.18g195900
 ACCA-3	carboxyl transferase alpha subunit	glyma.Wm82.gnm2.ann1.Glyma.18g196000
-ACCase	acetyl-CoA carboxylase	glyma.Wm82.gnm2.ann1.Glyma.05g221100
 ACCB-1	biotin carboxyl carrier protein precursor	glyma.Wm82.gnm2.ann1.Glyma.18g243500
 ACCB-2	biotin carboxyl carrier protein subunit	glyma.Wm82.gnm2.ann1.Glyma.18g265300
 ACCC-3	biotin carboxylase precursor	glyma.Wm82.gnm2.ann1.Glyma.08g027600
+ACCase	acetyl-CoA carboxylase	glyma.Wm82.gnm2.ann1.Glyma.05g221100
 ACP1	acid phosphatase 1	glyma.Wm82.gnm2.ann1.Glyma.08g195100
-ACPD	stearoyl-acyl carrier protein desaturase	glyma.Wm82.gnm2.ann1.Glyma.02g138100
-ACPD-1	stearoyl-acyl carrier protein desaturase gene 1	glyma.Wm82.gnm2.ann1.Glyma.02g138100
-ACPD-2	stearoyl-acyl carrier protein desaturase gene 2	glyma.Wm82.gnm2.ann1.Glyma.07g207200
-ACPD-3	stearoyl-acyl carrier protein desaturase gene 3	glyma.Wm82.gnm2.ann1.Glyma.14g121400
+ACPD, ACPD-1, FAB2, SACPD, SAD1	stearoyl-acyl carrier protein desaturase	glyma.Wm82.gnm2.ann1.Glyma.02g138100
+ACPD-2, SAD2	stearoyl-ACP desaturase 2	glyma.Wm82.gnm2.ann1.Glyma.07g207200
+ACPD-3, SACPD-C	stearoyl-acyl carrier protein desaturase	glyma.Wm82.gnm2.ann1.Glyma.14g121400
 ACS10a	ACC Synthase 10 gene a	glyma.Wm82.gnm2.ann1.Glyma.01G213700
 ACS10b	ACC Synthase 10 gene b	glyma.Wm82.gnm2.ann1.Glyma.11G028200
 ACSL2	long-chain acyl-CoA synthetase ACSL2	glyma.Wm82.gnm2.ann1.Glyma.05g151200
-ACT2/7	BAHD acyltransferase 2/7	glyma.Wm82.gnm2.ann1.Glyma.19G147900
-ACTIN	actin-6	glyma.Wm82.gnm2.ann1.Glyma.18g290800
-Actin11	Actin 11	glyma.Wm82.gnm1.ann1.Glyma02g10170
+ACT2/7, UBQ10	polyubiquitin 10	glyma.Wm82.gnm2.ann1.Glyma.19G147900
+ACTIN, SAc6	Actin 6 gene	glyma.Wm82.gnm2.ann1.Glyma.18g290800
 ACX1;1	acyl-CoA oxidase	glyma.Wm82.gnm2.ann1.Glyma.11g035200
 ACX1;2	acyl-CoA oxidase	glyma.Wm82.gnm2.ann1.Glyma.05g062200
 ADC	arginine decarboxylase	glyma.Wm82.gnm2.ann1.Glyma.06g007500
 ADF1	actin depolymerizing factor 1	glyma.Wm82.gnm2.ann1.Glyma.15g125300
-ADO3	Adagio 3 like gene	glyma.Wm82.gnm2.ann1.Glyma.08g046500
+ADO3, FKF2	Flavin-binding Kelch Repeat F-Box 2 gene	glyma.Wm82.gnm2.ann1.Glyma.08g046500
 ADR11	AAI_LTSS superfamily protein	glyma.Wm82.gnm2.ann1.Glyma.17g111100
 ADT2 	AROGENATE DEHYDRATASE 2	glyma.Wm82.gnm1.ann1.Glyma12g07720
-AFB2	AUXIN SIGNALING F-BOX 2	glyma.Wm82.gnm2.ann1.Glyma.19G100200
-AFB3A	auxin signaling F-box 3 protein	glyma.Wm82.gnm2.ann1.Glyma.19g100200
+AFB2, AFB3A	auxin signaling F-box 3 protein	glyma.Wm82.gnm2.ann1.Glyma.19g100200
 AFB3B	auxin signaling F-box 3 protein	glyma.Wm82.gnm2.ann1.Glyma.16g050500
 AG1	arginase	glyma.Wm82.gnm2.ann1.Glyma.03g0280001
 AGL1	agamous-like MADS-box protein AGL1	glyma.Wm82.gnm2.ann1.Glyma.14g027200
@@ -55,29 +52,29 @@ AGL1L	agamous-like MADS-box protein AGL1-like	glyma.Wm82.gnm2.ann1.Glyma.08g3101
 AGL20	Agamous-Like 20	glyma.Wm82.gnm2.ann1.Glyma.07G080900
 AGL3L	agamous-like MADS-box protein AGL3-like	glyma.Wm82.gnm2.ann1.Glyma.08g105400
 AGL8a	Agamous 8-Like gene a	glyma.Wm82.gnm2.ann1.Glyma.17G081200
-AGL8b	Agamous 8-Like gene b	glyma.Wm82.gnm2.ann1.Glyma.06G205800
+AGL8b, AP1A, FULa	Fruitfull gene a	glyma.Wm82.gnm2.ann1.Glyma.06g205800
 AGL8c	Agamous 8-Like gene c	glyma.Wm82.gnm2.ann1.Glyma.13G052100
 AGL8d	Agamous 8-Like gene d	glyma.Wm82.gnm2.ann1.Glyma.19G034600
 AGO2	Argonaut 2 ranscription factor	glyma.Wm82.gnm2.ann1.Glyma.20G022900
 AGO4	Argonaut 4 ranscription factor	glyma.Wm82.gnm2.ann1.Glyma.02G274900
-AHAS1	acetohydroxyacid synthase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.04g196100
-AHAS2	acetohydroxyacid synthase 2 gene	glyma.Wm82.gnm2.ann1.Glyma.06g169700
-AHAS3	Acetohydroxy acid synthase  gene 3	glyma.Wm82.gnm2.ann1.Glyma.13g241000
-AHAS4	acetohydroxyacid synthase  gene 4	glyma.Wm82.gnm2.ann1.Glyma.15g072500
+AHAS1, ALS-1, ALS1	Acetolactate synthase gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g196100
+AHAS2, ALS-2, ALS2	Acetolactate synthase gene 2	glyma.Wm82.gnm2.ann1.Glyma.06g169700
+AHAS3, ALS-3, ALS3	Acetolactate synthase gene 3	glyma.Wm82.gnm2.ann1.Glyma.13g241000
+AHAS4, ALS-4, ALS4	Acetolactate synthase gene 4	glyma.Wm82.gnm2.ann1.Glyma.15g072500
 AIR12	plasma membrane ascorbate-reducible b-type cytochrome family protein	glyma.Wm82.gnm2.ann1.Glyma.03g088900
 AK-HSDH	aspartokinase-homoserine dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.08g107800
 AKR1	probable aldo-keto reductase 1	glyma.Wm82.gnm2.ann1.Glyma.03g248400
 AKT2	Potassium channel AKT2 gene	glyma.Wm82.gnm2.ann1.Glyma.08g187600
 ALAAT1	alanine aminotransferase 1	glyma.Wm82.gnm2.ann1.Glyma.16g013900
 ALAAT2	alanine aminotransferase 2	glyma.Wm82.gnm2.ann1.Glyma.01g026700
-ALAD	delta-aminolevulinic acid dehydratase, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.04g247700
+ALAD, HEMB	aminolevulinate, delta-, dehydratase	glyma.Wm82.gnm2.ann1.Glyma.04g247700
 ALDH10A1	betaine aldehyde dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.05g033500
 ALDH10A2	betaine aldehyde dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.06g186300
 ALDH11A1	aldehyde dehydrogenase 11A1	glyma.Wm82.gnm2.ann1.Glyma.02g202500
 ALDH11A2	aldehyde dehydrogenase 11A2	glyma.Wm82.gnm2.ann1.Glyma.17g075300
 ALDH11A3	aldehyde dehydrogenase 11A3	glyma.Wm82.gnm2.ann1.Glyma.17g218200
 ALDH12A1	aldehyde dehydrogenase 12A1	glyma.Wm82.gnm2.ann1.Glyma.05g029100
-ALDH12A2	aldehyde dehydrogenase 12A2	glyma.Wm82.gnm2.ann1.Glyma.05g029200
+ALDH12A2, P5CD	delta-pyrroline-5-corboxylate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.05G029200
 ALDH12A3	aldehyde dehydrogenase 12A3	glyma.Wm82.gnm2.ann1.Glyma.17g097800
 ALDH18B1	delta-1-pyrroline-5-carboxylate synthase	glyma.Wm82.gnm2.ann1.Glyma.01g099800
 ALDH18B2	delta-1-pyrroline-5-carboxylate synthase	glyma.Wm82.gnm2.ann1.Glyma.02g251100
@@ -145,14 +142,6 @@ ALMT4	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.
 ALMT5	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.02g147900
 ALMT6	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.03g152700
 ALMT8	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.05g112700
-ALS-1	Acetolactate synthase  gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g196100
-ALS-2	Acetolactate synthase  gene 2	glyma.Wm82.gnm2.ann1.Glyma.06g169700
-ALS-3	Acetolactate synthase  gene 3	glyma.Wm82.gnm2.ann1.Glyma.13g241000
-ALS-4	Acetolactate synthase  gene 4	glyma.Wm82.gnm2.ann1.Glyma.15g072500
-ALS1	Acetolactate synthase gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g196100
-ALS2	Acetolactate synthase gene 2	glyma.Wm82.gnm2.ann1.Glyma.06g169700
-ALS3	Acetolactate synthase gene 3	glyma.Wm82.gnm2.ann1.Glyma.13g241000
-ALS4	Acetolactate synthase gene 4	glyma.Wm82.gnm2.ann1.Glyma.15g072500
 AMF3	ammonium-facilitator 3	glyma.Wm82.gnm1.ann1.Glyma15g06660
 AMF5	ammonium-facilitator 5	glyma.Wm82.gnm1.ann1.Glyma09g33680
 AMS1	beta-amyrin synthase	glyma.Wm82.gnm2.ann1.Glyma.07g001300
@@ -169,8 +158,6 @@ AMT4.2	ammonium transporter AMT4.2	glyma.Wm82.gnm2.ann1.Glyma.20g004100
 AMT4.3	ammonium transporter AMT4.3	glyma.Wm82.gnm2.ann1.Glyma.19g244400
 AMT4.4	ammonium transporter AMT4.4	glyma.Wm82.gnm2.ann1.Glyma.02g043700
 AMT4.5	ammonium transporter AMT4.5	glyma.Wm82.gnm2.ann1.Glyma.02g143500
-Amy1	Alpha-amylase 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g017700
-Amy3	Alpha-amylase 3 gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g296800
 AN1	zinc finger A20 and AN1 domain-containing stress-associated protein 5-like	glyma.Wm82.gnm2.ann1.Glyma.08g153200
 ANK4	ankyrin repeats-containing protein	glyma.Wm82.gnm2.ann1.Glyma.01g150400
 ANK6	ankyrin repeats-containing protein	glyma.Wm82.gnm2.ann1.Glyma.02g033700
@@ -181,7 +168,7 @@ ANR1	Anthocyanidin reductase 1	glyma.Wm82.gnm1.ann1.Glyma08g06630
 ANR2	Anthocyanidin reductase 2	glyma.Wm82.gnm1.ann1.Glyma08g06640
 ANS2	Anthocyanidin synthase 2	glyma.Wm82.gnm2.ann1.Glyma.01g214200
 ANS3	Anthocyanidin synthase 3	glyma.Wm82.gnm2.ann1.Glyma.11g027700
-AO	ascorbate oxidase	glyma.Wm82.gnm2.ann1.Glyma.20g051700
+AO, Lac84	Laccase 84	glyma.Wm82.gnm2.ann1.Glyma.20G051700
 AOC1	allene oxide cyclase 4, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.01g086900
 AOC3	amine oxidase, copper containing 3 (vascular adhesion protein 1)	glyma.Wm82.gnm2.ann1.Glyma.19g044900
 AOC4	allene oxide cyclase 3, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.13g047300
@@ -194,30 +181,27 @@ AOX1	ubiquinol oxidase 1, mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.04g123800
 AOX1A	alternative oxidase 1A  	glyma.Wm82.gnm1.ann1.Glyma04g14800
 AOX2	alternative oxidase 2a	glyma.Wm82.gnm2.ann1.Glyma.08g072300
 AOX3	alternative oxidase 3, mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.08g072200
-AP1A	agamous-like MADS-box protein AGL8 homolog	glyma.Wm82.gnm2.ann1.Glyma.06g205800
 AP1b	Apetella 1 gene b	glyma.Wm82.gnm2.ann1.Glyma.01g064200
 AP1c	Apetella 1 gene c	glyma.Wm82.gnm2.ann1.Glyma.08g250800
 AP2-1	dehydration-responsive element-binding protein 3-like	glyma.Wm82.gnm2.ann1.Glyma.06g085700
 AP2-2	AP2 domain-containing transcription factor 2	glyma.Wm82.gnm2.ann1.Glyma.04g084000
-AP2-3	AP2 domain-containing transcription factor 3	glyma.Wm82.gnm2.ann1.Glyma.13g081600
-AP2-4	AP2 domain-containing transcription factor 4	glyma.Wm82.gnm2.ann1.Glyma.14g147500
-AP2-5	AP2 domain-containing transcription factor 5	glyma.Wm82.gnm2.ann1.Glyma.06g111300
+AP2-3, ERF96	Ethylene-responsive factor gene 96	glyma.Wm82.gnm2.ann1.Glyma.13G081600
+AP2-4, ERF115	Ethylene-responsive factor gene 115	glyma.Wm82.gnm2.ann1.Glyma.14G147500
+AP2-5, ERF44	Ethylene-responsive factor gene 44	glyma.Wm82.gnm2.ann1.Glyma.06G111300
 AP2-6	AP2 domain-containing transcription factor 6	glyma.Wm82.gnm2.ann1.Glyma.04g251400
 AP2-8	dehydration-responsive element-binding protein 2C-like	glyma.Wm82.gnm2.ann1.Glyma.02g261700
 AP2-9	AP2-EREBP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.11g018100
 AP3a	Apetala 3 gene a	glyma.Wm82.gnm2.ann1.Glyma.01G169600
-AP3b	Apetala 3 gene b	glyma.Wm82.gnm2.ann1.Glyma.06G027200
+AP3b, NMH7	MADS-box protein NMH7	glyma.Wm82.gnm2.ann1.Glyma.06g027200
 APS-5a2	Ascorbate peroxidase 5 gene a2	glyma.Wm82.gnm2.ann1.Glyma.11g080900
-APX	Ascorbate Peroxidase	glyma.Wm82.gnm2.ann1.Glyma.03G038700
-APX-1	Ascorbate peroxidase 1	glyma.Wm82.gnm2.ann1.Glyma.U021900
-APX-2	Ascorbate peroxidase 2	glyma.Wm82.gnm2.ann1.Glyma.12G073100
+APX, POD1	Peroxidase 1	glyma.Wm82.gnm2.ann1.Glyma.03G038700
+APX-1, APX1	ascorbate peroxidase 1, cytosolic	glyma.Wm82.gnm2.ann1.Glyma.u021900
+APX-2, APX2	L-ascorbate peroxidase 2	glyma.Wm82.gnm2.ann1.Glyma.12g073100
 APX-3a1	Ascorbate peroxidase 3 gene a1	glyma.Wm82.gnm2.ann1.Glyma.11G107200
 APX-3a2	Ascorbate peroxidase 3 gene a2	glyma.Wm82.gnm2.ann1.Glyma.11G078400
 APX-4a	Ascorbate peroxidase 4 gene a	glyma.Wm82.gnm2.ann1.Glyma.02G209000
 APX-4b	Ascorbate peroxidase 6 gene b	glyma.Wm82.gnm2.ann1.Glyma.14G177200
 APX-5a1	Ascorbate peroxidase 5 gene a1	glyma.Wm82.gnm2.ann1.Glyma.01G164700
-APX1	ascorbate peroxidase 1, cytosolic	glyma.Wm82.gnm2.ann1.Glyma.u021900
-APX2	L-ascorbate peroxidase 2	glyma.Wm82.gnm2.ann1.Glyma.12g073100
 APX6	Ascorbate peroxidase 6 	glyma.Wm82.gnm2.ann1.Glyma.06G068200
 AR791	actin binding	glyma.Wm82.gnm1.ann1.Glyma13g42970
 ARF	ADP-ribosylation factor	glyma.Wm82.gnm2.ann1.Glyma.19g006400
@@ -229,9 +213,8 @@ ARI2	putative E3 ubiquitin-protein ligase ARI2	glyma.Wm82.gnm2.ann1.Glyma.12g053
 ARI3	putative E3 ubiquitin-protein ligase ARI3	glyma.Wm82.gnm2.ann1.Glyma.15g031100
 ARI7	ariadne A subfamily protein ARI7	glyma.Wm82.gnm2.ann1.Glyma.11g121300
 ARPC4	ARP2/3 complex 20 kDa subunit  4	glyma.Wm82.gnm2.ann1.Glyma.08G111500
-AS1	asparagine synthetase 1	glyma.Wm82.gnm2.ann1.Glyma.18g061100
+AS1, ASNS	glutamine-dependent asparagine synthetase	glyma.Wm82.gnm2.ann1.Glyma.18G061100
 AS2	asparagine synthetase 2	glyma.Wm82.gnm2.ann1.Glyma.14g195000
-ASNS	glutamine-dependent asparagine synthetase	glyma.Wm82.gnm2.ann1.Glyma.18G061100
 ASP1	L-asparaginase	glyma.Wm82.gnm2.ann1.Glyma.14g086300
 AT-1SNBP	HMG I/Y like protein	glyma.Wm82.gnm2.ann1.Glyma.08g052600
 AT133	malonyl-CoA:isoflavone 7-O-glucoside-6''-O-malonyltransferase	glyma.Wm82.gnm2.ann1.Glyma.19g030500
@@ -244,10 +227,13 @@ ATG8d	autophagy-related protein 8d	glyma.Wm82.gnm2.ann1.Glyma.12g098400
 ATG8i	autophagy-related protein 8i	glyma.Wm82.gnm2.ann1.Glyma.02g008800
 ATPC	ATP synthase gamma chain, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.15g107900
 ATS9	NON-ATPASE SUBUNIT 9	glyma.Wm82.gnm1.ann1.Glyma04g08280
-AUX28	Auxin-regulated protein 28	glyma.Wm82.gnm2.ann1.Glyma.19g161100
+AUX28, IAA56	Indole-3-Acetic Acid Responsive Gene 56	glyma.Wm82.gnm2.ann1.Glyma.19G161100
+Actin11	Actin 11	glyma.Wm82.gnm1.ann1.Glyma02g10170
+Amy1	Alpha-amylase 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g017700
+Amy3	Alpha-amylase 3 gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g296800
 B12	AS3/PDS5-related	glyma.Wm82.gnm2.ann1.Glyma.06g062700
-B13-1-1	syringolide-induced protein B13-1-1	glyma.Wm82.gnm2.ann1.Glyma.u040600
-B13-1-9	syringolide-induced protein B13-1-9	glyma.Wm82.gnm2.ann1.Glyma.03g201300
+B13-1-1, Lac93	Laccase 93	glyma.Wm82.gnm2.ann1.Glyma.U040600
+B13-1-9, LEA2-15	late embryogenesis abundant 2 gene 15	glyma.Wm82.gnm2.ann1.Glyma.03G201300
 B15-3-5	syringolide-induced protein B15-3-5	glyma.Wm82.gnm2.ann1.Glyma.03g001500
 B3	B3 domain protein	glyma.Wm82.gnm2.ann1.Glyma.10g076100
 BAG6A	BAG family molecular chaperone regulator 6	glyma.Wm82.gnm2.ann1.Glyma.07g061500
@@ -263,7 +249,7 @@ BCH4	beta-carotene hydroxylase 4	glyma.Wm82.gnm2.ann1.Glyma.20g162600
 BCH5	beta-carotene hydroxylase 5	glyma.Wm82.gnm2.ann1.Glyma.09g132200
 BEHL1	BES1/BZR1 family protein	glyma.Wm82.gnm2.ann1.Glyma.01g178000
 BEN1	Brassinosteriod Insensitive 1 Enhanced 1 gene	glyma.Wm82.gnm1.ann1.Glyma09g40590
-BES1	Transcription Factor	glyma.Wm82.gnm2.ann1.Glyma.06G034000
+BES1, BZL3	protein BRASSINAZOLE-RESISTANT 1-like	glyma.Wm82.gnm2.ann1.Glyma.06g034000
 BES1-1	protein BRI1-EMS-SUPPRESSOR 1	glyma.Wm82.gnm2.ann1.Glyma.17g248900
 BES1-10	protein BRI1-EMS-SUPPRESSOR 1	glyma.Wm82.gnm2.ann1.Glyma.12g231400
 BES1-11	protein BRI1-EMS-SUPPRESSOR 1	glyma.Wm82.gnm2.ann1.Glyma.13g266500
@@ -277,25 +263,18 @@ BFA3	chloroplast stromal protein BFA3	glyma.Wm82.gnm2.ann1.Glyma.12g038800
 BFT	phosphatidylethanolamine-binding protein BFT	glyma.Wm82.gnm2.ann1.Glyma.16g196300
 BG7S-1	basic 7S globulin	glyma.Wm82.gnm2.ann1.Glyma.03g239700
 BG7S-2	basic 7S globulin 2	glyma.Wm82.gnm2.ann1.Glyma.19g236600
-bHLH15	bHLH protein	glyma.Wm82.gnm2.ann1.Glyma.15G005100
 BHLH30	Basic helix-loop-helix transcription factor 30	glyma.Wm82.gnm2.ann1.Glyma.02G100700
 BHLH300	bHLH transcription factor bHLH300	glyma.Wm82.gnm2.ann1.Glyma.03g130600
 BHLH320	bHLH transcription factor bHLH320	glyma.Wm82.gnm2.ann1.Glyma.03g130400
 BHLH322	bHLH transcription factor bHLH322	glyma.Wm82.gnm2.ann1.Glyma.19g132600
-bHLH35	PREDICTED: transcription factor bHLH35-like	glyma.Wm82.gnm2.ann1.Glyma.13G101100
-bHLH5	bHLH protein	glyma.Wm82.gnm2.ann1.Glyma.05G134400
 BHLH56	basic helix-loop-helix transcription factor	glyma.Wm82.gnm2.ann1.Glyma.13g322100
 BHLH57	bHLH transcription factor	glyma.Wm82.gnm2.ann1.Glyma.12g178500
 BHLH59	basic helix-loop-helix transcription factor bHLH59	glyma.Wm82.gnm2.ann1.Glyma.11g192800
-bHLH7	bHLH protein	glyma.Wm82.gnm2.ann1.Glyma.07G205800
-Bic-C1	Bicaudal- C gene 1	glyma.Wm82.gnm2.ann1.Glyma.08G113000
-Bic-c2	Bicaudal- C gene 2	glyma.Wm82.gnm2.ann1.Glyma.03G064800
 BIK1-2	BOTRYTIS INDUCED KINASE1 gene 2	glyma.Wm82.gnm1.ann1.Glyma02g41490
 BIK1-6	BOTRYTIS INDUCED KINASE1 gene 6	glyma.Wm82.gnm1.ann1.Glyma14g07460
-BIP2	ER-binding immunoglobulin protein BIP2	glyma.Wm82.gnm2.ann1.Glyma.08g025900
-BMY1	beta-amylase	glyma.Wm82.gnm2.ann1.Glyma.15g098100
+BIP2, MED37-7	Mediator Complex 37 gene 7	glyma.Wm82.gnm2.ann1.Glyma.08g025900
+BMY1, BMY1-2	Beta-amylase 1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.15g098100
 BMY1-1	Beta-amylase 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.06g301500
-BMY1-2	Beta-amylase 1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.15g098100
 BMY1-3	Beta-amylase 1 gene 3	glyma.Wm82.gnm2.ann1.Glyma.08g025500
 BMY2	Beta-amylase 2	glyma.Wm82.gnm2.ann1.Glyma.17g150100
 BMY3-1	Beta-amylase 3 gene 1	glyma.Wm82.gnm2.ann1.Glyma.05g068000
@@ -303,7 +282,7 @@ BMY3-2	Beta-amylase 3 gene 2	glyma.Wm82.gnm2.ann1.Glyma.01g203400
 BMY3-3	Beta-amylase 3 gene 3	glyma.Wm82.gnm2.ann1.Glyma.11g039400
 BMY9	Beta-amylase 9	glyma.Wm82.gnm2.ann1.Glyma.13g215000
 BOR2	boron transporter BOR2	glyma.Wm82.gnm2.ann1.Glyma.06g181900
-BRC1	TCP tanscription factor BRC1	glyma.Wm82.gnm2.ann1.Glyma.06g210600
+BRC1, TCP48	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 48	glyma.Wm82.gnm2.ann1.Glyma.06G210600
 BRI1A	brassinosteroid receptor	glyma.Wm82.gnm2.ann1.Glyma.06g147600
 BRI1B	brassinosteroid receptor	glyma.Wm82.gnm2.ann1.Glyma.04g218300
 BRL1A	brassinosteroid receptor-like protein	glyma.Wm82.gnm2.ann1.Glyma.04g115700
@@ -312,95 +291,9 @@ BRL2A	brassinosteroid receptor-like protein	glyma.Wm82.gnm2.ann1.Glyma.05g136900
 BRL2B	brassinosteroid receptor-like protein	glyma.Wm82.gnm2.ann1.Glyma.08g092200
 BSAS	beta-substituted alanine synthase	glyma.Wm82.gnm2.ann1.Glyma.19g119100
 BURP2	BURP domain protein 2	glyma.Wm82.gnm2.ann1.Glyma.14g140900
-bZIP100	Basic leucine zipper transcription factor-like protein gene 100	glyma.Wm82.gnm2.ann1.Glyma.12G088700
-bZIP102	Basic leucine zipper transcription factor-like protein gene 102	glyma.Wm82.gnm2.ann1.Glyma.12G121000
-bZIP103	Basic leucine zipper transcription factor-like protein gene 103	glyma.Wm82.gnm2.ann1.Glyma.12G184400
-bZIP106	Basic leucine zipper transcription factor-like protein gene 106	glyma.Wm82.gnm2.ann1.Glyma.12G227700
-bZIP107	Basic leucine zipper transcription factor-like protein gene 107	glyma.Wm82.gnm2.ann1.Glyma.13G050700
-bZIP116	Basic leucine zipper transcription factor-like protein gene 116	glyma.Wm82.gnm2.ann1.Glyma.13G316900
-bZIP118	Basic leucine zipper transcription factor-like protein gene 118	glyma.Wm82.gnm2.ann1.Glyma.13G345200
-bZIP12	Basic leucine zipper transcription factor-like protein gene 12	glyma.Wm82.gnm2.ann1.Glyma.02G097900
-bZIP120	Basic leucine zipper transcription factor-like protein gene 120	glyma.Wm82.gnm2.ann1.Glyma.14G167000
-bZIP127	Basic leucine zipper transcription factor-like protein gene 127	glyma.Wm82.gnm2.ann1.Glyma.15G129700
-bZIP129	Basic leucine zipper transcription factor-like protein gene 129	glyma.Wm82.gnm2.ann1.Glyma.15G232000
-bZIP13	Basic leucine zipper transcription factor-like protein gene 13	glyma.Wm82.gnm2.ann1.Glyma.02G126100
-bZIP131	Basic leucine zipper transcription factor-like protein gene 131	glyma.Wm82.gnm2.ann1.Glyma.16G092700
-bZIP133	Basic leucine zipper transcription factor-like protein gene 133	glyma.Wm82.gnm2.ann1.Glyma.16G141500
-bZIP134	Basic leucine zipper transcription factor-like protein gene 134	glyma.Wm82.gnm2.ann1.Glyma.16G168400
-bZIP135	Basic leucine zipper transcription factor-like protein gene 135	glyma.Wm82.gnm2.ann1.Glyma.17G158900
-bZIP136	Basic leucine zipper transcription factor-like protein gene 136	glyma.Wm82.gnm2.ann1.Glyma.17G188500
-bZIP137	Basic leucine zipper transcription factor-like protein gene 137	glyma.Wm82.gnm2.ann1.Glyma.17G197300
-bZIP138	Basic leucine zipper transcription factor-like protein gene 138	glyma.Wm82.gnm2.ann1.Glyma.17G253200
-bZIP139	Basic leucine zipper transcription factor-like protein gene 139	glyma.Wm82.gnm2.ann1.Glyma.17G255800
-bZIP14	Basic leucine zipper transcription factor-like protein gene 14	glyma.Wm82.gnm2.ann1.Glyma.02G131700
-bZIP140	Basic leucine zipper transcription factor-like protein gene 140	glyma.Wm82.gnm2.ann1.Glyma.18G020900
-bZIP141	Basic leucine zipper transcription factor-like protein gene 141	glyma.Wm82.gnm2.ann1.Glyma.18G052500
-bZIP142	Basic leucine zipper transcription factor-like protein gene 142	glyma.Wm82.gnm2.ann1.Glyma.18G117100
-bZIP143	Basic leucine zipper transcription factor-like protein gene 143	glyma.Wm82.gnm2.ann1.Glyma.18G277100
-bZIP144	Basic leucine zipper transcription factor-like protein gene 144	glyma.Wm82.gnm2.ann1.Glyma.19G037900
-bZIP145	Basic leucine zipper transcription factor-like protein gene 145	glyma.Wm82.gnm2.ann1.Glyma.19G067900
-bZIP146	Basic leucine zipper transcription factor-like protein gene 146	glyma.Wm82.gnm2.ann1.Glyma.19G122800
-bZIP147	Basic leucine zipper transcription factor-like protein gene 147	glyma.Wm82.gnm2.ann1.Glyma.19G126800
-bZIP148	Basic leucine zipper transcription factor-like protein gene 148	glyma.Wm82.gnm2.ann1.Glyma.19G130200
-bZIP149	Basic leucine zipper transcription factor-like protein gene 149	glyma.Wm82.gnm2.ann1.Glyma.19G145300
-bZIP15	Basic leucine zipper transcription factor-like protein gene 15	glyma.Wm82.gnm2.ann1.Glyma.02G161100
-bZIP150	Basic leucine zipper transcription factor-like protein gene 150	glyma.Wm82.gnm2.ann1.Glyma.19G193400
-bZIP151	Basic leucine zipper transcription factor-like protein gene 151	glyma.Wm82.gnm2.ann1.Glyma.19G194500
-bZIP152	Basic leucine zipper transcription factor-like protein gene 152	glyma.Wm82.gnm2.ann1.Glyma.19G216200
-bZIP153	Basic leucine zipper transcription factor-like protein gene 153	glyma.Wm82.gnm2.ann1.Glyma.19G244800
-bZIP154	Basic leucine zipper transcription factor-like protein gene 154	glyma.Wm82.gnm2.ann1.Glyma.19G252600
-bZIP155	Basic leucine zipper transcription factor-like protein gene 155	glyma.Wm82.gnm2.ann1.Glyma.20G007700
-bZIP156	Basic leucine zipper transcription factor-like protein gene 156	glyma.Wm82.gnm2.ann1.Glyma.20G032700
-bZIP157	Basic leucine zipper transcription factor-like protein gene 157	glyma.Wm82.gnm2.ann1.Glyma.20G049200
-bZIP158	Basic leucine zipper transcription factor-like protein gene 158	glyma.Wm82.gnm2.ann1.Glyma.20G113600
-bZIP159	Basic leucine zipper transcription factor-like protein gene 159	glyma.Wm82.gnm2.ann1.Glyma.20G224500
-bZIP160	Basic leucine zipper transcription factor-like protein gene 160	glyma.Wm82.gnm2.ann1.Glyma.20G246400
-bZIP17	Basic leucine zipper transcription factor-like protein gene 17	glyma.Wm82.gnm2.ann1.Glyma.02G236200
-bZIP18	Basic leucine zipper transcription factor-like protein gene 18	glyma.Wm82.gnm2.ann1.Glyma.03G003400
-bZIP2	Basic leucine zipper transcription factor-like protein gene 2	glyma.Wm82.gnm2.ann1.Glyma.01G069300
-bZIP20	Basic leucine zipper transcription factor-like protein gene 20	glyma.Wm82.gnm2.ann1.Glyma.03G081700
-bZIP23	Basic leucine zipper transcription factor-like protein gene 23	glyma.Wm82.gnm2.ann1.Glyma.03G128200
-bZIP26	Basic leucine zipper transcription factor-like protein gene 26	glyma.Wm82.gnm2.ann1.Glyma.03G219300
-bZIP29	Basic leucine zipper transcription factor-like protein gene 29	glyma.Wm82.gnm2.ann1.Glyma.04G010300
-bZIP31	Basic leucine zipper transcription factor-like protein gene 31	glyma.Wm82.gnm2.ann1.Glyma.04G026200
-bZIP32	Basic leucine zipper transcription factor-like protein gene 32	glyma.Wm82.gnm2.ann1.Glyma.04G029600
-bZIP33	Basic leucine zipper transcription factor-like protein gene 33	glyma.Wm82.gnm2.ann1.Glyma.04G039300
-bZIP34	Basic leucine zipper transcription factor-like protein gene 34	glyma.Wm82.gnm2.ann1.Glyma.04G078300
-bZIP39	Basic leucine zipper transcription factor-like protein gene 39	glyma.Wm82.gnm2.ann1.Glyma.05G017400
-bZIP40	Basic leucine zipper transcription factor-like protein gene 40	glyma.Wm82.gnm2.ann1.Glyma.05G079800
-bZIP41	Basic leucine zipper transcription factor-like protein gene 41	glyma.Wm82.gnm2.ann1.Glyma.05G108200
-bZIP43	Basic leucine zipper transcription factor-like protein gene 43	glyma.Wm82.gnm2.ann1.Glyma.05G157000
-bZIP45	Basic leucine zipper transcription factor-like protein gene 45	glyma.Wm82.gnm2.ann1.Glyma.05G168100
-bZIP49	Basic leucine zipper transcription factor-like protein gene 49	glyma.Wm82.gnm2.ann1.Glyma.06G029600
-bZIP52	Basic leucine zipper transcription factor-like protein gene 52	glyma.Wm82.gnm2.ann1.Glyma.06G062000
-bZIP53	Basic leucine zipper transcription factor-like protein gene 53	glyma.Wm82.gnm2.ann1.Glyma.06G079800
-BZIP53B	bZIP transcription factor 53B	glyma.Wm82.gnm2.ann1.Glyma.19g216200
-bZIP54	Basic leucine zipper transcription factor-like protein gene 54	glyma.Wm82.gnm2.ann1.Glyma.06G107300
-bZIP56	Basic leucine zipper transcription factor-like protein gene 56	glyma.Wm82.gnm2.ann1.Glyma.06G307200
-bZIP57	Basic leucine zipper transcription factor-like protein gene 57	glyma.Wm82.gnm2.ann1.Glyma.06G314400
-bZIP6	Basic leucine zipper transcription factor-like protein gene 6	glyma.Wm82.gnm2.ann1.Glyma.01G177400
-bZIP65	Basic leucine zipper transcription factor-like protein gene 65	glyma.Wm82.gnm2.ann1.Glyma.08G183600
-bZIP66	Basic leucine zipper transcription factor-like protein gene 66	glyma.Wm82.gnm2.ann1.Glyma.08G227000
-bZIP67	Basic leucine zipper transcription factor-like protein gene 67	glyma.Wm82.gnm2.ann1.Glyma.08G254400
-bZIP7	Basic leucine zipper transcription factor-like protein gene 7	glyma.Wm82.gnm2.ann1.Glyma.01G195800
-bZIP73	Basic leucine zipper transcription factor-like protein gene 73	glyma.Wm82.gnm2.ann1.Glyma.10G013300
-BZIP73A	bZIP transcription factor bZIP73A	glyma.Wm82.gnm2.ann1.Glyma.18g277100
-BZIP73B	BZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g254400
-bZIP74	Basic leucine zipper transcription factor-like protein gene 74	glyma.Wm82.gnm2.ann1.Glyma.10G071700
-bZIP75	Basic leucine zipper transcription factor-like protein gene 75	glyma.Wm82.gnm2.ann1.Glyma.10G092100
-bZIP76	Basic leucine zipper transcription factor-like protein gene 76	glyma.Wm82.gnm2.ann1.Glyma.10G162100
-bZIP78	Basic leucine zipper transcription factor-like protein gene 78	glyma.Wm82.gnm2.ann1.Glyma.10G226000
-bZIP79	Basic leucine zipper transcription factor-like protein gene 79	glyma.Wm82.gnm2.ann1.Glyma.10G276100
-bZIP84	Basic leucine zipper transcription factor-like protein gene 84	glyma.Wm82.gnm2.ann1.Glyma.11G108100
-bZIP86	Basic leucine zipper transcription factor-like protein gene 86	glyma.Wm82.gnm2.ann1.Glyma.11G114800
-bZIP88	Basic leucine zipper transcription factor-like protein gene 88	glyma.Wm82.gnm2.ann1.Glyma.11G167400
-bZIP91	Basic leucine zipper transcription factor-like protein gene 91	glyma.Wm82.gnm2.ann1.Glyma.11G168000
-bZIP92	Basic leucine zipper transcription factor-like protein gene 92	glyma.Wm82.gnm2.ann1.Glyma.11G183700
-bZIP95	Basic leucine zipper transcription factor-like protein gene 95	glyma.Wm82.gnm2.ann1.Glyma.12G033000
-bZIP96	Basic leucine zipper transcription factor-like protein gene 96	glyma.Wm82.gnm2.ann1.Glyma.12G036400
-bZIP97	Basic leucine zipper transcription factor-like protein gene 97	glyma.Wm82.gnm2.ann1.Glyma.12G040600
 BZL2	protein BRASSINAZOLE-RESISTANT 1-like	glyma.Wm82.gnm2.ann1.Glyma.14g076900
-BZL3	protein BRASSINAZOLE-RESISTANT 1-like	glyma.Wm82.gnm2.ann1.Glyma.06g034000
+Bic-C1, RHA	RNA helicase A	glyma.Wm82.gnm2.ann1.Glyma.08G113000
+Bic-c2	Bicaudal- C gene 2	glyma.Wm82.gnm2.ann1.Glyma.03G064800
 C/VIF1	pectinesterase inhibitor 	glyma.Wm82.gnm1.ann1.Glyma17g04050
 C2-1	C2 domain containing protein gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G162100
 C2-10	C2 domain containing protein gene 10	glyma.Wm82.gnm2.ann1.Glyma.02G220300
@@ -454,7 +347,7 @@ C2-142	C2 domain containing protein gene 142	glyma.Wm82.gnm2.ann1.Glyma.15G03160
 C2-143	C2 domain containing protein gene 143	glyma.Wm82.gnm2.ann1.Glyma.15G120400
 C2-144	C2 domain containing protein gene 144	glyma.Wm82.gnm2.ann1.Glyma.15G121500
 C2-145	C2 domain containing protein gene 145	glyma.Wm82.gnm2.ann1.Glyma.15G130300
-C2-146	C2 domain containing protein gene 146	glyma.Wm82.gnm2.ann1.Glyma.15G152900
+C2-146, SRC2	SOYBEAN GENE REGULATED BY COLD 2	glyma.Wm82.gnm2.ann1.Glyma.15g152900
 C2-147	C2 domain containing protein gene 147	glyma.Wm82.gnm2.ann1.Glyma.15G236900
 C2-148	C2 domain containing protein gene 148	glyma.Wm82.gnm2.ann1.Glyma.15G245600
 C2-149	C2 domain containing protein gene 149	glyma.Wm82.gnm2.ann1.Glyma.15G271400
@@ -573,7 +466,7 @@ C2-88	C2 domain containing protein gene 88	glyma.Wm82.gnm2.ann1.Glyma.09G014700
 C2-89	C2 domain containing protein gene 89	glyma.Wm82.gnm2.ann1.Glyma.09G015700
 C2-9	C2 domain containing protein gene 9	glyma.Wm82.gnm2.ann1.Glyma.02G176700
 C2-90	C2 domain containing protein gene 90	glyma.Wm82.gnm2.ann1.Glyma.09G024400
-C2-91	C2 domain containing protein gene 91	glyma.Wm82.gnm2.ann1.Glyma.09G045700
+C2-91, COR2	cold-regulated protein	glyma.Wm82.gnm2.ann1.Glyma.09g045700
 C2-92	C2 domain containing protein gene 92	glyma.Wm82.gnm2.ann1.Glyma.09G117100
 C2-93	C2 domain containing protein gene 93	glyma.Wm82.gnm2.ann1.Glyma.09G134500
 C2-94	C2 domain containing protein gene 94	glyma.Wm82.gnm2.ann1.Glyma.09G176900
@@ -626,11 +519,6 @@ CDF3a	Cycling Dof Factor 3 gene a	glyma.Wm82.gnm2.ann1.Glyma.06G194800
 CDF3b	Cycling Dof Factor 3 gene b	glyma.Wm82.gnm2.ann1.Glyma.02G108600
 CDF3c	Cycling Dof Factor 3 gene c	glyma.Wm82.gnm2.ann1.Glyma.05G025900
 CDF3d	Cycling Dof Factor 3 gene d	glyma.Wm82.gnm2.ann1.Glyma.17G101000
-Cdk8-1	Cyclin-dependent kinase 8 gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g207900
-Cdk8-2	Cyclin-dependent kinase 8 gene 2	glyma.Wm82.gnm2.ann1.Glyma.05g145800
-Cdk8-3	Cyclin-dependent kinase 8 gene 3	glyma.Wm82.gnm2.ann1.Glyma.05g195300
-Cdk8-4	Cyclin-dependent kinase 8 gene 4	glyma.Wm82.gnm2.ann1.Glyma.08g002900
-Cdk8-5	Cyclin-dependent kinase 8 gene 6	glyma.Wm82.gnm2.ann1.Glyma.08g102600
 CDPK	Calcium-dependent protein kinase SK5	glyma.Wm82.gnm2.ann1.Glyma.08g005600
 CDPK-BETA	calmodulin-like domain protein kinase isoenzyme beta	glyma.Wm82.gnm2.ann1.Glyma.20g175100
 CDPK-GAMMA	calmodulin-like domain protein kinase isoenzyme gamma	glyma.Wm82.gnm2.ann1.Glyma.08g316500
@@ -643,19 +531,15 @@ CEN3	CENTRORADIALIS-like protein 3	glyma.Wm82.gnm2.ann1.Glyma.12g184000
 CEN4	protein CENTRORADIALIS-like	glyma.Wm82.gnm2.ann1.Glyma.13g317100
 CENH3	Centromere specific histone 3	glyma.Wm82.gnm2.ann1.Glyma.07G057300
 CFIM-25	mRNA and protein family	glyma.Wm82.gnm1.ann1.Glyma09g07670
-CG-1	beta-conglycinin alpha prime subunit	glyma.Wm82.gnm2.ann1.Glyma.10g246300
-CG-ALPHA-2	beta-conglycinin alpha prime subunit 2	glyma.Wm82.gnm2.ann1.Glyma.20g148400
-CG-BETA-1	beta-conglycinin beta-subunit	glyma.Wm82.gnm2.ann1.Glyma.20g146200
+CG-1, GM7S	beta-conglycinin alpha prime subunit 1	glyma.Wm82.gnm2.ann1.Glyma.10g246300
+CG-ALPHA-2, Cgy2	beta-conglycinin alpha prime subunit 2	glyma.Wm82.gnm2.ann1.Glyma.20g148400
+CG-BETA-1, Cgy4	beta-conglycinin beta-subunit 4	glyma.Wm82.gnm2.ann1.Glyma.20g146200
 CG-BETA-2	beta-conglycinin, beta chain-like	glyma.Wm82.gnm2.ann1.Glyma.20g148200
 CGS1	cystathionine gamma-synthase 1, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.18g261600
 CGS2	cystathionine-gamma-synthase	glyma.Wm82.gnm2.ann1.Glyma.09g235400
-Cgy2	beta-conglycinin alpha prime subunit 2	glyma.Wm82.gnm2.ann1.Glyma.20g148400
-Cgy4	beta-conglycinin beta-subunit 4	glyma.Wm82.gnm2.ann1.Glyma.20g146200
-CHI1	chalcone-flavonone isomerase 1A	glyma.Wm82.gnm2.ann1.Glyma.20g241500
-CHI1A	chalcone-flavonone isomerase 1A	glyma.Wm82.gnm2.ann1.Glyma.20g241500
-CHI1B1	chalcone isomerase 1B1	glyma.Wm82.gnm2.ann1.Glyma.20g241600
+CHI1, CHI1A	chalcone-flavonone isomerase 1A	glyma.Wm82.gnm2.ann1.Glyma.20g241500
+CHI1B1, CHI2	chalcone isomerase 2	glyma.Wm82.gnm2.ann1.Glyma.20g241600
 CHI1B2	chalcone isomerase 1B2	glyma.Wm82.gnm2.ann1.Glyma.10g292200
-CHI2	chalcone isomerase 2	glyma.Wm82.gnm2.ann1.Glyma.20g241600
 CHI2-A	chalcone--flavonone isomerase 2-A	glyma.Wm82.gnm2.ann1.Glyma.20g241700
 CHI3A1	chalcone isomerase 3A1	glyma.Wm82.gnm2.ann1.Glyma.13g262500
 CHI3A2	chalcone isomerase 3A2	glyma.Wm82.gnm2.ann1.Glyma.15g242900
@@ -663,8 +547,7 @@ CHI3B1	chlacone isomerase 3B1	glyma.Wm82.gnm2.ann1.Glyma.03g154600
 CHI3B2	chalcone isomerase 3B2	glyma.Wm82.gnm2.ann1.Glyma.19g156900
 CHI3C1	chalcone isomerase 3C1	glyma.Wm82.gnm2.ann1.Glyma.14g098100
 CHI3C2	chalcone isomerase 3C2	glyma.Wm82.gnm2.ann1.Glyma.17g226600
-CHI4	chalcone isomerase 4	glyma.Wm82.gnm2.ann1.Glyma.06g143000
-CHI4A	chalcone isomerase 4A	glyma.Wm82.gnm2.ann1.Glyma.06g143000
+CHI4, CHI4A	chalcone isomerase 4A	glyma.Wm82.gnm2.ann1.Glyma.06g143000
 CHI4B	chalcone isomerase 4B	glyma.Wm82.gnm2.ann1.Glyma.04g222400
 CHIA1	chitinase class I	glyma.Wm82.gnm2.ann1.Glyma.02g042500
 CHL	chloroplastic lipocalin	glyma.Wm82.gnm2.ann1.Glyma.02g289400
@@ -678,20 +561,15 @@ CHR5	chalcone reductase CHR5	glyma.Wm82.gnm2.ann1.Glyma.18g285800
 CHR6	chalcone reductase CHR6	glyma.Wm82.gnm2.ann1.Glyma.02g307300
 CHS	Chalcone synthase	glyma.Wm82.gnm1.ann1.Glyma08g11530
 CHS1	chalcone synthase 1	glyma.Wm82.gnm2.ann1.Glyma.08g109400
-CHS10	chalcone synthase 10	glyma.Wm82.gnm2.ann1.Glyma.02g130400
-CHS11	chalcone synthase 11	glyma.Wm82.gnm2.ann1.Glyma.01g091400
+CHS10, CHS6c	Chalcone and stilbene synthases, C-terminal domain; Chalcone and stilbene synthases, N-terminal domain 6 gene c	glyma.Wm82.gnm2.ann1.Glyma.02G130400
+CHS11, CHS6a	Chalcone and stilbene synthases, C-terminal domain; Chalcone and stilbene synthases, N-terminal domain 6 gene a	glyma.Wm82.gnm2.ann1.Glyma.01G091400
 CHS13	chalcone synthase 13	glyma.Wm82.gnm2.ann1.Glyma.19g105100
 CHS14	chalcone synthase	glyma.Wm82.gnm2.ann1.Glyma.06g118500
-CHS3	chalcone synthase 3	glyma.Wm82.gnm2.ann1.Glyma.08g109300
+CHS3, SOYCHS	chalcone synthase	glyma.Wm82.gnm2.ann1.Glyma.08g109300
 CHS3B	chalcone synthase 3	glyma.Wm82.gnm2.ann1.Glyma.08g110900
 CHS3C	chalcone synthase 3	glyma.Wm82.gnm2.ann1.Glyma.08g110300
-CHS4	chalcone synthase 4	glyma.Wm82.gnm2.ann1.Glyma.08g110700
-CHS4A	chalcone synthase 4a	glyma.Wm82.gnm2.ann1.Glyma.08g110700
+CHS4, CHS4A	chalcone synthase 4a	glyma.Wm82.gnm2.ann1.Glyma.08g110700
 CHS4B	chalcone synthase 4b	glyma.Wm82.gnm2.ann1.Glyma.08g110500
-chs6	chalcone synthase 6	glyma.Wm82.gnm2.ann1.Glyma.09g075200
-CHS6a	Chalcone and stilbene synthases, C-terminal domain; Chalcone and stilbene synthases, N-terminal domain 6 gene a	glyma.Wm82.gnm2.ann1.Glyma.01G091400
-CHS6b	Chalcone and stilbene synthases, C-terminal domain; Chalcone and stilbene synthases, N-terminal domain 6 gene b	glyma.Wm82.gnm2.ann1.Glyma.09G075200
-CHS6c	Chalcone and stilbene synthases, C-terminal domain; Chalcone and stilbene synthases, N-terminal domain 6 gene c	glyma.Wm82.gnm2.ann1.Glyma.02G130400
 CHS9	chalcone synthase 9	glyma.Wm82.gnm2.ann1.Glyma.08g109500
 CIF1	cell-wall inhibitor of beta-fructosidase	glyma.Wm82.gnm2.ann1.Glyma.17g036300
 CIM1	cytokinin induced message	glyma.Wm82.gnm2.ann1.Glyma.01g077000
@@ -735,7 +613,7 @@ COL12a	Constans-like 12a	glyma.Wm82.gnm1.ann1.Glyma10g02621
 COL13	Constans-like 13	glyma.Wm82.gnm1.ann1.Glyma02g17181
 COL13a	Constans-like 13a	glyma.Wm82.gnm1.ann1.Glyma16g05540
 COL13b	Constans-like 13b	glyma.Wm82.gnm1.ann1.Glyma19g27240
-COL14a	Constans-like 14a	glyma.Wm82.gnm1.ann1.Glyma20g24940
+COL14a, COL7b	Constans-like 7b	glyma.Wm82.gnm1.ann1.Glyma20g24940
 COL15	zinc finger protein CONSTANS-LIKE 13-like	glyma.Wm82.gnm2.ann1.Glyma.03g209800
 COL16	zinc finger protein CONSTANS-LIKE 15	glyma.Wm82.gnm2.ann1.Glyma.16g050900
 COL17	zinc finger protein CONSTANS-LIKE 14-like	glyma.Wm82.gnm2.ann1.Glyma.19g099700
@@ -749,7 +627,6 @@ COL5b	Constans-like 5b	glyma.Wm82.gnm1.ann1.Glyma13g33420
 COL6a	Constans-like 6a	glyma.Wm82.gnm1.ann1.Glyma05g35151
 COL6b	Constans-like 6b	glyma.Wm82.gnm1.ann1.Glyma08g04570
 COL7a	Constans-like 7a	glyma.Wm82.gnm1.ann1.Glyma10g42090
-COL7b	Constans-like 7b	glyma.Wm82.gnm1.ann1.Glyma20g24940
 COL8	Constans-like 8	glyma.Wm82.gnm1.ann1.Glyma02g38870
 COL8b	Constans-like 8b	glyma.Wm82.gnm1.ann1.Glyma14g36930
 COL9	zinc finger protein CONSTANS-LIKE 13-like	glyma.Wm82.gnm2.ann1.Glyma.19g207100
@@ -762,12 +639,11 @@ COPE2	epsilon2-COP	glyma.Wm82.gnm2.ann1.Glyma.09g030400
 COPZ1	nonclathrin coat protein zeta1-COP	glyma.Wm82.gnm2.ann1.Glyma.07g008000
 COPZ2	nonclathrin coat protein zeta2-COP	glyma.Wm82.gnm2.ann1.Glyma.15g125800
 COR1	cold-regulated protein	glyma.Wm82.gnm2.ann1.Glyma.12g047500
-COR2	cold-regulated protein	glyma.Wm82.gnm2.ann1.Glyma.09g045700
 CP3	cysteine proteinase	glyma.Wm82.gnm2.ann1.Glyma.10g207100
 CPIP	Soybean mosaic virus coat protein-interacting protein	glyma.Wm82.gnm2.ann1.Glyma.06g289000
-CPK2	Cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11G206300
+CPK2, CRK35	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g206300
 CPP1	cysteine-rich polycomb-like protein	glyma.Wm82.gnm2.ann1.Glyma.17g208500
-CPS2	copalyl pyrophosphate synthase 2	glyma.Wm82.gnm2.ann1.Glyma.19G157000
+CPS2, TPS22	terpene synthase 22	glyma.Wm82.gnm2.ann1.Glyma.19g157000
 CPX	coproporphyrinogen oxidase	glyma.Wm82.gnm2.ann1.Glyma.14g003200
 CRK1	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.01g013500
 CRK11	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.08g284100
@@ -795,7 +671,6 @@ CRK31	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g2
 CRK32	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g205400
 CRK33	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g205600
 CRK34	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g206100
-CRK35	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g206300
 CRK36	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g206400
 CRK37	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g206700
 CRK39	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g207000
@@ -853,31 +728,11 @@ CRK89	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g1
 CRK9	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.05g005100
 CRK90	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g140600
 CRK91	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g140700
-CrRI,k1l,08	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.09G024700
-CrRI,k1l,09	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.09G133000
-CrRLk1L01	CrRLK1-Like Kinase 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02G121900
-CrRLk1L02	CrRLK1-Like Kinase 1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.02G122000
-CrRLk1L03	CrRLK1-Like Kinase 1 gene 3	glyma.Wm82.gnm2.ann1.Glyma.03G247800
-CrRLk1L04	CrRLK1-Like Kinase 1 gene 4	glyma.Wm82.gnm2.ann1.Glyma.05G099900
-CrRLk1L05	CrRLK1-Like Kinase 1 gene 5	glyma.Wm82.gnm2.ann1.Glyma.08G248900
-CrRLk1L06	CrRLK1-Like Kinase 1 gene 6	glyma.Wm82.gnm2.ann1.Glyma.08G249200
-CrRLk1L07	CrRLK1-Like Kinase 1 gene 7	glyma.Wm82.gnm2.ann1.Glyma.08G249400
-CrRLk1L12	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10G231500
-CrRLk1L14	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.12G148200
-CrRLk1L15	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.12G220400
-CrRLk1L16	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.12G235900
-CrRLk1L25	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.16G179600
-CrRLk1L29	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G269900
-CrRLk1L31	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G270600
-CrRLkUGo	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G054200
-CrRRk1R1 1	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10G163200
-CrRRk1R1 3	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.12G074600
-CrRRk1R10	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.09G273300
 CRY1a	Cryptochrome 1a	glyma.Wm82.gnm2.ann1.Glyma.04g101500
 CRY1b1	Cryptochrome 1b1	glyma.Wm82.gnm2.ann1.Glyma.06g103200
 CRY1c1	Cryptochrome 1c1	glyma.Wm82.gnm2.ann1.Glyma.14g174200
-CRY2a1	Cryptochrome 2a1	glyma.Wm82.gnm2.ann1.Glyma.10g180600
 CRY2B	Cryptochrome 2-like	glyma.Wm82.gnm2.ann1.Glyma.02g005700
+CRY2a1	Cryptochrome 2a1	glyma.Wm82.gnm2.ann1.Glyma.10g180600
 CRY2c	Cryptochrome 2c	glyma.Wm82.gnm2.ann1.Glyma.20g209900
 CWINV	beta-fructofuranosidase	glyma.Wm82.gnm2.ann1.Glyma.07g008800
 CYCA1;1	mitotic cyclin a2-type	glyma.Wm82.gnm2.ann1.Glyma.04g246600
@@ -886,10 +741,8 @@ CYCA3;1	mitotic cyclin a1-type	glyma.Wm82.gnm2.ann1.Glyma.04g043400
 CYCB1;1	G2/mitotic-specific cyclin S13-6	glyma.Wm82.gnm2.ann1.Glyma.03g123600
 CYCB1;2	G2/mitotic-specific cyclin S13-7	glyma.Wm82.gnm2.ann1.Glyma.19g127200
 CYCB1;3	mitotic cyclin b1-type	glyma.Wm82.gnm2.ann1.Glyma.14g037100
-CycC-1	Cyclin C gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g347600
-CycC-2	Cyclin C gene 2	glyma.Wm82.gnm2.ann1.Glyma.18g159000
 CYN	Cyanate hydratase	glyma.Wm82.gnm2.ann1.Glyma.10g005200
-CYP	Cytochrome	glyma.Wm82.gnm2.ann1.Glyma.12G024700
+CYP, CYP2	peptidyl-prolyl cis-trans isomerase CYP2	glyma.Wm82.gnm2.ann1.Glyma.12g024700
 CYP1	peptidyl-prolyl cis-trans isomerase 1	glyma.Wm82.gnm2.ann1.Glyma.11g098700
 CYP10	peptidyl-prolyl cis-trans isomerase CYP10	glyma.Wm82.gnm2.ann1.Glyma.20g249300
 CYP11	peptidyl-prolyl cis-trans isomerase CYP11	glyma.Wm82.gnm2.ann1.Glyma.19g249000
@@ -901,7 +754,6 @@ CYP16	peptidyl-prolyl cis-trans isomerase CYP16	glyma.Wm82.gnm2.ann1.Glyma.07g21
 CYP17	peptidyl-prolyl cis-trans isomerase CYP17	glyma.Wm82.gnm2.ann1.Glyma.02g134800
 CYP18	peptidyl-prolyl cis-trans isomerase CYP18	glyma.Wm82.gnm2.ann1.Glyma.11g047800
 CYP19	peptidyl-prolyl cis-trans isomerase CYP19	glyma.Wm82.gnm2.ann1.Glyma.01g194100
-CYP2	peptidyl-prolyl cis-trans isomerase CYP2	glyma.Wm82.gnm2.ann1.Glyma.12g024700
 CYP20	peptidyl-prolyl cis-trans isomerase CYP20	glyma.Wm82.gnm2.ann1.Glyma.13g318300
 CYP21	peptidyl-prolyl cis-trans isomerase CYP21	glyma.Wm82.gnm2.ann1.Glyma.09g090900
 CYP23	peptidyl-prolyl cis-trans isomerase CYP23	glyma.Wm82.gnm2.ann1.Glyma.10g298200
@@ -978,6 +830,33 @@ CYP98A2	cytochrome P450 98A2	glyma.Wm82.gnm2.ann1.Glyma.19g126000
 CYSP1	cysteine proteinase	glyma.Wm82.gnm2.ann1.Glyma.04g190700
 CYSP2	cysteine proteinase	glyma.Wm82.gnm2.ann1.Glyma.06g174800
 CYSTATIN	cysteine proteinase inhibitor	glyma.Wm82.gnm2.ann1.Glyma.15g227500
+Cdk8-1	Cyclin-dependent kinase 8 gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g207900
+Cdk8-2	Cyclin-dependent kinase 8 gene 2	glyma.Wm82.gnm2.ann1.Glyma.05g145800
+Cdk8-3	Cyclin-dependent kinase 8 gene 3	glyma.Wm82.gnm2.ann1.Glyma.05g195300
+Cdk8-4	Cyclin-dependent kinase 8 gene 4	glyma.Wm82.gnm2.ann1.Glyma.08g002900
+Cdk8-5	Cyclin-dependent kinase 8 gene 6	glyma.Wm82.gnm2.ann1.Glyma.08g102600
+CrRI,k1l,08	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.09G024700
+CrRI,k1l,09	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.09G133000
+CrRLk1L01	CrRLK1-Like Kinase 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02G121900
+CrRLk1L02	CrRLK1-Like Kinase 1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.02G122000
+CrRLk1L03	CrRLK1-Like Kinase 1 gene 3	glyma.Wm82.gnm2.ann1.Glyma.03G247800
+CrRLk1L04	CrRLK1-Like Kinase 1 gene 4	glyma.Wm82.gnm2.ann1.Glyma.05G099900
+CrRLk1L05	CrRLK1-Like Kinase 1 gene 5	glyma.Wm82.gnm2.ann1.Glyma.08G248900
+CrRLk1L06	CrRLK1-Like Kinase 1 gene 6	glyma.Wm82.gnm2.ann1.Glyma.08G249200
+CrRLk1L07	CrRLK1-Like Kinase 1 gene 7	glyma.Wm82.gnm2.ann1.Glyma.08G249400
+CrRLk1L12	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10G231500
+CrRLk1L14	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.12G148200
+CrRLk1L15	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.12G220400
+CrRLk1L16	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.12G235900
+CrRLk1L25	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.16G179600
+CrRLk1L29	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G269900
+CrRLk1L31	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G270600
+CrRLkUGo	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G054200
+CrRRk1R1 1	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10G163200
+CrRRk1R1 3	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.12G074600
+CrRRk1R10	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.09G273300
+CycC-1	Cyclin C gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g347600
+CycC-2	Cyclin C gene 2	glyma.Wm82.gnm2.ann1.Glyma.18g159000
 D-II	Bowman-Birk proteinase isoinhibitor D-II	glyma.Wm82.gnm2.ann1.Glyma.16g208900
 D1	D1	glyma.Wm82.gnm1.ann1.Glyma01g42390
 D14	alpha/beta hydroxylase D14	glyma.Wm82.gnm2.ann1.Glyma.17g235300
@@ -986,20 +865,19 @@ DAD1	dolichyl-diphosphooligosaccharide--protein glycosyltransferase subunit DAD1
 DAGL	Diacylglycerol lipase	glyma.Wm82.gnm1.ann1.Glyma09G34250
 DAO	copper amino oxidase	glyma.Wm82.gnm2.ann1.Glyma.17g019300
 DBB	DBB protein	glyma.Wm82.gnm2.ann1.Glyma.15g029500
-DCL2	Dicer-like 2	glyma.Wm82.gnm2.ann1.Glyma.09G025300
+DCL2, DCL2B	endoribonuclease dicer-like 2b	glyma.Wm82.gnm2.ann1.Glyma.09g025300
 DCL2A	endoribonuclease dicer-like 2a	glyma.Wm82.gnm2.ann1.Glyma.09g025400
-DCL2B	endoribonuclease dicer-like 2b	glyma.Wm82.gnm2.ann1.Glyma.09g025300
 DCL3A	endoribonuclease dicer-like 3a	glyma.Wm82.gnm2.ann1.Glyma.04g057400
 DD2/63	expansin	glyma.Wm82.gnm2.ann1.Glyma.06g143300
 DDKCS	3-ketoacyl-CoA synthase 4-like	glyma.Wm82.gnm2.ann1.Glyma.14g074300
-DEHYDRIN	dehydrin-like protein	glyma.Wm82.gnm2.ann1.Glyma.09g185500
+DEHYDRIN, MAT9	Maturation-associated protein 9 gene	glyma.Wm82.gnm2.ann1.Glyma.09g185500
 DEP1	dense and erect panicle 1	glyma.Wm82.gnm2.ann1.Glyma.17g048600
 DES1.1	sphingolipid delta(4)-desaturase DES1-like	glyma.Wm82.gnm2.ann1.Glyma.13g240700
 DES1.2	sphingolipid delta(4)-desaturase DES1-like	glyma.Wm82.gnm2.ann1.Glyma.15g072800
 DET2	Steroid reductase	glyma.Wm82.gnm2.ann1.Glyma.11G110300
 DFR	dihydroflavanol reductase	glyma.Wm82.gnm2.ann1.Glyma.17g173200
-DFR1	dihydroflavonol-4-reductase DFR1	glyma.Wm82.gnm2.ann1.Glyma.14g072700
-DFR2	dihydroflavonol-4-reductase	glyma.Wm82.gnm2.ann1.Glyma.17g252200
+DFR1, DHFR1, W3	White flower 3	glyma.Wm82.gnm2.ann1.Glyma.14g072700
+DFR2, DHFR2, W4	White flower 4	glyma.Wm82.gnm2.ann1.Glyma.17g252200
 DGAT1C	diacylglycerol acyltransferase 1 gene C	glyma.Wm82.gnm1.ann1.Glyma09g07520
 DGAT2A	diacylglycerol acyltransferase 2 gene A	glyma.Wm82.gnm1.ann1.Glyma09g32790
 DGAT2B	diacylglycerol acyltransferase 2 gene B	glyma.Wm82.gnm1.ann1.Glyma16g21960
@@ -1020,18 +898,12 @@ DGK6	diacylglycerol kinase 6	glyma.Wm82.gnm2.ann1.Glyma.04g143000
 DGK7	diacylglycerol kinase 7	glyma.Wm82.gnm2.ann1.Glyma.13g093100
 DGK8	diacylglycerol kinase 8	glyma.Wm82.gnm2.ann1.Glyma.06g254900
 DGK9	diacylglycerol kinase 9	glyma.Wm82.gnm2.ann1.Glyma.12g146700
-DHAR-1a	DHAR class glutathione S-transferase 1 gene a	glyma.Wm82.gnm2.ann1.Glyma.10g291100
-DHAR-1b	DHAR class glutathione S-transferase 1 gene a	glyma.Wm82.gnm2.ann1.Glyma.20g240300
-DHAR-3a	DHAR class glutathione S-transferase 3 gene a	glyma.Wm82.gnm2.ann1.Glyma.18G040100
-DHAR-3b	DHAR class glutathione S-transferase 3 gene b	glyma.Wm82.gnm2.ann1.Glyma.11G216400
-DHAR1	DHAR class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.10g291100
-DHAR2	DHAR class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.11g216400
-DHAR3	dehydroascorbate reductase	glyma.Wm82.gnm2.ann1.Glyma.18g040100
-DHAR4	DHAR class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.20g240300
+DHAR-1a, DHAR1, MDHAR-1a	DEHYDROASCORBATE REDUCTASE 1 gene a	glyma.Wm82.gnm2.ann1.Glyma.10G291100
+DHAR-1b, DHAR4, MDHAR-1b	DEHYDROASCORBATE REDUCTASE 1 gene b	glyma.Wm82.gnm2.ann1.Glyma.20G240300
+DHAR-3a, DHAR3, MDHAR-3a	DEHYDROASCORBATE REDUCTASE 3 gene a	glyma.Wm82.gnm2.ann1.Glyma.18G040100
+DHAR-3b, DHAR2	DHAR class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.11g216400
 DHBK	putative 3,4-dihydroxy-2-butanone kinase	glyma.Wm82.gnm2.ann1.Glyma.07g107100
 DHFR-TS	bifunctional dihydrofolate reductase-thymidylate synthase	glyma.Wm82.gnm2.ann1.Glyma.06g010600
-DHFR1	dihydroflavonol-4-reductase 1	glyma.Wm82.gnm2.ann1.Glyma.14g072700
-DHFR2	dihydroflavonol-4-reductase 2	glyma.Wm82.gnm2.ann1.Glyma.17g252200
 DHPS1	dihydrodipicolinate synthase	glyma.Wm82.gnm2.ann1.Glyma.18g221700
 DIM1	DIM 1-like protein	glyma.Wm82.gnm2.ann1.Glyma.09g283300
 DIN1	asparagine	glyma.Wm82.gnm1.ann1.Glyma11g27480
@@ -1060,8 +932,8 @@ DXR2	putative 1-deoxy-D-xylulose 5-phosphate reductoisomerase	glyma.Wm82.gnm2.an
 DXS1	1-deoxy-D-xylulose 5-phosphate synthase 1	glyma.Wm82.gnm2.ann1.Glyma.07g252600
 E1LA	B3 domain-containing protein E1La	glyma.Wm82.gnm2.ann1.Glyma.04g156400
 E1LB	B3 domain-containing protein E1Lb	glyma.Wm82.gnm2.ann1.Glyma.04g143300
-E9-1	E9 gene 1	glyma.Wm82.gnm2.ann1.Glyma.16g150700
-EBP	ERF protein	glyma.Wm82.gnm2.ann1.Glyma.02g016100
+E9-1, FT2a (E9), FTL3	Flowering locus T-like gene 3	glyma.Wm82.gnm2.ann1.Glyma.16g150700
+EBP, ERF8	Ethylene-responsive factor gene 8	glyma.Wm82.gnm2.ann1.Glyma.02G016100
 EDR1	serine/threonine-protein kinase EDR1	glyma.Wm82.gnm2.ann1.Glyma.10g159200
 EDS1	Enhanced disease susceptibility 1	glyma.Wm82.gnm2.ann1.Glyma.06G187300
 EDS1a	Enhanced disease susceptibility 1 gene b	glyma.Wm82.gnm1.ann1.Glyma04g34800
@@ -1085,14 +957,13 @@ EN1	endonuclease	glyma.Wm82.gnm2.ann1.Glyma.15g068600
 EN2	endonuclease	glyma.Wm82.gnm2.ann1.Glyma.07g050300
 ENOD55-2	early nodulin	glyma.Wm82.gnm2.ann1.Glyma.17g073400
 ENOD93	early nodulin-93	glyma.Wm82.gnm2.ann1.Glyma.06g216500
-Ep	Seed coat peroxidase gene 1	glyma.Wm82.gnm2.ann1.Glyma.09g022300
 ERA1A	farnesyltransferase	glyma.Wm82.gnm2.ann1.Glyma.06g185500
 ERA1B	farnesyltransferase ERA1B	glyma.Wm82.gnm2.ann1.Glyma.13g168600
 ERD15A	Responsive to Desication 15 gene A	glyma.Wm82.gnm1.ann1.Glyma04g28560
 ERD15C	Responsive to Desication 15 gene C	glyma.Wm82.gnm1.ann1.Glyma02g42860
 ERD15D	Responsive to Desication 15 gene D	glyma.Wm82.gnm1.ann1.Glyma14g05980
-EREB	ethylene responsive protein	glyma.Wm82.gnm2.ann1.Glyma.16g012600
-EREBP1	ethylene-responsive element binding protein 1	glyma.Wm82.gnm2.ann1.Glyma.18g252300
+EREB, ERF124	Ethylene-responsive factor gene 124	glyma.Wm82.gnm2.ann1.Glyma.16G012600
+EREBP1, ERF141	Ethylene-responsive factor gene 141	glyma.Wm82.gnm2.ann1.Glyma.18G252300
 ERF1	Ethylene-responsive factor gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G025400
 ERF10	Ethylene-responsive factor gene 10	glyma.Wm82.gnm2.ann1.Glyma.02G066200
 ERF100	Ethylene-responsive factor gene 100	glyma.Wm82.gnm2.ann1.Glyma.13G122800
@@ -1110,7 +981,6 @@ ERF111	Ethylene-responsive factor gene 111	glyma.Wm82.gnm2.ann1.Glyma.14G020100
 ERF112	Ethylene-responsive factor gene 112	glyma.Wm82.gnm2.ann1.Glyma.14G050100
 ERF113	Ethylene-responsive factor gene 113	glyma.Wm82.gnm2.ann1.Glyma.14G111600
 ERF114	Ethylene-responsive factor gene 114	glyma.Wm82.gnm2.ann1.Glyma.14G123900
-ERF115	Ethylene-responsive factor gene 115	glyma.Wm82.gnm2.ann1.Glyma.14G147500
 ERF116	Ethylene-responsive factor gene 116	glyma.Wm82.gnm2.ann1.Glyma.15G004200
 ERF117	Ethylene-responsive factor gene 117	glyma.Wm82.gnm2.ann1.Glyma.15G008600
 ERF118	Ethylene-responsive factor gene 118	glyma.Wm82.gnm2.ann1.Glyma.15G077000
@@ -1120,7 +990,6 @@ ERF120	Ethylene-responsive factor gene 120	glyma.Wm82.gnm2.ann1.Glyma.15G079100
 ERF121	Ethylene-responsive factor gene 121	glyma.Wm82.gnm2.ann1.Glyma.15G079200
 ERF122	Ethylene-responsive factor gene 122	glyma.Wm82.gnm2.ann1.Glyma.15G152000
 ERF123	Ethylene-responsive factor gene 123	glyma.Wm82.gnm2.ann1.Glyma.15G159200
-ERF124	Ethylene-responsive factor gene 124	glyma.Wm82.gnm2.ann1.Glyma.16G012600
 ERF125	Ethylene-responsive factor gene 125	glyma.Wm82.gnm2.ann1.Glyma.16G040000
 ERF126	Ethylene-responsive factor gene 126	glyma.Wm82.gnm2.ann1.Glyma.16G046300
 ERF127	Ethylene-responsive factor gene 127	glyma.Wm82.gnm2.ann1.Glyma.16G047600
@@ -1139,11 +1008,10 @@ ERF138	Ethylene-responsive factor gene 138	glyma.Wm82.gnm2.ann1.Glyma.18G091600
 ERF139	Ethylene-responsive factor gene 139	glyma.Wm82.gnm2.ann1.Glyma.18G144700
 ERF14	Ethylene-responsive factor gene 14	glyma.Wm82.gnm2.ann1.Glyma.02G132500
 ERF140	Ethylene-responsive factor gene 140	glyma.Wm82.gnm2.ann1.Glyma.18G252200
-ERF141	Ethylene-responsive factor gene 141	glyma.Wm82.gnm2.ann1.Glyma.18G252300
 ERF142	Ethylene-responsive factor gene 142	glyma.Wm82.gnm2.ann1.Glyma.18G281400
 ERF143	Ethylene-responsive factor gene 143	glyma.Wm82.gnm2.ann1.Glyma.19G026000
 ERF144	Ethylene-responsive factor gene 144	glyma.Wm82.gnm2.ann1.Glyma.19G104200
-ERF145	Ethylene-responsive factor gene 145	glyma.Wm82.gnm2.ann1.Glyma.19G113100
+ERF145, ERN	ethylene-responsive transcription factor ERN1	glyma.Wm82.gnm2.ann1.Glyma.19g113100
 ERF146	Ethylene-responsive factor gene 146	glyma.Wm82.gnm2.ann1.Glyma.19G163700
 ERF147	Ethylene-responsive factor gene 147	glyma.Wm82.gnm2.ann1.Glyma.19G163900
 ERF148	Ethylene-responsive factor gene 148	glyma.Wm82.gnm2.ann1.Glyma.19G164100
@@ -1190,7 +1058,6 @@ ERF40	Ethylene-responsive factor gene 40	glyma.Wm82.gnm2.ann1.Glyma.05G200100
 ERF41	Ethylene-responsive factor gene 41	glyma.Wm82.gnm2.ann1.Glyma.05G214400
 ERF42	Ethylene-responsive factor gene 42	glyma.Wm82.gnm2.ann1.Glyma.06G064000
 ERF43	Ethylene-responsive factor gene 43	glyma.Wm82.gnm2.ann1.Glyma.06G068800
-ERF44	Ethylene-responsive factor gene 44	glyma.Wm82.gnm2.ann1.Glyma.06G111300
 ERF45	Ethylene-responsive factor gene 45	glyma.Wm82.gnm2.ann1.Glyma.06G125100
 ERF46	Ethylene-responsive factor gene 46	glyma.Wm82.gnm2.ann1.Glyma.06G148400
 ERF47	Ethylene-responsive factor gene 47	glyma.Wm82.gnm2.ann1.Glyma.06G163700
@@ -1212,7 +1079,7 @@ ERF62	Ethylene-responsive factor gene 62	glyma.Wm82.gnm2.ann1.Glyma.08G216600
 ERF63	Ethylene-responsive factor gene 63	glyma.Wm82.gnm2.ann1.Glyma.08G257300
 ERF64	Ethylene-responsive factor gene 64	glyma.Wm82.gnm2.ann1.Glyma.08G261500
 ERF65	Ethylene-responsive factor gene 65	glyma.Wm82.gnm2.ann1.Glyma.08G278800
-ERF66	Ethylene-responsive factor gene 66	glyma.Wm82.gnm2.ann1.Glyma.08G281900
+ERF66, LF1	putative AP2 domain-containing protein Lf1	glyma.Wm82.gnm2.ann1.Glyma.08g281900
 ERF67	Ethylene-responsive factor gene 67	glyma.Wm82.gnm2.ann1.Glyma.08G320700
 ERF68	Ethylene-responsive factor gene 68	glyma.Wm82.gnm2.ann1.Glyma.09G041500
 ERF69	Ethylene-responsive factor gene 69	glyma.Wm82.gnm2.ann1.Glyma.09G052800
@@ -1226,7 +1093,6 @@ ERF76	Ethylene-responsive factor gene 76	glyma.Wm82.gnm2.ann1.Glyma.10G036200
 ERF77	Ethylene-responsive factor gene 77	glyma.Wm82.gnm2.ann1.Glyma.10G036300
 ERF78	Ethylene-responsive factor gene 78	glyma.Wm82.gnm2.ann1.Glyma.10G036600
 ERF79	Ethylene-responsive factor gene 79	glyma.Wm82.gnm2.ann1.Glyma.10G036700
-ERF8	Ethylene-responsive factor gene 8	glyma.Wm82.gnm2.ann1.Glyma.02G016100
 ERF80	Ethylene-responsive factor gene 80	glyma.Wm82.gnm2.ann1.Glyma.10G061400
 ERF81	Ethylene-responsive factor gene 81	glyma.Wm82.gnm2.ann1.Glyma.10G118900
 ERF82	Ethylene-responsive factor gene 82	glyma.Wm82.gnm2.ann1.Glyma.10G186800
@@ -1237,21 +1103,18 @@ ERF86	Ethylene-responsive factor gene 86	glyma.Wm82.gnm2.ann1.Glyma.10G223200
 ERF87	Ethylene-responsive factor gene 87	glyma.Wm82.gnm2.ann1.Glyma.10G274600
 ERF88	Ethylene-responsive factor gene 88	glyma.Wm82.gnm2.ann1.Glyma.11G019000
 ERF89	Ethylene-responsive factor gene 89	glyma.Wm82.gnm2.ann1.Glyma.11G036400
-ERF9	Ethylene-responsive factor gene 9	glyma.Wm82.gnm2.ann1.Glyma.02G039300
+ERF9, ESR1	ethylene-responsive transcription factor ESR1	glyma.Wm82.gnm2.ann1.Glyma.02g039300
 ERF90	Ethylene-responsive factor gene 90	glyma.Wm82.gnm2.ann1.Glyma.11G036500
 ERF91	Ethylene-responsive factor gene 91	glyma.Wm82.gnm2.ann1.Glyma.12G117000
 ERF92	Ethylene-responsive factor gene 92	glyma.Wm82.gnm2.ann1.Glyma.12G162700
 ERF93	Ethylene-responsive factor gene 93	glyma.Wm82.gnm2.ann1.Glyma.12G226600
 ERF94	Ethylene-responsive factor gene 94	glyma.Wm82.gnm2.ann1.Glyma.13G040400
 ERF95	Ethylene-responsive factor gene 95	glyma.Wm82.gnm2.ann1.Glyma.13G060600
-ERF96	Ethylene-responsive factor gene 96	glyma.Wm82.gnm2.ann1.Glyma.13G081600
 ERF97	Ethylene-responsive factor gene 97	glyma.Wm82.gnm2.ann1.Glyma.13G122500
 ERF98	Ethylene-responsive factor gene 98	glyma.Wm82.gnm2.ann1.Glyma.13G122600
 ERF99	Ethylene-responsive factor gene 99	glyma.Wm82.gnm2.ann1.Glyma.13G122700
-ERN	ethylene-responsive transcription factor ERN1	glyma.Wm82.gnm2.ann1.Glyma.19g113100
 ERS1	Ubiquitous, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma19g40090
 ERS2	root preferential, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma03g37470
-ESR1	ethylene-responsive transcription factor ESR1	glyma.Wm82.gnm2.ann1.Glyma.02g039300
 ETR1	Ubiquitous, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma09g00490
 EU3	Ni-binding urease accessory protein UreG	glyma.Wm82.gnm2.ann1.Glyma.08g084800
 EU4	urease	glyma.Wm82.gnm2.ann1.Glyma.05g146000
@@ -1329,31 +1192,22 @@ EXPA7	alpha-expansin gene 7	glyma.Wm82.gnm1.ann1.Glyma01g06036
 EXPA8	alpha-expansin gene 8	glyma.Wm82.gnm1.ann1.Glyma01g06037
 EXPA9	alpha-expansin gene 9	glyma.Wm82.gnm1.ann1.Glyma01g06038
 EXPB1	beta-expansin gene 1	glyma.Wm82.gnm1.ann1.Glyma01g16140
+Ep, PRX1, SPOD4.1	Ep, peroxidase	glyma.Wm82.gnm2.ann1.Glyma.09g022300
 F-box protein2	F-box protein 2	glyma.Wm82.gnm2.ann1.Glyma.02G273700
 F3'5'H	flavonoid 3', 5'-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.13g072100
-F3G2Gt 1	anthocyanidin 3-O-glucoside 2''-O-glucosyltransferase-like gene 1	glyma.Wm82.gnm2.ann1.Glyma.06g285700
-F3G2Gt-a	flavonol 3-O-glycoside (1-2) glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.06g285700
-F3G2Gt-b	flavonol 3-O-glycoside (1-2) glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.06g285700
+F3G2Gt 1, F3G2Gt-a, F3G2Gt-b, UGT79B30, UGT79B30-1	anthocyanidin 3-O-glucoside 2''-O-glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.06g285700
 F3G6''Gt	anthocyanidin 3-O-glucosyltransferase-like	glyma.Wm82.gnm2.ann1.Glyma.20g196000
-F3G6''Rt	flavonol 3-O-glucoside (1->6) rhamnosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.10g194000
+F3G6''Rt, Fg2, UGT79A6, UGT79A6-1	flavonol 3-O-glucoside (1->6) rhamnosyltransferase gene 1	glyma.Wm82.gnm2.ann1.Glyma.10g194000
 F3H	flavanone 3-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.02g048400
 F6'H1	feruloyl CoA ortho-hydroxylase 1	glyma.Wm82.gnm2.ann1.Glyma.18g111000
 F6H1	flavonoid 6-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.18g080400
 F6H2	flavonoid 6-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.18g080200
 F6H3	flavonoid 6-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.08g326900
-FAB2		glyma.Wm82.gnm2.ann1.Glyma.02g138100
-FabD	malonyl-CoA:ACP malonyltransferase	glyma.Wm82.gnm2.ann1.Glyma.11g164500
-FabF	3-ketoacyl-ACP-synthase II	glyma.Wm82.gnm2.ann1.Glyma.13g112700
-FabG	3-ketoacyl-ACP reductase	glyma.Wm82.gnm2.ann1.Glyma.08g102100
-FabZ	3-hydroxyacyl-ACP dehydrase	glyma.Wm82.gnm2.ann1.Glyma.15g052500
-FAD2-1A	omega-6 fatty acid desaturase, endoplasmic reticulum isozyme 1	glyma.Wm82.gnm2.ann1.Glyma.10g278000
 FAD2-1A	fatty acid desaturase	glyma.Wm82.gnm2.ann1.Glyma.10g278000
 FAD2-2A	fatty acid desaturase-2	glyma.Wm82.gnm2.ann1.Glyma.19g147300
 FAD2-2B	fatty acid desaturase-2	glyma.Wm82.gnm2.ann1.Glyma.19g147400
 FAD2-2D	fatty acid desaturase-2	glyma.Wm82.gnm2.ann1.Glyma.09g111900
-FAD3	omega-3-fatty acid desaturase 3	glyma.Wm82.gnm2.ann1.Glyma.11g174100
-FAD3-2b	omega-3 fatty acid desaturase D	glyma.Wm82.gnm2.ann1.Glyma.11g174100
-FAD3d	omega-3-fatty acid desaturase 3 gene 4	glyma.Wm82.gnm2.ann1.Glyma.11g174100
+FAD3, FAD3-2b, FAD3d	omega-3-fatty acid desaturase 3 gene 4	glyma.Wm82.gnm2.ann1.Glyma.11g174100
 FAD5.1	delta-7 desaturase	glyma.Wm82.gnm2.ann1.Glyma.07g030000
 FAD5.2	delta-7 desaturase	glyma.Wm82.gnm2.ann1.Glyma.08g212900
 FAD6.1	omega-6 fatty acid desaturase, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.02g203300
@@ -1369,13 +1223,7 @@ FBA	fructose-bisphosphate aldolase	glyma.Wm82.gnm2.ann1.Glyma.02g303000
 FBP	fructose-1,6-bisphosphatase	glyma.Wm82.gnm2.ann1.Glyma.07g142700
 FCL1	homeobox protein knotted-1-like 1	glyma.Wm82.gnm2.ann1.Glyma.07g104800
 FCL2	homeobox protein knotted-1-like	glyma.Wm82.gnm2.ann1.Glyma.09g172800
-FDa1	Flowering Locus D	glyma.Wm82.gnm2.ann1.Glyma.01G163500
-FDa2	Flowering Locus D	glyma.Wm82.gnm2.ann1.Glyma.11G080000
-FDb1	Flowering Locus D	glyma.Wm82.gnm2.ann1.Glyma.02G045500
-FDc1	Flowering Locus D	glyma.Wm82.gnm2.ann1.Glyma.04G022100
-FDc2	Flowering Locus D	glyma.Wm82.gnm2.ann1.Glyma.06G022300
 FDL02	Flowering Locus D-like gene 2	glyma.Wm82.gnm1.ann1.Glyma02g05100
-FDL04	Flowering Locus D-like gene 4	glyma.Wm82.gnm2.ann1.Glyma.04G022100
 FDL0513	Flowering Locus D-like gene 513	glyma.Wm82.gnm1.ann1.Glyma05g13890
 FDL0525	Flowering Locus D-like gene 525	glyma.Wm82.gnm1.ann1.Glyma05g25200
 FDL06	Flowering Locus D-like gene 6	glyma.Wm82.gnm1.ann1.Glyma06g04350
@@ -1391,11 +1239,14 @@ FDL1339	Flowering Locus D-like gene 1339	glyma.Wm82.gnm1.ann1.Glyma13g39340
 FDL15	Flowering Locus D-like gene 15	glyma.Wm82.gnm1.ann1.Glyma15g35080
 FDL1920	Flowering Locus D-like gene 1920	glyma.Wm82.gnm1.ann1.Glyma19g20090
 FDL20	Flowering Locus D-like gene 20	glyma.Wm82.gnm1.ann1.Glyma20g10060
+FDa1	Flowering Locus D	glyma.Wm82.gnm2.ann1.Glyma.01G163500
+FDa2	Flowering Locus D	glyma.Wm82.gnm2.ann1.Glyma.11G080000
+FDb1	Flowering Locus D	glyma.Wm82.gnm2.ann1.Glyma.02G045500
+FDc1, FDL04	Flowering Locus D-like gene 4	glyma.Wm82.gnm2.ann1.Glyma.04G022100
+FDc2	Flowering Locus D	glyma.Wm82.gnm2.ann1.Glyma.06G022300
 FER2-1	ferritin	glyma.Wm82.gnm2.ann1.Glyma.02g262500
-Fg2	flavonol 3-O-glucoside (1->6) rhamnosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.10g194000
 FILA	YABBY protein FILa	glyma.Wm82.gnm2.ann1.Glyma.17g138200
 FKF1	Flavin-binding Kelch Repeat F-Box 1 gene	glyma.Wm82.gnm1.ann1.Glyma05g34530
-FKF2	Flavin-binding Kelch Repeat F-Box 2 gene	glyma.Wm82.gnm2.ann1.Glyma.08g046500
 FLD	Flowering locus D	glyma.Wm82.gnm2.ann1.Glyma.02g159100
 FLS1	Flavonol synthase 1	glyma.Wm82.gnm2.ann1.Glyma.13g082300
 FLS2a	flavanol synthase	glyma.Wm82.gnm2.ann1.Glyma.08g083300
@@ -1405,13 +1256,10 @@ FNSII-2	flavone synthase II	glyma.Wm82.gnm2.ann1.Glyma.12g067100
 FRD3a	ferric reductase defective 3a	glyma.Wm82.gnm2.ann1.Glyma.15g274600
 FRD3b	ferric reductase defective 3b	glyma.Wm82.gnm2.ann1.Glyma.09g102800
 FT	FLOWERING LOCUS T  	glyma.Wm82.gnm1.ann1.Glyma02g07650
-FT2a (E9)	Flowering Locus T gene 2a	glyma.Wm82.gnm2.ann1.Glyma.16G150700
-FT2C	flowering locus T 2c	glyma.Wm82.gnm2.ann1.Glyma.02g069200
-FT2c-N	Flowering Locus T gene 2c	glyma.Wm82.gnm2.ann1.Glyma.02G069200
+FT2C, FT2c-N	Flowering Locus T gene 2c	glyma.Wm82.gnm2.ann1.Glyma.02G069200
 FT4 (E10)	Flowering Locus T gene 4	glyma.Wm82.gnm2.ann1.Glyma.08G363100
 FTL1	Flowering locus T-like gene 1	glyma.Wm82.gnm2.ann1.Glyma.16g044200
 FTL2	Flowering locus T-like gene 2	glyma.Wm82.gnm2.ann1.Glyma.19g108100
-FTL3	Flowering locus T-like gene 3	glyma.Wm82.gnm2.ann1.Glyma.16g150700
 FTL4	Flowering locus T-like gene 4	glyma.Wm82.gnm2.ann1.Glyma.16g044100
 FTL5	Flowering locus T-like gene 5	glyma.Wm82.gnm2.ann1.Glyma.16g151000
 FTL6	Flowering locus T-like gene 6	glyma.Wm82.gnm2.ann1.Glyma.19g108200
@@ -1419,7 +1267,6 @@ FTL7	Flowering locus T-like gene 7	glyma.Wm82.gnm2.ann1.Glyma.08g363200
 FTL9	flowering locus T-like protein 9	glyma.Wm82.gnm2.ann1.Glyma.08g256000
 FTRC	ferredoxin thioredoxin reductase precursor	glyma.Wm82.gnm2.ann1.Glyma.13g069100
 FTSH9	ATP-dependent zinc metalloprotease FTSH 8, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.15g158900
-FULa	Fruitfull gene a	glyma.Wm82.gnm2.ann1.Glyma.06g205800
 FULb	Fruitfull gene b	glyma.Wm82.gnm2.ann1.Glyma.04g159300
 FUSA1	elongation factor G-1	glyma.Wm82.gnm2.ann1.Glyma.17g137600
 FUSA2	elongation factor G-2	glyma.Wm82.gnm2.ann1.Glyma.05g055500
@@ -1428,31 +1275,31 @@ FWL3	protein FW2.2-like 3	glyma.Wm82.gnm2.ann1.Glyma.08g043500
 FWL6	protein FW2.2-like 6	glyma.Wm82.gnm2.ann1.Glyma.07g185200
 FWL7	protein FW2.2-like 7	glyma.Wm82.gnm2.ann1.Glyma.01g084000
 FWL8	protein FW2.2-like 8	glyma.Wm82.gnm2.ann1.Glyma.15g016800
+FabD	malonyl-CoA:ACP malonyltransferase	glyma.Wm82.gnm2.ann1.Glyma.11g164500
+FabF	3-ketoacyl-ACP-synthase II	glyma.Wm82.gnm2.ann1.Glyma.13g112700
+FabG	3-ketoacyl-ACP reductase	glyma.Wm82.gnm2.ann1.Glyma.08g102100
+FabZ	3-hydroxyacyl-ACP dehydrase	glyma.Wm82.gnm2.ann1.Glyma.15g052500
 G2DT	glycinol 2-dimethylallyltransferase	glyma.Wm82.gnm2.ann1.Glyma.20g245100
-G3pdh	Glycerol-3-phosphate dehydrogenase	glyma.Wm82.gnm1.ann1.Glyma02g38310 
+G3pdh	Glycerol-3-phosphate dehydrogenase	glyma.Wm82.gnm1.ann1.Glyma02g38310
 G4DT	Glycinol 4-dimethylallyltransferase	glyma.Wm82.gnm2.ann1.Glyma.10g295300
-G6PD	Glucose Metabolism	glyma.Wm82.gnm2.ann1.Glyma.16G063200
-G6PDH	glucose-6-phosphate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.19g082300
+G6PD, G6PDH4	Glucose-6-phosphate dehydrogenase gene 4	glyma.Wm82.gnm2.ann1.Glyma.16G063200
+G6PDH, G6PDH2	Glucose-6-phosphate dehydrogenase gene 2	glyma.Wm82.gnm2.ann1.Glyma.19G082300
 G6PDH1	Glucose-6-phosphate dehydrogenase gene 1	glyma.Wm82.gnm2.ann1.Glyma.03G229400
-G6PDH2	Glucose-6-phosphate dehydrogenase gene 2	glyma.Wm82.gnm2.ann1.Glyma.19G082300
 G6PDH3	Glucose-6-phosphate dehydrogenase gene 3	glyma.Wm82.gnm2.ann1.Glyma.08G199000
-G6PDH4	Glucose-6-phosphate dehydrogenase gene 4	glyma.Wm82.gnm2.ann1.Glyma.16G063200
 G6PDH5	Glucose-6-phosphate dehydrogenase gene 5	glyma.Wm82.gnm2.ann1.Glyma.02G096800
 G6PDH6	Glucose-6-phosphate dehydrogenase gene 6	glyma.Wm82.gnm2.ann1.Glyma.19G077300
 G6PDH7	Glucose-6-phosphate dehydrogenase gene 7	glyma.Wm82.gnm2.ann1.Glyma.18G284600
 G6PDH8	Glucose-6-phosphate dehydrogenase gene 8	glyma.Wm82.gnm2.ann1.Glyma.07G013800
 G6PDH9	Glucose-6-phosphate dehydrogenase gene 9	glyma.Wm82.gnm2.ann1.Glyma.19G226700
 G93	PH/RCC1/FYVE zinc finger domain-containing protein G93	glyma.Wm82.gnm2.ann1.Glyma.18g044000
-GA1	gibberellic acid-20 oxidase 1	glyma.Wm82.gnm2.ann1.Glyma.09G149200
-GA2	gibberellic acid-20 oxidase 2	glyma.Wm82.gnm2.ann1.Glyma.20G153400
+GA1, GA20OX3	gibberellin 20-oxidase	glyma.Wm82.gnm2.ann1.Glyma.09g149200
+GA2, GA20OX8	gibberellin 20 oxidase 8	glyma.Wm82.gnm2.ann1.Glyma.20g153400
 GA20OX	gibberellin oxidase gene 20	glyma.Wm82.gnm1.ann1.Glyma07g08950
 GA20OX1	gibberellin 20 oxidase 1	glyma.Wm82.gnm2.ann1.Glyma.03g019800
 GA20OX2	gibberellin 20 oxidase 2	glyma.Wm82.gnm2.ann1.Glyma.07g081700
-GA20OX3	gibberellin 20-oxidase	glyma.Wm82.gnm2.ann1.Glyma.09g149200
 GA20OX5	gibberellin 20 oxidase 5	glyma.Wm82.gnm2.ann1.Glyma.13g035600
 GA20OX6	gibberellin 20 oxidase 6	glyma.Wm82.gnm2.ann1.Glyma.14g157400
 GA20OX7	gibberellin 20-oxidase 7	glyma.Wm82.gnm2.ann1.Glyma.16g200800
-GA20OX8	gibberellin 20 oxidase 8	glyma.Wm82.gnm2.ann1.Glyma.20g153400
 GA2OX1	gibberellin 2-beta-dioxygenase 1	glyma.Wm82.gnm2.ann1.Glyma.02g010100
 GA2OX10	gibberellin 2-beta-dioxygenase 10	glyma.Wm82.gnm2.ann1.Glyma.15g252100
 GA2OX2	gibberellin 2-beta-dioxygenase 2	glyma.Wm82.gnm2.ann1.Glyma.10g010700
@@ -1462,9 +1309,9 @@ GA2OX5	gibberellin 2-beta-dioxygenase 5	glyma.Wm82.gnm2.ann1.Glyma.13g218200
 GA2OX6	gibberellin 2-beta-dioxygenase 6	glyma.Wm82.gnm2.ann1.Glyma.13g259400
 GA2OX7	gibberellin 2-beta-dioxygenase 7	glyma.Wm82.gnm2.ann1.Glyma.13g259500
 GA2OX8	gibberellin 2-beta-dioxygenase 8	glyma.Wm82.gnm2.ann1.Glyma.15g093900
+GA2OX9	gibberellin 2-beta-dioxygenase 9	glyma.Wm82.gnm2.ann1.Glyma.15g248400
 GA2ox8A	giberellin 2-oxidase 8 gene A	glyma.Wm82.gnm2.ann1.Glyma.13G287600
 GA2ox8B	giberellin 2-oxidase 8 gene B	glyma.Wm82.gnm2.ann1.Glyma.13G288000
-GA2OX9	gibberellin 2-beta-dioxygenase 9	glyma.Wm82.gnm2.ann1.Glyma.15g248400
 GA3OX1	gibberellin 3-beta-dioxygenase 1	glyma.Wm82.gnm2.ann1.Glyma.04g071000
 GA3OX2	gibberellin 3-beta-dioxygenase 2	glyma.Wm82.gnm2.ann1.Glyma.06g072600
 GA3OX3	gibberellin 3-beta-dioxygenase 3	glyma.Wm82.gnm2.ann1.Glyma.13g361700
@@ -1473,7 +1320,7 @@ GA3OX5	gibberellin 3-beta-dioxygenase 5	glyma.Wm82.gnm2.ann1.Glyma.15g012100
 GA3OX6	gibberellin 3-beta-dioxygenase 6	glyma.Wm82.gnm2.ann1.Glyma.17g205300
 GAD	GAD protein	glyma.Wm82.gnm2.ann1.Glyma.18g043600
 GAI1	DELLA protein GAI 1	glyma.Wm82.gnm2.ann1.Glyma.05g140400
-GAI2	DELLA protein GAI 2	glyma.Wm82.gnm2.ann1.Glyma.11g216500
+GAI2, GR8	giberellic acid responsive gene 8	glyma.Wm82.gnm2.ann1.Glyma.11G216500
 GAMMA-TMT	gamma-tocopherol methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.09g222800
 GAPC1	glyceraldehyde-3-phosphate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.06g172600
 GAPDH	glyceraldehyde 3-phosphate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.04g193500
@@ -1533,64 +1380,44 @@ GER6	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.10g168900
 GER7	germin-like protein 7	glyma.Wm82.gnm2.ann1.Glyma.08g226800
 GER8	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.07g038500
 GER9	germin-like protein 9	glyma.Wm82.gnm2.ann1.Glyma.07g039100
-GF14e	GF14 gene family gene e	glyma.Wm82.gnm2.ann1.Glyma.04G099900
+GF14e, SGF14h	14-3-3 protein SGF14h	glyma.Wm82.gnm2.ann1.Glyma.04g099900
 GF14f	GF14 gene family gene f	glyma.Wm82.gnm2.ann1.Glyma.04G183400
 GF14g	GF14 gene family gene g	glyma.Wm82.gnm2.ann1.Glyma.05G158100
-GF14h	GF14 gene family gene h	glyma.Wm82.gnm2.ann1.Glyma.06G094400
-GF14i	GF14 gene family gene i	glyma.Wm82.gnm2.ann1.Glyma.06G101500
+GF14h, SGF14J	14-3-3 protein SGF14j	glyma.Wm82.gnm2.ann1.Glyma.06g094400
+GF14i, SGF14I	14-3-3 protein SGF14i	glyma.Wm82.gnm2.ann1.Glyma.06g101500
 GF14j	GF14 gene family gene j	glyma.Wm82.gnm2.ann1.Glyma.06G182800
-GF14k	GF14 gene family gene k	glyma.Wm82.gnm2.ann1.Glyma.07G226000
-GF14l	GF14 gene family gene l	glyma.Wm82.gnm2.ann1.Glyma.08G115800
-GF14m	GF14 gene family gene m	glyma.Wm82.gnm2.ann1.Glyma.08G363800
-GF14n	GF14 gene family gene n	glyma.Wm82.gnm2.ann1.Glyma.12G210400
-GF14o	GF14 gene family gene o	glyma.Wm82.gnm2.ann1.Glyma.12G229200
-GF14p	GF14 gene family gene p	glyma.Wm82.gnm2.ann1.Glyma.13G270600
+GF14k, SGF14Q	putative 14-3-3 protein SGF14q	glyma.Wm82.gnm2.ann1.Glyma.07g226000
+GF14l, SGF14L	14-3-3 protein SGF14l	glyma.Wm82.gnm2.ann1.Glyma.08g115800
+GF14m, SGF14M	14-3-3 protein SGF14m	glyma.Wm82.gnm2.ann1.Glyma.08g363800
+GF14n, SGF14O	14-3-3 protein SGF14o	glyma.Wm82.gnm2.ann1.Glyma.12g210400
+GF14o, SGF14n	14-3-3 protein SGF14n	glyma.Wm82.gnm2.ann1.Glyma.12g229200
+GF14p, SGF14P	14-3-3 protein SGF14p	glyma.Wm82.gnm2.ann1.Glyma.13g270600
 GF14q	GF14 gene family gene q	glyma.Wm82.gnm2.ann1.Glyma.13G290900
-GF14r	GF14 gene family gene r	glyma.Wm82.gnm2.ann1.Glyma.14G176900
+GF14r, SGF14K	14-3-3 protein SGF14k	glyma.Wm82.gnm2.ann1.Glyma.14g176900
 GF14s	GF14 gene family gene s	glyma.Wm82.gnm2.ann1.Glyma.17G208100
 GF14t	GF14 gene family gene t	glyma.Wm82.gnm2.ann1.Glyma.18G298300
-GF14u	GF14 gene family gene u	glyma.Wm82.gnm2.ann1.Glyma.20G025900
+GF14u, SGF14R	putative 14-3-3 protein SGF14r	glyma.Wm82.gnm2.ann1.Glyma.20g025900
 GF14v	GF14 gene family gene v	glyma.Wm82.gnm2.ann1.Glyma.20G043700
 GH	gamma glutamyl hydrolase	glyma.Wm82.gnm2.ann1.Glyma.13g267800
-GH1	AUX/IAA family protein	glyma.Wm82.gnm2.ann1.Glyma.01g019400
+GH1, IAA1	Indole-3-Acetic Acid Responsive Gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G019400
 GH3.1	auxin synthesis-related gene	glyma.Wm82.gnm2.ann1.Glyma.02G125600
 GH3.6	auxin synthesis-related gene	glyma.Wm82.gnm2.ann1.Glyma.06G260800
 GI1	gigantea protein gene 1	glyma.Wm82.gnm1.ann1.Glyma20g30980
-GI1A	Gigantea gene 1	glyma.Wm82.gnm2.ann1.Glyma.20g170000
-GI3	Gigantea gene 3	glyma.Wm82.gnm2.ann1.Glyma.10g221500
-GIa (E2)	Gigantea gene a	glyma.Wm82.gnm2.ann1.Glyma.10G221500
-Gic	Gigantea gene c	glyma.Wm82.gnm2.ann1.Glyma.16G163200
+GI1A, GIGANTEA	protein GIGANTEA	glyma.Wm82.gnm2.ann1.Glyma.20g170000
+GI3, GIa (E2)	Gigantea gene a	glyma.Wm82.gnm2.ann1.Glyma.10G221500
 GID1B	GID Complex Subunit	glyma.Wm82.gnm2.ann1.Glyma.03G148300
-GID1C	GID Complex Subunit	glyma.Wm82.gnm2.ann1.Glyma.20G230600
-GIGANTEA	protein GIGANTEA	glyma.Wm82.gnm2.ann1.Glyma.20g170000
-GinCrRI,k1l,18	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G053700
-GinCrRI,k1l,21	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G054300
-GinCrRI,k1l,22	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G054400
-GinCrRI,k1l,23	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G201400
-GinCrRI,k1l,26	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.17G102600
-GinCrRI,k1l,28	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G215800
-GinCrRI,k1l,36	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.19G033100
-GinCrRl,k1l,19	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G053800
-GinCrRl,k1l,2-l	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.15G042900
-GinCrRl,k1l,32	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G270700
-GinCrRl,k1l,33	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G270900
-GinCrRl,k1l,38	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20G225800
-GinCrRLk1L30	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G270100
+GID1C, GR2	giberellic acid responsive gene 2	glyma.Wm82.gnm2.ann1.Glyma.20G230600
 GIP1	putative aspartic proteinase GIP1	glyma.Wm82.gnm2.ann1.Glyma.03g151900
 GK	glycerol kinase	glyma.Wm82.gnm2.ann1.Glyma.07g028600
-GLB1	Nonsymbiotic hemoglobin gene 1	glyma.Wm82.gnm2.ann1.Glyma.11g121800
+GLB1, HB1	Non-symbiotic hemoglobin 2 gene	glyma.Wm82.gnm2.ann1.Glyma.11g121800
 GLB3	Nonsymbiotic hemoglobin gene 3	glyma.Wm82.gnm2.ann1.Glyma.04g079200
-GLXI	lactoylglutathione lyase	glyma.Wm82.gnm2.ann1.Glyma.11g194300
-glycinin A2B1a	glycinin A2B1a subunit	glyma.Wm82.gnm2.ann1.Glyma.03g163500
-glycinin A3B4	glycinin A3B4 subunit	glyma.Wm82.gnm2.ann1.Glyma.13g123500
-glycinin A5A4B3	glycinin A5A4B3 subunit	glyma.Wm82.gnm2.ann1.Glyma.10g037100
+GLXI, GLYI-15	Glyoxylase 1 gene 15	glyma.Wm82.gnm2.ann1.Glyma.11g194300
 GLYI-1	Glyoxylase 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.01g146300
 GLYI-10	Glyoxylase 1 gene 10	glyma.Wm82.gnm2.ann1.Glyma.09g004300
 GLYI-11	Glyoxylase 1 gene 11	glyma.Wm82.gnm2.ann1.Glyma.09g193800
 GLYI-12	Glyoxylase 1 gene 12	glyma.Wm82.gnm2.ann1.Glyma.09g226500
 GLYI-13	Glyoxylase 1 gene 13	glyma.Wm82.gnm2.ann1.Glyma.11g075000
 GLYI-14	Glyoxylase 1 gene 14	glyma.Wm82.gnm2.ann1.Glyma.11g194200
-GLYI-15	Glyoxylase 1 gene 15	glyma.Wm82.gnm2.ann1.Glyma.11g194300
 GLYI-16	Glyoxylase 1 gene 16	glyma.Wm82.gnm2.ann1.Glyma.12g079700
 GLYI-17	putative lactoylglutathione lyase	glyma.Wm82.gnm2.ann1.Glyma.12g167400
 GLYI-18	putative lactoylglutathione lyase	glyma.Wm82.gnm2.ann1.Glyma.13g106600
@@ -1619,17 +1446,12 @@ GLYII-7	putative hydroxyacylglutathione hydrolase	glyma.Wm82.gnm2.ann1.Glyma.13g
 GLYII-8	putative hydroxyacylglutathione hydrolase	glyma.Wm82.gnm2.ann1.Glyma.14g187700
 GLYII-9	putative hydroxyacylglutathione hydrolase	glyma.Wm82.gnm2.ann1.Glyma.15g028900
 GM2S-1	2S albumin	glyma.Wm82.gnm2.ann1.Glyma.13g288100
-GM7S	beta-conglycinin alpha prime subunit 1	glyma.Wm82.gnm2.ann1.Glyma.10g246300
 GME1	GDP-mannose 3',5'-epimerase	glyma.Wm82.gnm2.ann1.Glyma.19g244600
-GMNAC184	NAC domain-containing protein	glyma.Wm82.gnm2.ann1.Glyma.20g175500
+GMNAC184, NAC184	NAC Transcription Factor gene 184	glyma.Wm82.gnm2.ann1.Glyma.20G175500
 GMP1	mannose-1-phosphate guanylyltransferase 1-like	glyma.Wm82.gnm2.ann1.Glyma.14g065900
 GMP2	mannose-1-phosphate guanylyltransferase 1-like	glyma.Wm82.gnm2.ann1.Glyma.11g223700
 GMR1	ras-related protein RABA5d-like	glyma.Wm82.gnm2.ann1.Glyma.18g300600
 GMR2	ras-related protein RABA5d-like	glyma.Wm82.gnm2.ann1.Glyma.08g361000
-GnCrRLk1L27	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.17G166200
-GnCrRLk1L34	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G271000
-GnCrRLk1L35	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G271100
-GnCrRLk1L37	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20G162300
 GND	6-phosphogluconate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.18g277300
 GOS12	SNARE GOS12	glyma.Wm82.gnm2.ann1.Glyma.01g137300
 GPA1	G protein alpha subunit	glyma.Wm82.gnm2.ann1.Glyma.04g056600
@@ -1638,13 +1460,10 @@ GPPS	geranyl-diphosphate synthase	glyma.Wm82.gnm2.ann1.Glyma.14g023000
 GPRP3	glycine and proline rich protein 3	glyma.Wm82.gnm2.ann1.Glyma.16g076800
 GPRP4	glycine-rich protein A3-like	glyma.Wm82.gnm2.ann1.Glyma.01g154000
 GPX	Glutathione Peroxidase	glyma.Wm82.gnm2.ann1.Glyma.08G013800
-GR	glutathione reductase	glyma.Wm82.gnm2.ann1.Glyma.02g141800
+GR, GR-2b	Chloroplastic glutathione reductase 2 gene b	glyma.Wm82.gnm2.ann1.Glyma.02G141800
 GR-1a	Cytosolic glutathione reductase 1 gene a	glyma.Wm82.gnm2.ann1.Glyma.16G155700
 GR-1b	Cytosolic glutathione reductase 1 gene b	glyma.Wm82.gnm2.ann1.Glyma.02G074200
 GR-2a	Chloroplastic glutathione reductase 2 gene a	glyma.Wm82.gnm2.ann1.Glyma.10G032100
-GR-2b	Chloroplastic glutathione reductase 2 gene b	glyma.Wm82.gnm2.ann1.Glyma.02G141800
-GR2	giberellic acid responsive gene 2	glyma.Wm82.gnm2.ann1.Glyma.20G230600
-GR8	giberellic acid responsive gene 8	glyma.Wm82.gnm2.ann1.Glyma.11G216500
 GRF1	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.01g148600
 GRF10	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.11g008500
 GRF11	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.11g110700
@@ -1667,17 +1486,13 @@ GRF6	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.07g038400
 GRF7	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.09g068700
 GRF8	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.09g212500
 GRF9	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.10g067200
-GrnCrRLk1L17	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G053600
 GRP	glycine-rich RNA-binding protein	glyma.Wm82.gnm2.ann1.Glyma.12g043000
 GRR1	putative EIN3-binding F-box protein	glyma.Wm82.gnm2.ann1.Glyma.06g068400
-GS	glutamine synthetase	glyma.Wm82.gnm2.ann1.Glyma.02G244000
+GS, GS-gamma2-a, GS1GAMMA2	glutamine synthetase cytosolic isozyme 2	glyma.Wm82.gnm2.ann1.Glyma.02g244000
 GS-2	glutamine synthetase precursor	glyma.Wm82.gnm2.ann1.Glyma.13g210800
-GS-gamma2-a	Gamma glutamine synthase 2 gene	glyma.Wm82.gnm2.ann1.Glyma.02g244000
-GS1-GAMMA	gamma glutamine synthetase	glyma.Wm82.gnm2.ann1.Glyma.14g213300
-GS1-gamma1	Gamma glutamine synthase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.14g213300
+GS1-GAMMA, GS1-gamma1	Gamma glutamine synthase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.14g213300
 GS1alpha	Glutamine synthase 1 alpha gene	glyma.Wm82.gnm2.ann1.Glyma.09g173200
 GS1beta2	Glutamine synthase 1 beta 2 gene	glyma.Wm82.gnm2.ann1.Glyma.18g041100
-GS1GAMMA2	glutamine synthetase cytosolic isozyme 2	glyma.Wm82.gnm2.ann1.Glyma.02g244000
 GS52	ecto-apyrase GS52	glyma.Wm82.gnm2.ann1.Glyma.16g043300
 GSA1	glutamate 1-semialdehyde aminotransferase gene 1	glyma.Wm82.gnm2.ann1.Glyma.06g002900
 GSH1	gamma glutamylcysteine synthestase	glyma.Wm82.gnm2.ann1.Glyma.02G142000
@@ -1686,7 +1501,6 @@ GSRLCK	receptor-like cytoplasmic serine/threonine protein kinase GsRLCK	glyma.Wm
 GST1	Glutathione-S Transferase 1	glyma.Wm82.gnm2.ann1.Glyma.03G150300
 GST24	glutathione S-transferase 24	glyma.Wm82.gnm2.ann1.Glyma.14g031000
 GST3	lactoylglutathione lyase gene 	glyma.Wm82.gnm2.ann1.Glyma.15g252200
-GSTa	2,4-D inducible glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.15g251600
 GSTF1	glutathione S-transferase F1	glyma.Wm82.gnm2.ann1.Glyma.02g154300
 GSTF13	phi class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.18g111200
 GSTF2	glutathione S-transferase F2	glyma.Wm82.gnm2.ann1.Glyma.02g154400
@@ -1717,19 +1531,37 @@ GSTU62	glutathione S-transferase GST 18	glyma.Wm82.gnm2.ann1.Glyma.20g101100
 GSTU9	glutathione S-transferase GST 19	glyma.Wm82.gnm2.ann1.Glyma.02g187200
 GSTZ1	glutathione S-transferase zeta class	glyma.Wm82.gnm2.ann1.Glyma.01g142800
 GSTZ3	glutathione S-transferase GST 25	glyma.Wm82.gnm2.ann1.Glyma.17g003300
+GSTa	2,4-D inducible glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.15g251600
 GT-2A	trihelix transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g216100
 GT-2B	trihelix transcription factor	glyma.Wm82.gnm2.ann1.Glyma.10g161200
-GT4	glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.07g254600
+GT4, UGT73F2	Plant uridine 5' -diphosphate glycosyltransferase 73F2	glyma.Wm82.gnm2.ann1.Glyma.07G254600
 GTR1	glutamyl-tRNA reductase 1	glyma.Wm82.gnm2.ann1.Glyma.02g218300
 GTR2	glutamyl-tRNA reductase 2	glyma.Wm82.gnm2.ann1.Glyma.08g064700
+Gic	Gigantea gene c	glyma.Wm82.gnm2.ann1.Glyma.16G163200
+GinCrRI,k1l,18	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G053700
+GinCrRI,k1l,21	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G054300
+GinCrRI,k1l,22	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G054400
+GinCrRI,k1l,23	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G201400
+GinCrRI,k1l,26	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.17G102600
+GinCrRI,k1l,28	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G215800
+GinCrRI,k1l,36	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.19G033100
+GinCrRLk1L30	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G270100
+GinCrRl,k1l,19	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G053800
+GinCrRl,k1l,2-l	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.15G042900
+GinCrRl,k1l,32	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G270700
+GinCrRl,k1l,33	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G270900
+GinCrRl,k1l,38	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20G225800
+GnCrRLk1L27	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.17G166200
+GnCrRLk1L34	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G271000
+GnCrRLk1L35	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G271100
+GnCrRLk1L37	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20G162300
+GrnCrRLk1L17	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G053600
 Gy1	Glycinin gene 1	glyma.Wm82.gnm1.ann1.Glyma03g32030
 H-1	ferritin light chain	glyma.Wm82.gnm2.ann1.Glyma.18g205800
 H1	homeobox protein SBH1	glyma.Wm82.gnm2.ann1.Glyma.09g007500
 H4	stress-induced protein H4	glyma.Wm82.gnm2.ann1.Glyma.17g030200
-HAD1	acid phosphatase	glyma.Wm82.gnm2.ann1.Glyma.10g134700
-HAD3-1	acid phosphatase	glyma.Wm82.gnm2.ann1.Glyma.10G134700
+HAD1, HAD3-1	acid phosphatase	glyma.Wm82.gnm2.ann1.Glyma.10G134700
 HAK	potassium transporter 5-like	glyma.Wm82.gnm2.ann1.Glyma.03g264100
-HB1	Non-symbiotic hemoglobin 2 gene	glyma.Wm82.gnm2.ann1.Glyma.11g121800
 HB2	Non-symbiotic hemoglobin 1-like gene	glyma.Wm82.gnm2.ann1.Glyma.11g121700
 HD2A	histone deacetylase HDT1	glyma.Wm82.gnm2.ann1.Glyma.12g084700
 HDA1	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.01g245100
@@ -1755,7 +1587,6 @@ HDT2	histone deacetylase HDT1-like	glyma.Wm82.gnm2.ann1.Glyma.11g189500
 HDT4	histone deacetylase HDT1-like	glyma.Wm82.gnm2.ann1.Glyma.12g181400
 HDT6	histone deacetylase HDT1-like	glyma.Wm82.gnm2.ann1.Glyma.19g191000
 HELRP	ATP-dependent RNA helicase DEAH12, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.18g014800
-HEMB	aminolevulinate, delta-, dehydratase	glyma.Wm82.gnm2.ann1.Glyma.04g247700
 HEMG	protoporphyrinogen IX oxidase	glyma.Wm82.gnm2.ann1.Glyma.19g087600
 HEN1A	protein Hua enhancer 1a	glyma.Wm82.gnm2.ann1.Glyma.08g081600
 HEN1B	protein Hua enhancer 1b	glyma.Wm82.gnm2.ann1.Glyma.05g126600
@@ -1791,8 +1622,6 @@ HMA8	chloroplast copper-translocating HMA8 P-ATPase	glyma.Wm82.gnm2.ann1.Glyma.0
 HMGB6	Transcription factor	glyma.Wm82.gnm1.ann1.Glyma20g23370
 HO1	heme oxygenase 1, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.04g147700
 HO3	heme oxygenase 3	glyma.Wm82.gnm2.ann1.Glyma.06g221900
-Hop-1	Hsp70-Hsp90 organizing protein 1	glyma.Wm82.gnm2.ann1.Glyma.17g137700
-HOP1	hsp70-Hsp90 organizing protein 1	glyma.Wm82.gnm2.ann1.Glyma.17g137700
 HP01	Root Preferential, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma15g10660
 HP02	Ubiquitous, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma13g28390
 HP03	Root Specific, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma07g38310
@@ -1865,8 +1694,8 @@ HSP90-2	heat shock cognate protein 80-like	glyma.Wm82.gnm2.ann1.Glyma.08g332900
 HSP90A1	heat shock protein 90-A1	glyma.Wm82.gnm2.ann1.Glyma.09g131500
 HSP90A2	heat shock protein 90-A2	glyma.Wm82.gnm2.ann1.Glyma.16g178800
 HTA8	HISTONE H2A 8	glyma.Wm82.gnm1.ann1.Glyma02g16150
+Hop-1, HOP1	hsp70-Hsp90 organizing protein 1	glyma.Wm82.gnm2.ann1.Glyma.17g137700
 I2'H	isoflavone 2'-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.09g049300
-IAA1	Indole-3-Acetic Acid Responsive Gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G019400
 IAA10	Indole-3-Acetic Acid Responsive Gene 10	glyma.Wm82.gnm2.ann1.Glyma.03G158600
 IAA11	Indole-3-Acetic Acid Responsive Gene 11	glyma.Wm82.gnm2.ann1.Glyma.03G158700
 IAA12	Indole-3-Acetic Acid Responsive Gene 12	glyma.Wm82.gnm2.ann1.Glyma.03G167400
@@ -1897,7 +1726,7 @@ IAA34	Indole-3-Acetic Acid Responsive Gene 34	glyma.Wm82.gnm2.ann1.Glyma.10G0404
 IAA35	Indole-3-Acetic Acid Responsive Gene 35	glyma.Wm82.gnm2.ann1.Glyma.10G138500
 IAA36	Indole-3-Acetic Acid Responsive Gene 36	glyma.Wm82.gnm2.ann1.Glyma.10G162400
 IAA37	Indole-3-Acetic Acid Responsive Gene 37	glyma.Wm82.gnm2.ann1.Glyma.10G180000
-IAA38	Indole-3-Acetic Acid Responsive Gene 38	glyma.Wm82.gnm2.ann1.Glyma.10G180100
+IAA38, SLR1	auxin-induced protein ali50	glyma.Wm82.gnm2.ann1.Glyma.10g180100
 IAA39	Indole-3-Acetic Acid Responsive Gene 39	glyma.Wm82.gnm2.ann1.Glyma.10G270500
 IAA4	Indole-3-Acetic Acid Responsive Gene 4	glyma.Wm82.gnm2.ann1.Glyma.02G000500
 IAA40	Indole-3-Acetic Acid Responsive Gene 40	glyma.Wm82.gnm2.ann1.Glyma.13G117100
@@ -1917,7 +1746,6 @@ IAA52	Indole-3-Acetic Acid Responsive Gene 52	glyma.Wm82.gnm2.ann1.Glyma.15G0203
 IAA53	Indole-3-Acetic Acid Responsive Gene 53	glyma.Wm82.gnm2.ann1.Glyma.17G042800
 IAA54	Indole-3-Acetic Acid Responsive Gene 54	glyma.Wm82.gnm2.ann1.Glyma.17G112300
 IAA55	Indole-3-Acetic Acid Responsive Gene 55	glyma.Wm82.gnm2.ann1.Glyma.19G161000
-IAA56	Indole-3-Acetic Acid Responsive Gene 56	glyma.Wm82.gnm2.ann1.Glyma.19G161100
 IAA57	Indole-3-Acetic Acid Responsive Gene 57	glyma.Wm82.gnm2.ann1.Glyma.19G168500
 IAA58	Indole-3-Acetic Acid Responsive Gene 58	glyma.Wm82.gnm2.ann1.Glyma.19G221900
 IAA59	Indole-3-Acetic Acid Responsive Gene 59	glyma.Wm82.gnm2.ann1.Glyma.19G245200
@@ -2033,7 +1861,6 @@ ITPK4	inositol phosphate kinase	glyma.Wm82.gnm2.ann1.Glyma.10g255000
 J1	DnaJ-like protein	glyma.Wm82.gnm2.ann1.Glyma.08g109700
 JAG1	JAGGED gene 1	glyma.Wm82.gnm2.ann1.Glyma.20g116200
 JAG2	JAGGED gene 2	glyma.Wm82.gnm2.ann1.Glyma.10g273800
-jmjC	transcription factor; jumonji (jmjC) domain-containing protein	glyma.Wm82.gnm1.ann1.Glyma12g05890
 JOX1	jasnonate-induced oxygenase 1	glyma.Wm82.gnm2.ann1.Glyma.09G107100
 JOX2	jasnonate-induced oxygenase 2	glyma.Wm82.gnm2.ann1.Glyma.18G026500
 JOX3	jasnonate-induced oxygenase 3	glyma.Wm82.gnm2.ann1.Glyma.18G201900
@@ -2042,21 +1869,205 @@ KAPP2	kinase-associated protein phosphatase 2	glyma.Wm82.gnm2.ann1.Glyma.01g2397
 KAR	3-oxoacyl-[acyl-carrier-protein] reductase	glyma.Wm82.gnm1.ann1.Glyma08G10760
 KASI	Beta-ketoacyl-ACP carrier protein synthase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.08G084300
 KASII-A	beta-ketoacyl-ACP synthetase 2 gene 1	glyma.Wm82.gnm2.ann1.Glyma.17g047000
-KASII-B	beta-ketoacyl-ACP synthetase 2 gene 2	glyma.Wm82.gnm1.ann1.Glyma13g112700
-KASIIa	3-ketoacyl-ACP synthase II	glyma.Wm82.gnm1.ann1.Glyma17g05200
-KASIIb	3-ketoacyl-ACP synthase II	glyma.Wm82.gnm1.ann1.Glyma13g17290
+KASII-B, KASIIb	3-ketoacyl-ACP synthase II	glyma.Wm82.gnm1.ann1.Glyma13g17290
 KASIII-1	beta-ketoacyl-ACP synthetase 3 gene 1	glyma.Wm82.gnm2.ann1.Glyma.09g277400
 KASIII-2	beta-ketoacyl-ACP synthetase 3 gene 2	glyma.Wm82.gnm2.ann1.Glyma.15g003100
+KASIIa	3-ketoacyl-ACP synthase II	glyma.Wm82.gnm1.ann1.Glyma17g05200
 KEU	protein transporter  	glyma.Wm82.gnm1.ann1.Glyma11g03230
 KR1	resistance protein KR1	glyma.Wm82.gnm2.ann1.Glyma.19g054900
 KR3	disease resistance protein KR3	glyma.Wm82.gnm2.ann1.Glyma.06g267300
-KTI-1	kunitz trypsin inhibitor	glyma.Wm82.gnm2.ann1.Glyma.08g341400
+KTI-1, KTI-S, KTi2	Kunitz trypsin inhibitor gene 2	glyma.Wm82.gnm2.ann1.Glyma.08g341400
 KTI-2	kunitz trypsin protease inhibitor	glyma.Wm82.gnm2.ann1.Glyma.09g155500
 KTI-3	kunitz family trypsin and protease inhibitor protein	glyma.Wm82.gnm2.ann1.Glyma.16g211700
-KTI-S	Kunitz trypsin inhibitor S gene	glyma.Wm82.gnm2.ann1.Glyma.08g341400
-KTi2	Kunitz trypsin inhibitor gene 2	glyma.Wm82.gnm2.ann1.Glyma.08g341400
-L-4	Lipoxygenase L-4 gene	glyma.Wm82.gnm2.ann1.Glyma.13g347700
-L-5	Lipoxygenase L-5 gene	glyma.Wm82.gnm2.ann1.Glyma.15g026500
+L-4, LOX4, LoxB, LOXB1	lipoxygenase	glyma.Wm82.gnm2.ann1.Glyma.13g347700
+L-5, LOX8, VLXB	lipoxygenase L-5	glyma.Wm82.gnm2.ann1.Glyma.15g026500
+LAR1	leucoanthocyanidin reductase	glyma.Wm82.gnm2.ann1.Glyma.20g185700
+LAX1	auxin transporter-like protein 1	glyma.Wm82.gnm2.ann1.Glyma.01g114000
+LAX10	auxin transporter-like protein 10	glyma.Wm82.gnm2.ann1.Glyma.11g106000
+LAX11	auxin transporter-like protein 11	glyma.Wm82.gnm2.ann1.Glyma.11g228300
+LAX12	auxin transporter-like protein 12	glyma.Wm82.gnm2.ann1.Glyma.12g030900
+LAX13	auxin transporter-like protein 13	glyma.Wm82.gnm2.ann1.Glyma.14g060700
+LAX14	auxin transporter-like protein 14	glyma.Wm82.gnm2.ann1.Glyma.18g029000
+LAX15	auxin transporter-like protein 15	glyma.Wm82.gnm2.ann1.Glyma.18g198400
+LAX2	auxin transporter-like protein 2	glyma.Wm82.gnm2.ann1.Glyma.02g255800
+LAX3	auxin transporter-like protein 3	glyma.Wm82.gnm2.ann1.Glyma.03g063600
+LAX4	auxin transporter-like protein 4	glyma.Wm82.gnm2.ann1.Glyma.03g063900
+LAX5	auxin transporter-like protein 5	glyma.Wm82.gnm2.ann1.Glyma.04g004800
+LAX6	auxin transporter-like protein 6	glyma.Wm82.gnm2.ann1.Glyma.04g252300
+LAX7	auxin transporter-like protein 7	glyma.Wm82.gnm2.ann1.Glyma.06g004500
+LAX8	auxin transporter-like protein 8	glyma.Wm82.gnm2.ann1.Glyma.06g110200
+LAX9	auxin transporter-like protein 9	glyma.Wm82.gnm2.ann1.Glyma.07g147000
+LB	leghemoglobin	glyma.Wm82.gnm2.ann1.Glyma.10g198900
+LBA	Leghemoglobin A	glyma.Wm82.gnm2.ann1.Glyma.10g199100
+LBC1	leghemoglobin C1	glyma.Wm82.gnm2.ann1.Glyma.10g199000
+LBD1	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.01g131000
+LBD10	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g264500
+LBD12	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.03g023000
+LBD13	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.03g023100
+LBD14	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.03g161400
+LBD15	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.03g161500
+LBD16	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g044800
+LBD17	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g106400
+LBD18	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g186900
+LBD19	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g220500
+LBD20	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.05g004400
+LBD21	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.05g040500
+LBD22	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.05g081400
+LBD23	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.05g103300
+LBD25	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.06g106500
+LBD26	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.06g145400
+LBD27	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.06g178900
+LBD28	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.06g285100
+LBD29	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.07g009500
+LBD3	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.01g143900
+LBD30	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.07g091600
+LBD31	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.07g223600
+LBD32	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g169000
+LBD33	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g192600
+LBD34	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g235200
+LBD35	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g261900
+LBD36	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g334200
+LBD37	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g365100
+LBD4	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.01g183900
+LBD5	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.01g192600
+LBD6	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g166400
+LBD7.2	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g234600
+LBD8	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g249700
+LBD9	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g262400
+LCL-1, LCL1, LHY1a	LATE ELONGATED HYPOCOTYL 1 gene a	glyma.Wm82.gnm2.ann1.Glyma.16G017400
+LCL-2, LHY2b, MYB114	MYB transcription factor MYB114	glyma.Wm82.gnm2.ann1.Glyma.03g261800
+LCL-3, LCL3, LHY2a	LATE ELONGATED HYPOCOTYL 2 gene a	glyma.Wm82.gnm2.ann1.Glyma.19G260900
+LCL-4, LCL4, LHY1b	LATE ELONGATED HYPOCOTYL 1 gene b	glyma.Wm82.gnm2.ann1.Glyma.07G048500
+LDL1-1	LSD1-like1 gene 1	glyma.Wm82.gnm1.ann1.Glyma07g09980
+LDL1-2	LSD1-like1 gene 2	glyma.Wm82.gnm1.ann1.Glyma09g31770
+LDL2-1	LSD2-like2 gene 1	glyma.Wm82.gnm1.ann1.Glyma06g38600
+LE1, Le1-1	Lectin 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02g012600
+LEA-1, LEA2-79	late embryogenesis abundant 2 gene 79	glyma.Wm82.gnm2.ann1.Glyma.14G037300
+LEA-2, LEA2-101	late embryogenesis abundant 2 gene 101	glyma.Wm82.gnm2.ann1.Glyma.20G044800
+LEA2-1	late embryogenesis abundant 2 gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G152600
+LEA2-10	late embryogenesis abundant 2 gene 10	glyma.Wm82.gnm2.ann1.Glyma.02G303100
+LEA2-100	late embryogenesis abundant 2 gene 100	glyma.Wm82.gnm2.ann1.Glyma.19G260500
+LEA2-102	late embryogenesis abundant 2 gene 102	glyma.Wm82.gnm2.ann1.Glyma.20G140900
+LEA2-103	late embryogenesis abundant 2 gene 103	glyma.Wm82.gnm2.ann1.Glyma.20G216300
+LEA2-11	late embryogenesis abundant 2 gene 11	glyma.Wm82.gnm2.ann1.Glyma.03G000800
+LEA2-12	late embryogenesis abundant 2 gene 12	glyma.Wm82.gnm2.ann1.Glyma.03G201000
+LEA2-13	late embryogenesis abundant 2 gene 13	glyma.Wm82.gnm2.ann1.Glyma.03G201100
+LEA2-14	late embryogenesis abundant 2 gene 14	glyma.Wm82.gnm2.ann1.Glyma.03G201200
+LEA2-16	late embryogenesis abundant 2 gene 16	glyma.Wm82.gnm2.ann1.Glyma.03G201500
+LEA2-17	late embryogenesis abundant 2 gene 17	glyma.Wm82.gnm2.ann1.Glyma.03G201600
+LEA2-18	late embryogenesis abundant 2 gene 18	glyma.Wm82.gnm2.ann1.Glyma.03G261400
+LEA2-19	late embryogenesis abundant 2 gene 19	glyma.Wm82.gnm2.ann1.Glyma.03G263800
+LEA2-2	late embryogenesis abundant 2 gene 2	glyma.Wm82.gnm2.ann1.Glyma.01G222800
+LEA2-20	late embryogenesis abundant 2 gene 20	glyma.Wm82.gnm2.ann1.Glyma.04G051600
+LEA2-21	late embryogenesis abundant 2 gene 21	glyma.Wm82.gnm2.ann1.Glyma.04G103700
+LEA2-22	late embryogenesis abundant 2 gene 22	glyma.Wm82.gnm2.ann1.Glyma.04G228200
+LEA2-23	late embryogenesis abundant 2 gene 23	glyma.Wm82.gnm2.ann1.Glyma.05G094300
+LEA2-24	late embryogenesis abundant 2 gene 24	glyma.Wm82.gnm2.ann1.Glyma.05G179200
+LEA2-25	late embryogenesis abundant 2 gene 25	glyma.Wm82.gnm2.ann1.Glyma.05G212600
+LEA2-26	late embryogenesis abundant 2 gene 26	glyma.Wm82.gnm2.ann1.Glyma.05G217500
+LEA2-27	late embryogenesis abundant 2 gene 27	glyma.Wm82.gnm2.ann1.Glyma.05G242600
+LEA2-28	late embryogenesis abundant 2 gene 28	glyma.Wm82.gnm2.ann1.Glyma.06G052400
+LEA2-29	late embryogenesis abundant 2 gene 29	glyma.Wm82.gnm2.ann1.Glyma.06G104900
+LEA2-3	late embryogenesis abundant 2 gene 3	glyma.Wm82.gnm2.ann1.Glyma.01G226100
+LEA2-30	late embryogenesis abundant 2 gene 30	glyma.Wm82.gnm2.ann1.Glyma.06G136700
+LEA2-31	late embryogenesis abundant 2 gene 31	glyma.Wm82.gnm2.ann1.Glyma.06G303300
+LEA2-32	late embryogenesis abundant 2 gene 32	glyma.Wm82.gnm2.ann1.Glyma.07G009700
+LEA2-33	late embryogenesis abundant 2 gene 33	glyma.Wm82.gnm2.ann1.Glyma.07G049300
+LEA2-34	late embryogenesis abundant 2 gene 34	glyma.Wm82.gnm2.ann1.Glyma.07G084600
+LEA2-35	late embryogenesis abundant 2 gene 35	glyma.Wm82.gnm2.ann1.Glyma.07G087000
+LEA2-36	late embryogenesis abundant 2 gene 36	glyma.Wm82.gnm2.ann1.Glyma.07G099500
+LEA2-37	late embryogenesis abundant 2 gene 37	glyma.Wm82.gnm2.ann1.Glyma.07G103700
+LEA2-38	late embryogenesis abundant 2 gene 38	glyma.Wm82.gnm2.ann1.Glyma.07G103800
+LEA2-39	late embryogenesis abundant 2 gene 39	glyma.Wm82.gnm2.ann1.Glyma.07G103900
+LEA2-4	late embryogenesis abundant 2 gene 4	glyma.Wm82.gnm2.ann1.Glyma.01G240600
+LEA2-40	late embryogenesis abundant 2 gene 40	glyma.Wm82.gnm2.ann1.Glyma.08G019000
+LEA2-41	late embryogenesis abundant 2 gene 41	glyma.Wm82.gnm2.ann1.Glyma.08G023500
+LEA2-42	late embryogenesis abundant 2 gene 42	glyma.Wm82.gnm2.ann1.Glyma.08G077900
+LEA2-43	late embryogenesis abundant 2 gene 43	glyma.Wm82.gnm2.ann1.Glyma.08G136900
+LEA2-44	late embryogenesis abundant 2 gene 44	glyma.Wm82.gnm2.ann1.Glyma.08G184000
+LEA2-45	late embryogenesis abundant 2 gene 45	glyma.Wm82.gnm2.ann1.Glyma.09G071900
+LEA2-46	late embryogenesis abundant 2 gene 46	glyma.Wm82.gnm2.ann1.Glyma.09G179400
+LEA2-47	late embryogenesis abundant 2 gene 47	glyma.Wm82.gnm2.ann1.Glyma.09G189900
+LEA2-48	late embryogenesis abundant 2 gene 48	glyma.Wm82.gnm2.ann1.Glyma.09G192300
+LEA2-49	late embryogenesis abundant 2 gene 49	glyma.Wm82.gnm2.ann1.Glyma.09G217800
+LEA2-5	late embryogenesis abundant 2 gene 5	glyma.Wm82.gnm2.ann1.Glyma.02G197600
+LEA2-50	late embryogenesis abundant 2 gene 50	glyma.Wm82.gnm2.ann1.Glyma.10G079400
+LEA2-51	late embryogenesis abundant 2 gene 51	glyma.Wm82.gnm2.ann1.Glyma.10G079900
+LEA2-52	late embryogenesis abundant 2 gene 52	glyma.Wm82.gnm2.ann1.Glyma.10G080000
+LEA2-53	late embryogenesis abundant 2 gene 53	glyma.Wm82.gnm2.ann1.Glyma.10G174100
+LEA2-54	late embryogenesis abundant 2 gene 54	glyma.Wm82.gnm2.ann1.Glyma.10G252500
+LEA2-55	late embryogenesis abundant 2 gene 55	glyma.Wm82.gnm2.ann1.Glyma.11G003000
+LEA2-56	late embryogenesis abundant 2 gene 56	glyma.Wm82.gnm2.ann1.Glyma.11G020500
+LEA2-57	late embryogenesis abundant 2 gene 57	glyma.Wm82.gnm2.ann1.Glyma.11G020600
+LEA2-58	late embryogenesis abundant 2 gene 58	glyma.Wm82.gnm2.ann1.Glyma.11G097100
+LEA2-59	late embryogenesis abundant 2 gene 59	glyma.Wm82.gnm2.ann1.Glyma.11G179900
+LEA2-6	late embryogenesis abundant 2 gene 6	glyma.Wm82.gnm2.ann1.Glyma.02G197800
+LEA2-60	late embryogenesis abundant 2 gene 60	glyma.Wm82.gnm2.ann1.Glyma.11G182400
+LEA2-61	late embryogenesis abundant 2 gene 61	glyma.Wm82.gnm2.ann1.Glyma.11G199600
+LEA2-62	late embryogenesis abundant 2 gene 62	glyma.Wm82.gnm2.ann1.Glyma.11G203000
+LEA2-63	late embryogenesis abundant 2 gene 63	glyma.Wm82.gnm2.ann1.Glyma.12G023200
+LEA2-64	late embryogenesis abundant 2 gene 64	glyma.Wm82.gnm2.ann1.Glyma.12G093600
+LEA2-65	late embryogenesis abundant 2 gene 65	glyma.Wm82.gnm2.ann1.Glyma.12G187600
+LEA2-66	late embryogenesis abundant 2 gene 66	glyma.Wm82.gnm2.ann1.Glyma.12G194700
+LEA2-67	late embryogenesis abundant 2 gene 67	glyma.Wm82.gnm2.ann1.Glyma.12G202900
+LEA2-68	late embryogenesis abundant 2 gene 68	glyma.Wm82.gnm2.ann1.Glyma.13G000500
+LEA2-69	late embryogenesis abundant 2 gene 69	glyma.Wm82.gnm2.ann1.Glyma.13G248600
+LEA2-7	late embryogenesis abundant 2 gene 7	glyma.Wm82.gnm2.ann1.Glyma.02G239100
+LEA2-70	late embryogenesis abundant 2 gene 70	glyma.Wm82.gnm2.ann1.Glyma.13G298800
+LEA2-71	late embryogenesis abundant 2 gene 71	glyma.Wm82.gnm2.ann1.Glyma.13G307700
+LEA2-72	late embryogenesis abundant 2 gene 72	glyma.Wm82.gnm2.ann1.Glyma.13G307900
+LEA2-73	late embryogenesis abundant 2 gene 73	glyma.Wm82.gnm2.ann1.Glyma.13G313600
+LEA2-74	late embryogenesis abundant 2 gene 74	glyma.Wm82.gnm2.ann1.Glyma.13G313700
+LEA2-75	late embryogenesis abundant 2 gene 75	glyma.Wm82.gnm2.ann1.Glyma.13G349900
+LEA2-76	late embryogenesis abundant 2 gene 76	glyma.Wm82.gnm2.ann1.Glyma.13G357600
+LEA2-77	late embryogenesis abundant 2 gene 77	glyma.Wm82.gnm2.ann1.Glyma.13G359200
+LEA2-78	late embryogenesis abundant 2 gene 78	glyma.Wm82.gnm2.ann1.Glyma.14G010800
+LEA2-8	late embryogenesis abundant 2 gene 8	glyma.Wm82.gnm2.ann1.Glyma.02G274400
+LEA2-80	late embryogenesis abundant 2 gene 80	glyma.Wm82.gnm2.ann1.Glyma.14G041700
+LEA2-81	late embryogenesis abundant 2 gene 81	glyma.Wm82.gnm2.ann1.Glyma.14G160000
+LEA2-82	late embryogenesis abundant 2 gene 82	glyma.Wm82.gnm2.ann1.Glyma.14G208000
+LEA2-83	late embryogenesis abundant 2 gene 83	glyma.Wm82.gnm2.ann1.Glyma.15G015800
+LEA2-84	late embryogenesis abundant 2 gene 84	glyma.Wm82.gnm2.ann1.Glyma.15G024400
+LEA2-85	late embryogenesis abundant 2 gene 85	glyma.Wm82.gnm2.ann1.Glyma.15G048800
+LEA2-86	late embryogenesis abundant 2 gene 86	glyma.Wm82.gnm2.ann1.Glyma.15G065400
+LEA2-87	late embryogenesis abundant 2 gene 87	glyma.Wm82.gnm2.ann1.Glyma.16G031000
+LEA2-88, PM22	Maturation protein 22 gene	glyma.Wm82.gnm2.ann1.Glyma.16g031300
+LEA2-89	late embryogenesis abundant 2 gene 89	glyma.Wm82.gnm2.ann1.Glyma.16G221900
+LEA2-9	late embryogenesis abundant 2 gene 9	glyma.Wm82.gnm2.ann1.Glyma.02G277300
+LEA2-90	late embryogenesis abundant 2 gene 90	glyma.Wm82.gnm2.ann1.Glyma.17G172900
+LEA2-91	late embryogenesis abundant 2 gene 91	glyma.Wm82.gnm2.ann1.Glyma.18G047800
+LEA2-92	late embryogenesis abundant 2 gene 92	glyma.Wm82.gnm2.ann1.Glyma.18G073200
+LEA2-93	late embryogenesis abundant 2 gene 93	glyma.Wm82.gnm2.ann1.Glyma.18G218700
+LEA2-94	late embryogenesis abundant 2 gene 94	glyma.Wm82.gnm2.ann1.Glyma.18G218800
+LEA2-95	late embryogenesis abundant 2 gene 95	glyma.Wm82.gnm2.ann1.Glyma.18G238700
+LEA2-97	late embryogenesis abundant 2 gene 97	glyma.Wm82.gnm2.ann1.Glyma.19G19870
+LEA2-98	late embryogenesis abundant 2 gene 98	glyma.Wm82.gnm2.ann1.Glyma.19G198800
+LEA2-99	late embryogenesis abundant 2 gene 99	glyma.Wm82.gnm2.ann1.Glyma.19G198900
+LEA5	desiccation protective protein LEA5	glyma.Wm82.gnm2.ann1.Glyma.17g027400
+LEC1-A	transcription factor LEC1-A	glyma.Wm82.gnm2.ann1.Glyma.07g268100
+LEC1-B	nuclear transcription factor Y subunit B-6-like	glyma.Wm82.gnm2.ann1.Glyma.17g005600
+LEC2a	B3 domain transcription factor	glyma.Wm82.gnm2.ann1.Glyma.20G035800
+LEC2b	B3 domain transcription factor	glyma.Wm82.gnm2.ann1.Glyma.20G035700
+LEM3	ligand-effect modulator 3	glyma.Wm82.gnm1.ann1.Glyma08g17460
+LHCB1-7	photosystem II type I chlorophyll a/b-binding protein	glyma.Wm82.gnm2.ann1.Glyma.16g165800
+LHP1, LHP1-1	chromo domain-containing protein LHP1-1	glyma.Wm82.gnm2.ann1.Glyma.16g079900
+LHP1-2	chromo domain-containing protein LHP1-2	glyma.Wm82.gnm2.ann1.Glyma.03g094200
+LOG	Lonely Guy	glyma.Wm82.gnm2.ann1.Glyma.12G174900
+LOX	seed linoleate 9S-lipoxygenase-3	glyma.Wm82.gnm2.ann1.Glyma.08g189200
+LOX1.4, SC514	lipoxygenase	glyma.Wm82.gnm2.ann1.Glyma.07g007000
+LOX10	lipoxygenase-10 gene	glyma.Wm82.gnm2.ann1.Glyma.08g189600
+LOX9	Lipoxygenase 9 gene	glyma.Wm82.gnm2.ann1.Glyma.07g034800
+LPAAT	lysophosphatidic acid acyltransferase	glyma.Wm82.gnm2.ann1.Glyma.15g034100
+LPAT	Lysophosphatidyl acyltransferase	glyma.Wm82.gnm1.ann1.Glyma11G12830
+LRK1	leucine-rich repeat receptor-like kinase 1	glyma.Wm82.gnm2.ann1.Glyma.03g189800
+LRPK	serine/threonine-protein kinase LRPK	glyma.Wm82.gnm2.ann1.Glyma.16g015400
+LRR	Leucine-rich repeat receptor-like kinase	glyma.Wm82.gnm2.ann1.Glyma.06G265400
+LSD1	Lys-Specific Demethylase 1	glyma.Wm82.gnm1.ann1.Glyma02g18610
+LUXA	transcription factor LUXa	glyma.Wm82.gnm2.ann1.Glyma.01g162600
+LUXB	transcription factor LUXb	glyma.Wm82.gnm2.ann1.Glyma.12g060200
+LUXC	transcription factor LUXc	glyma.Wm82.gnm2.ann1.Glyma.11g136600
+LYK10	protein LYK2	glyma.Wm82.gnm2.ann1.Glyma.19g088300
+LYK4	lysM domain receptor-like kinase 4	glyma.Wm82.gnm2.ann1.Glyma.01g179000
 Lac1	Laccase 1	glyma.Wm82.gnm2.ann1.Glyma.01G108200
 Lac10	Laccase 10	glyma.Wm82.gnm2.ann1.Glyma.04G019500
 Lac11	Laccase 11	glyma.Wm82.gnm2.ann1.Glyma.04G119600
@@ -2139,7 +2150,6 @@ Lac80	Laccase 80	glyma.Wm82.gnm2.ann1.Glyma.18G193400
 Lac81	Laccase 81	glyma.Wm82.gnm2.ann1.Glyma.18G197400
 Lac82	Laccase 82	glyma.Wm82.gnm2.ann1.Glyma.20G025200
 Lac83	Laccase 83	glyma.Wm82.gnm2.ann1.Glyma.20G051600
-Lac84	Laccase 84	glyma.Wm82.gnm2.ann1.Glyma.20G051700
 Lac85	Laccase 85	glyma.Wm82.gnm2.ann1.Glyma.20G051900
 Lac86	Laccase 86	glyma.Wm82.gnm2.ann1.Glyma.20G126500
 Lac87	Laccase 87	glyma.Wm82.gnm2.ann1.Glyma.20G172600
@@ -2149,217 +2159,12 @@ Lac9	Laccase 9	glyma.Wm82.gnm2.ann1.Glyma.03G077900
 Lac90	Laccase 90	glyma.Wm82.gnm2.ann1.Glyma.20G192900
 Lac91	Laccase 91	glyma.Wm82.gnm2.ann1.Glyma.U027300
 Lac92	Laccase 92	glyma.Wm82.gnm2.ann1.Glyma.U027400
-Lac93	Laccase 93	glyma.Wm82.gnm2.ann1.Glyma.U040600
-LAR1	leucoanthocyanidin reductase	glyma.Wm82.gnm2.ann1.Glyma.20g185700
-LAX1	auxin transporter-like protein 1	glyma.Wm82.gnm2.ann1.Glyma.01g114000
-LAX10	auxin transporter-like protein 10	glyma.Wm82.gnm2.ann1.Glyma.11g106000
-LAX11	auxin transporter-like protein 11	glyma.Wm82.gnm2.ann1.Glyma.11g228300
-LAX12	auxin transporter-like protein 12	glyma.Wm82.gnm2.ann1.Glyma.12g030900
-LAX13	auxin transporter-like protein 13	glyma.Wm82.gnm2.ann1.Glyma.14g060700
-LAX14	auxin transporter-like protein 14	glyma.Wm82.gnm2.ann1.Glyma.18g029000
-LAX15	auxin transporter-like protein 15	glyma.Wm82.gnm2.ann1.Glyma.18g198400
-LAX2	auxin transporter-like protein 2	glyma.Wm82.gnm2.ann1.Glyma.02g255800
-LAX3	auxin transporter-like protein 3	glyma.Wm82.gnm2.ann1.Glyma.03g063600
-LAX4	auxin transporter-like protein 4	glyma.Wm82.gnm2.ann1.Glyma.03g063900
-LAX5	auxin transporter-like protein 5	glyma.Wm82.gnm2.ann1.Glyma.04g004800
-LAX6	auxin transporter-like protein 6	glyma.Wm82.gnm2.ann1.Glyma.04g252300
-LAX7	auxin transporter-like protein 7	glyma.Wm82.gnm2.ann1.Glyma.06g004500
-LAX8	auxin transporter-like protein 8	glyma.Wm82.gnm2.ann1.Glyma.06g110200
-LAX9	auxin transporter-like protein 9	glyma.Wm82.gnm2.ann1.Glyma.07g147000
-LB	leghemoglobin	glyma.Wm82.gnm2.ann1.Glyma.10g198900
-LBA	Leghemoglobin A	glyma.Wm82.gnm2.ann1.Glyma.10g199100
-LBC1	leghemoglobin C1	glyma.Wm82.gnm2.ann1.Glyma.10g199000
 Lbc2A	Leghemoglobin C2 gene A	glyma.Wm82.gnm1.ann1.Glyma20g33290
-LBD1	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.01g131000
-LBD10	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g264500
-LBD12	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.03g023000
-LBD13	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.03g023100
-LBD14	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.03g161400
-LBD15	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.03g161500
-LBD16	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g044800
-LBD17	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g106400
-LBD18	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g186900
-LBD19	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g220500
-LBD20	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.05g004400
-LBD21	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.05g040500
-LBD22	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.05g081400
-LBD23	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.05g103300
-LBD25	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.06g106500
-LBD26	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.06g145400
-LBD27	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.06g178900
-LBD28	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.06g285100
-LBD29	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.07g009500
-LBD3	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.01g143900
-LBD30	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.07g091600
-LBD31	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.07g223600
-LBD32	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g169000
-LBD33	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g192600
-LBD34	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g235200
-LBD35	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g261900
-LBD36	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g334200
-LBD37	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g365100
-LBD4	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.01g183900
-LBD5	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.01g192600
-LBD6	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g166400
-LBD7.2	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g234600
-LBD8	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g249700
-LBD9	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g262400
-LCL-1	Late Elongated Hypocotyl/ CCA gene 1	glyma.Wm82.gnm2.ann1.Glyma.16G017400
-LCL-2	Late Elongated Hypocotyl/ CCA gene 2	glyma.Wm82.gnm2.ann1.Glyma.03G261800
-LCL-3	Late Elongated Hypocotyl/ CCA gene 3	glyma.Wm82.gnm2.ann1.Glyma.19G260900
-LCL-4	Late Elongated Hypocotyl/ CCA gene 4	glyma.Wm82.gnm2.ann1.Glyma.07G048500
-LCL1	late elongated hypocotyl and circadian clock associated-1-like protein 1	glyma.Wm82.gnm2.ann1.Glyma.16g017400
-LCL3	LHY1/CCA1-like protein	glyma.Wm82.gnm2.ann1.Glyma.19g260900
-LCL4	LHY1/CCA1-like protein	glyma.Wm82.gnm2.ann1.Glyma.07g048500
-LDL1-1	LSD1-like1 gene 1	glyma.Wm82.gnm1.ann1.Glyma07g09980
-LDL1-2	LSD1-like1 gene 2	glyma.Wm82.gnm1.ann1.Glyma09g31770
-LDL2-1	LSD2-like2 gene 1	glyma.Wm82.gnm1.ann1.Glyma06g38600
-LE1	lectin	glyma.Wm82.gnm2.ann1.Glyma.02g012600
-Le1-1	Lectin 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02g012600
 Le4-2	lectin DB58-like	glyma.Wm82.gnm2.ann1.Glyma.10g108900
 Le5	Lectin gene 5	glyma.Wm82.gnm1.ann1.Glyma10g15480
-LEA-1	late-embryogenesis abundant protein 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.14g037300
-LEA-2	late-embryogenesis abundant protein 1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.20g044800
-LEA2-1	late embryogenesis abundant 2 gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G152600
-LEA2-10	late embryogenesis abundant 2 gene 10	glyma.Wm82.gnm2.ann1.Glyma.02G303100
-LEA2-100	late embryogenesis abundant 2 gene 100	glyma.Wm82.gnm2.ann1.Glyma.19G260500
-LEA2-101	late embryogenesis abundant 2 gene 101	glyma.Wm82.gnm2.ann1.Glyma.20G044800
-LEA2-102	late embryogenesis abundant 2 gene 102	glyma.Wm82.gnm2.ann1.Glyma.20G140900
-LEA2-103	late embryogenesis abundant 2 gene 103	glyma.Wm82.gnm2.ann1.Glyma.20G216300
-LEA2-11	late embryogenesis abundant 2 gene 11	glyma.Wm82.gnm2.ann1.Glyma.03G000800
-LEA2-12	late embryogenesis abundant 2 gene 12	glyma.Wm82.gnm2.ann1.Glyma.03G201000
-LEA2-13	late embryogenesis abundant 2 gene 13	glyma.Wm82.gnm2.ann1.Glyma.03G201100
-LEA2-14	late embryogenesis abundant 2 gene 14	glyma.Wm82.gnm2.ann1.Glyma.03G201200
-LEA2-15	late embryogenesis abundant 2 gene 15	glyma.Wm82.gnm2.ann1.Glyma.03G201300
-LEA2-16	late embryogenesis abundant 2 gene 16	glyma.Wm82.gnm2.ann1.Glyma.03G201500
-LEA2-17	late embryogenesis abundant 2 gene 17	glyma.Wm82.gnm2.ann1.Glyma.03G201600
-LEA2-18	late embryogenesis abundant 2 gene 18	glyma.Wm82.gnm2.ann1.Glyma.03G261400
-LEA2-19	late embryogenesis abundant 2 gene 19	glyma.Wm82.gnm2.ann1.Glyma.03G263800
-LEA2-2	late embryogenesis abundant 2 gene 2	glyma.Wm82.gnm2.ann1.Glyma.01G222800
-LEA2-20	late embryogenesis abundant 2 gene 20	glyma.Wm82.gnm2.ann1.Glyma.04G051600
-LEA2-21	late embryogenesis abundant 2 gene 21	glyma.Wm82.gnm2.ann1.Glyma.04G103700
-LEA2-22	late embryogenesis abundant 2 gene 22	glyma.Wm82.gnm2.ann1.Glyma.04G228200
-LEA2-23	late embryogenesis abundant 2 gene 23	glyma.Wm82.gnm2.ann1.Glyma.05G094300
-LEA2-24	late embryogenesis abundant 2 gene 24	glyma.Wm82.gnm2.ann1.Glyma.05G179200
-LEA2-25	late embryogenesis abundant 2 gene 25	glyma.Wm82.gnm2.ann1.Glyma.05G212600
-LEA2-26	late embryogenesis abundant 2 gene 26	glyma.Wm82.gnm2.ann1.Glyma.05G217500
-LEA2-27	late embryogenesis abundant 2 gene 27	glyma.Wm82.gnm2.ann1.Glyma.05G242600
-LEA2-28	late embryogenesis abundant 2 gene 28	glyma.Wm82.gnm2.ann1.Glyma.06G052400
-LEA2-29	late embryogenesis abundant 2 gene 29	glyma.Wm82.gnm2.ann1.Glyma.06G104900
-LEA2-3	late embryogenesis abundant 2 gene 3	glyma.Wm82.gnm2.ann1.Glyma.01G226100
-LEA2-30	late embryogenesis abundant 2 gene 30	glyma.Wm82.gnm2.ann1.Glyma.06G136700
-LEA2-31	late embryogenesis abundant 2 gene 31	glyma.Wm82.gnm2.ann1.Glyma.06G303300
-LEA2-32	late embryogenesis abundant 2 gene 32	glyma.Wm82.gnm2.ann1.Glyma.07G009700
-LEA2-33	late embryogenesis abundant 2 gene 33	glyma.Wm82.gnm2.ann1.Glyma.07G049300
-LEA2-34	late embryogenesis abundant 2 gene 34	glyma.Wm82.gnm2.ann1.Glyma.07G084600
-LEA2-35	late embryogenesis abundant 2 gene 35	glyma.Wm82.gnm2.ann1.Glyma.07G087000
-LEA2-36	late embryogenesis abundant 2 gene 36	glyma.Wm82.gnm2.ann1.Glyma.07G099500
-LEA2-37	late embryogenesis abundant 2 gene 37	glyma.Wm82.gnm2.ann1.Glyma.07G103700
-LEA2-38	late embryogenesis abundant 2 gene 38	glyma.Wm82.gnm2.ann1.Glyma.07G103800
-LEA2-39	late embryogenesis abundant 2 gene 39	glyma.Wm82.gnm2.ann1.Glyma.07G103900
-LEA2-4	late embryogenesis abundant 2 gene 4	glyma.Wm82.gnm2.ann1.Glyma.01G240600
-LEA2-40	late embryogenesis abundant 2 gene 40	glyma.Wm82.gnm2.ann1.Glyma.08G019000
-LEA2-41	late embryogenesis abundant 2 gene 41	glyma.Wm82.gnm2.ann1.Glyma.08G023500
-LEA2-42	late embryogenesis abundant 2 gene 42	glyma.Wm82.gnm2.ann1.Glyma.08G077900
-LEA2-43	late embryogenesis abundant 2 gene 43	glyma.Wm82.gnm2.ann1.Glyma.08G136900
-LEA2-44	late embryogenesis abundant 2 gene 44	glyma.Wm82.gnm2.ann1.Glyma.08G184000
-LEA2-45	late embryogenesis abundant 2 gene 45	glyma.Wm82.gnm2.ann1.Glyma.09G071900
-LEA2-46	late embryogenesis abundant 2 gene 46	glyma.Wm82.gnm2.ann1.Glyma.09G179400
-LEA2-47	late embryogenesis abundant 2 gene 47	glyma.Wm82.gnm2.ann1.Glyma.09G189900
-LEA2-48	late embryogenesis abundant 2 gene 48	glyma.Wm82.gnm2.ann1.Glyma.09G192300
-LEA2-49	late embryogenesis abundant 2 gene 49	glyma.Wm82.gnm2.ann1.Glyma.09G217800
-LEA2-5	late embryogenesis abundant 2 gene 5	glyma.Wm82.gnm2.ann1.Glyma.02G197600
-LEA2-50	late embryogenesis abundant 2 gene 50	glyma.Wm82.gnm2.ann1.Glyma.10G079400
-LEA2-51	late embryogenesis abundant 2 gene 51	glyma.Wm82.gnm2.ann1.Glyma.10G079900
-LEA2-52	late embryogenesis abundant 2 gene 52	glyma.Wm82.gnm2.ann1.Glyma.10G080000
-LEA2-53	late embryogenesis abundant 2 gene 53	glyma.Wm82.gnm2.ann1.Glyma.10G174100
-LEA2-54	late embryogenesis abundant 2 gene 54	glyma.Wm82.gnm2.ann1.Glyma.10G252500
-LEA2-55	late embryogenesis abundant 2 gene 55	glyma.Wm82.gnm2.ann1.Glyma.11G003000
-LEA2-56	late embryogenesis abundant 2 gene 56	glyma.Wm82.gnm2.ann1.Glyma.11G020500
-LEA2-57	late embryogenesis abundant 2 gene 57	glyma.Wm82.gnm2.ann1.Glyma.11G020600
-LEA2-58	late embryogenesis abundant 2 gene 58	glyma.Wm82.gnm2.ann1.Glyma.11G097100
-LEA2-59	late embryogenesis abundant 2 gene 59	glyma.Wm82.gnm2.ann1.Glyma.11G179900
-LEA2-6	late embryogenesis abundant 2 gene 6	glyma.Wm82.gnm2.ann1.Glyma.02G197800
-LEA2-60	late embryogenesis abundant 2 gene 60	glyma.Wm82.gnm2.ann1.Glyma.11G182400
-LEA2-61	late embryogenesis abundant 2 gene 61	glyma.Wm82.gnm2.ann1.Glyma.11G199600
-LEA2-62	late embryogenesis abundant 2 gene 62	glyma.Wm82.gnm2.ann1.Glyma.11G203000
-LEA2-63	late embryogenesis abundant 2 gene 63	glyma.Wm82.gnm2.ann1.Glyma.12G023200
-LEA2-64	late embryogenesis abundant 2 gene 64	glyma.Wm82.gnm2.ann1.Glyma.12G093600
-LEA2-65	late embryogenesis abundant 2 gene 65	glyma.Wm82.gnm2.ann1.Glyma.12G187600
-LEA2-66	late embryogenesis abundant 2 gene 66	glyma.Wm82.gnm2.ann1.Glyma.12G194700
-LEA2-67	late embryogenesis abundant 2 gene 67	glyma.Wm82.gnm2.ann1.Glyma.12G202900
-LEA2-68	late embryogenesis abundant 2 gene 68	glyma.Wm82.gnm2.ann1.Glyma.13G000500
-LEA2-69	late embryogenesis abundant 2 gene 69	glyma.Wm82.gnm2.ann1.Glyma.13G248600
-LEA2-7	late embryogenesis abundant 2 gene 7	glyma.Wm82.gnm2.ann1.Glyma.02G239100
-LEA2-70	late embryogenesis abundant 2 gene 70	glyma.Wm82.gnm2.ann1.Glyma.13G298800
-LEA2-71	late embryogenesis abundant 2 gene 71	glyma.Wm82.gnm2.ann1.Glyma.13G307700
-LEA2-72	late embryogenesis abundant 2 gene 72	glyma.Wm82.gnm2.ann1.Glyma.13G307900
-LEA2-73	late embryogenesis abundant 2 gene 73	glyma.Wm82.gnm2.ann1.Glyma.13G313600
-LEA2-74	late embryogenesis abundant 2 gene 74	glyma.Wm82.gnm2.ann1.Glyma.13G313700
-LEA2-75	late embryogenesis abundant 2 gene 75	glyma.Wm82.gnm2.ann1.Glyma.13G349900
-LEA2-76	late embryogenesis abundant 2 gene 76	glyma.Wm82.gnm2.ann1.Glyma.13G357600
-LEA2-77	late embryogenesis abundant 2 gene 77	glyma.Wm82.gnm2.ann1.Glyma.13G359200
-LEA2-78	late embryogenesis abundant 2 gene 78	glyma.Wm82.gnm2.ann1.Glyma.14G010800
-LEA2-79	late embryogenesis abundant 2 gene 79	glyma.Wm82.gnm2.ann1.Glyma.14G037300
-LEA2-8	late embryogenesis abundant 2 gene 8	glyma.Wm82.gnm2.ann1.Glyma.02G274400
-LEA2-80	late embryogenesis abundant 2 gene 80	glyma.Wm82.gnm2.ann1.Glyma.14G041700
-LEA2-81	late embryogenesis abundant 2 gene 81	glyma.Wm82.gnm2.ann1.Glyma.14G160000
-LEA2-82	late embryogenesis abundant 2 gene 82	glyma.Wm82.gnm2.ann1.Glyma.14G208000
-LEA2-83	late embryogenesis abundant 2 gene 83	glyma.Wm82.gnm2.ann1.Glyma.15G015800
-LEA2-84	late embryogenesis abundant 2 gene 84	glyma.Wm82.gnm2.ann1.Glyma.15G024400
-LEA2-85	late embryogenesis abundant 2 gene 85	glyma.Wm82.gnm2.ann1.Glyma.15G048800
-LEA2-86	late embryogenesis abundant 2 gene 86	glyma.Wm82.gnm2.ann1.Glyma.15G065400
-LEA2-87	late embryogenesis abundant 2 gene 87	glyma.Wm82.gnm2.ann1.Glyma.16G031000
-LEA2-88	late embryogenesis abundant 2 gene 88	glyma.Wm82.gnm2.ann1.Glyma.16G031300
-LEA2-89	late embryogenesis abundant 2 gene 89	glyma.Wm82.gnm2.ann1.Glyma.16G221900
-LEA2-9	late embryogenesis abundant 2 gene 9	glyma.Wm82.gnm2.ann1.Glyma.02G277300
-LEA2-90	late embryogenesis abundant 2 gene 90	glyma.Wm82.gnm2.ann1.Glyma.17G172900
-LEA2-91	late embryogenesis abundant 2 gene 91	glyma.Wm82.gnm2.ann1.Glyma.18G047800
-LEA2-92	late embryogenesis abundant 2 gene 92	glyma.Wm82.gnm2.ann1.Glyma.18G073200
-LEA2-93	late embryogenesis abundant 2 gene 93	glyma.Wm82.gnm2.ann1.Glyma.18G218700
-LEA2-94	late embryogenesis abundant 2 gene 94	glyma.Wm82.gnm2.ann1.Glyma.18G218800
-LEA2-95	late embryogenesis abundant 2 gene 95	glyma.Wm82.gnm2.ann1.Glyma.18G238700
-LEA2-97	late embryogenesis abundant 2 gene 97	glyma.Wm82.gnm2.ann1.Glyma.19G19870
-LEA2-98	late embryogenesis abundant 2 gene 98	glyma.Wm82.gnm2.ann1.Glyma.19G198800
-LEA2-99	late embryogenesis abundant 2 gene 99	glyma.Wm82.gnm2.ann1.Glyma.19G198900
-LEA5	desiccation protective protein LEA5	glyma.Wm82.gnm2.ann1.Glyma.17g027400
-LEC1-A	transcription factor LEC1-A	glyma.Wm82.gnm2.ann1.Glyma.07g268100
-LEC1-B	nuclear transcription factor Y subunit B-6-like	glyma.Wm82.gnm2.ann1.Glyma.17g005600
-LEC2a	B3 domain transcription factor	glyma.Wm82.gnm2.ann1.Glyma.20G035800
-LEC2b	B3 domain transcription factor	glyma.Wm82.gnm2.ann1.Glyma.20G035700
-LEM3	ligand-effect modulator 3	glyma.Wm82.gnm1.ann1.Glyma08g17460
-LF1	putative AP2 domain-containing protein Lf1	glyma.Wm82.gnm2.ann1.Glyma.08g281900
-LHCB1-7	photosystem II type I chlorophyll a/b-binding protein	glyma.Wm82.gnm2.ann1.Glyma.16g165800
-LHP1	non-histone chromosomal protein	glyma.Wm82.gnm2.ann1.Glyma.16G079900
-LHP1-1	chromo domain-containing protein LHP1-1	glyma.Wm82.gnm2.ann1.Glyma.16g079900
-LHP1-2	chromo domain-containing protein LHP1-2	glyma.Wm82.gnm2.ann1.Glyma.03g094200
-LHY1a	LATE ELONGATED HYPOCOTYL 1 gene a	glyma.Wm82.gnm2.ann1.Glyma.16G017400
-LHY1b	LATE ELONGATED HYPOCOTYL 1 gene b	glyma.Wm82.gnm2.ann1.Glyma.07G048500
-LHY2a	LATE ELONGATED HYPOCOTYL 2 gene a	glyma.Wm82.gnm2.ann1.Glyma.19G260900
-LHY2b	LATE ELONGATED HYPOCOTYL 2 gene b	glyma.Wm82.gnm2.ann1.Glyma.03G261800
-LOG	Lonely Guy	glyma.Wm82.gnm2.ann1.Glyma.12G174900
-LOX	seed linoleate 9S-lipoxygenase-3	glyma.Wm82.gnm2.ann1.Glyma.08g189200
-LOX1.4	lipoxygenase 1 gene 4	glyma.Wm82.gnm2.ann1.Glyma.07g007000
-LOX10	lipoxygenase-10 gene	glyma.Wm82.gnm2.ann1.Glyma.08g189600
-LOX4	Lipoxygenase 4 gene	glyma.Wm82.gnm2.ann1.Glyma.13g347700
-LOX8	lipoxygenase 8 gene	glyma.Wm82.gnm2.ann1.Glyma.15g026500
-LOX9	Lipoxygenase 9 gene	glyma.Wm82.gnm2.ann1.Glyma.07g034800
-LoxB	Lipoxygenase B1 gene	glyma.Wm82.gnm2.ann1.Glyma.13g347700
-LOXB1	lipoxygenase	glyma.Wm82.gnm2.ann1.Glyma.13g347700
-LPAAT	lysophosphatidic acid acyltransferase	glyma.Wm82.gnm2.ann1.Glyma.15g034100
-LPAT	Lysophosphatidyl acyltransferase	glyma.Wm82.gnm1.ann1.Glyma11G12830
-LRK1	leucine-rich repeat receptor-like kinase 1	glyma.Wm82.gnm2.ann1.Glyma.03g189800
-LRPK	serine/threonine-protein kinase LRPK	glyma.Wm82.gnm2.ann1.Glyma.16g015400
-LRR	Leucine-rich repeat receptor-like kinase	glyma.Wm82.gnm2.ann1.Glyma.06G265400
-LSD1	Lys-Specific Demethylase 1	glyma.Wm82.gnm1.ann1.Glyma02g18610
-LUXA	transcription factor LUXa	glyma.Wm82.gnm2.ann1.Glyma.01g162600
-LUXB	transcription factor LUXb	glyma.Wm82.gnm2.ann1.Glyma.12g060200
-LUXC	transcription factor LUXc	glyma.Wm82.gnm2.ann1.Glyma.11g136600
 Lx1	lipoxygenase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.13g347600
 Lx2	Lipoxygenase 2 gene	glyma.Wm82.gnm2.ann1.Glyma.13g347500
 Lx3	Lipoxygenase 3 gene	glyma.Wm82.gnm2.ann1.Glyma.15g026300
-LYK10	protein LYK2	glyma.Wm82.gnm2.ann1.Glyma.19g088300
-LYK4	lysM domain receptor-like kinase 4	glyma.Wm82.gnm2.ann1.Glyma.01g179000
 MADS28	MADS transcription factor	glyma.Wm82.gnm2.ann1.Glyma.18g0047001
 MAF1	MFP1 attachment factor 1	glyma.Wm82.gnm2.ann1.Glyma.17g237500
 MAGL	Monoacylglycerol lipase	glyma.Wm82.gnm1.ann1.Glyma08G19060
@@ -2377,16 +2182,10 @@ MAPKKK14-1	mitogen-activated protein kinase kinase kinase 14 gene 1	glyma.Wm82.g
 MAPKKK18-1	mitogen-activated protein kinase kinase 18 gene 1	glyma.Wm82.gnm2.ann1.Glyma.12G097200
 MAPKKK24-3	mitogen-activated protein kinase kinase kinase 24 gene 3	glyma.Wm82.gnm2.ann1.Glyma.14G080100
 MAT1	maturation-associated protein 1 gene	glyma.Wm82.gnm2.ann1.Glyma.07g090400
-MAT9	Maturation-associated protein 9 gene	glyma.Wm82.gnm2.ann1.Glyma.09g185500
 MATE	aluminum-activated citrate transporter	glyma.Wm82.gnm2.ann1.Glyma.13g339800
 MATE13	citrate-proton symporter	glyma.Wm82.gnm2.ann1.Glyma.02g181800
 MCCA	3-methylcrotonyl-CoA carboxylase 1	glyma.Wm82.gnm2.ann1.Glyma.02g145300
-MDH-1	malate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.12g159300
-Mdh1	malate dehydrogenase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.12g159300
-Mdh2	malate dehydrogenase 2 gene, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.05g026300
-MDHAR-1a	DEHYDROASCORBATE REDUCTASE 1 gene a	glyma.Wm82.gnm2.ann1.Glyma.10G291100
-MDHAR-1b	DEHYDROASCORBATE REDUCTASE 1 gene b	glyma.Wm82.gnm2.ann1.Glyma.20G240300
-MDHAR-3a	DEHYDROASCORBATE REDUCTASE 3 gene a	glyma.Wm82.gnm2.ann1.Glyma.18G040100
+MDH-1, Mdh1	malate dehydrogenase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.12g159300
 MDHAR-4a	Peroximal monodehydroascorbate reductase 4 gene a	glyma.Wm82.gnm2.ann1.Glyma.16g073100
 MDHAR-4b	Peroximal monodehydroascorbate reductase 4 gene b	glyma.Wm82.gnm2.ann1.Glyma.19g061200
 MDHAR-6	Monodehydroascorbate reductase 6, cytosolic	glyma.Wm82.gnm2.ann1.Glyma.08g017800
@@ -2460,7 +2259,6 @@ MED37-3	Mediator Complex 37 gene 3	glyma.Wm82.gnm2.ann1.Glyma.05g219600
 MED37-4	Mediator Complex 37 gene 4 	glyma.Wm82.gnm2.ann1.Glyma.05g219400
 MED37-5	Mediator Complex 37 gene 5	glyma.Wm82.gnm2.ann1.Glyma.07g170800
 MED37-6	Mediator Complex 37 gene 6	glyma.Wm82.gnm2.ann1.Glyma.08g025700
-MED37-7	Mediator Complex 37 gene 7	glyma.Wm82.gnm2.ann1.Glyma.08g025900
 MED37-8	Mediator Complex 37 gene 8	glyma.Wm82.gnm2.ann1.Glyma.11g140500
 MED37-9	Mediator Complex 37 gene 9	glyma.Wm82.gnm2.ann1.Glyma.12g064000
 MED4-1	Mediator Complex 4 gene 1	glyma.Wm82.gnm2.ann1.Glyma.06g188800
@@ -2496,12 +2294,11 @@ MLP34	MLP-like protein	glyma.Wm82.gnm2.ann1.Glyma.09G102400
 MMP2	Matrix metalloproteinase 2 gene	glyma.Wm82.gnm2.ann1.Glyma.01g036900
 MMT1	methionine S-methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.12g163700
 MMT2	methionine S-methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.16g000200
-MP2	maturation polypeptide 2 gene	glyma.Wm82.gnm2.ann1.Glyma.13g149000
+MP2, PM2	maturation polypeptide 2 gene	glyma.Wm82.gnm2.ann1.Glyma.13g149000
 MPK4	mitogen-activated protein kinase 4	glyma.Wm82.gnm2.ann1.Glyma.01G222000
 MPK4c	Mitogen-activated protein kinase kinase 4 gene c	glyma.Wm82.gnm1.ann1.Glyma09g39190
 MPK4d	Mitogen-activated protein kinase kinase 4 gene d	glyma.Wm82.gnm1.ann1.Glyma18g47140
 MS	malate synthase	glyma.Wm82.gnm2.ann1.Glyma.17g128000
-Ms1	Male Sterile 1	glyma.Wm82.gnm2.ann1.Glyma.13G114200
 MSG	MLP-like protein 28-like	glyma.Wm82.gnm2.ann1.Glyma.20g017900
 MSH1	DNA mismatch repair protein	glyma.Wm82.gnm2.ann1.Glyma.10g130700
 MST1	monosaccharide transporter	glyma.Wm82.gnm2.ann1.Glyma.08g035300
@@ -2515,7 +2312,6 @@ MYB107	MYB transcription factor MYB107	glyma.Wm82.gnm2.ann1.Glyma.08g189900
 MYB109	MYB transcription factor MYB109	glyma.Wm82.gnm2.ann1.Glyma.17g121000
 MYB11	MYB11 protein	glyma.Wm82.gnm2.ann1.Glyma.19g024700
 MYB112	MYB transcription factor MYB112	glyma.Wm82.gnm2.ann1.Glyma.01g190100
-MYB114	MYB transcription factor MYB114	glyma.Wm82.gnm2.ann1.Glyma.03g261800
 MYB118	MYB transcription factor MYB118	glyma.Wm82.gnm2.ann1.Glyma.10g048500
 MYB121	transcription factor MYBZ1	glyma.Wm82.gnm2.ann1.Glyma.15g176000
 MYB124	MYB transcription factor MYB124	glyma.Wm82.gnm2.ann1.Glyma.06g036800
@@ -2579,7 +2375,9 @@ MYB99	transcription factor MYB99	glyma.Wm82.gnm2.ann1.Glyma.05g006100
 MYBJ1	protein ODORANT1-like	glyma.Wm82.gnm2.ann1.Glyma.05g051700
 MYBJ2	myb-related protein 306-like	glyma.Wm82.gnm2.ann1.Glyma.04g170100
 MYBZ2	transcription factor MYBZ2	glyma.Wm82.gnm2.ann1.Glyma.11g107100
-N-21	nodulin-21	glyma.Wm82.gnm2.ann1.Glyma.05g121600
+Mdh2	malate dehydrogenase 2 gene, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.05g026300
+Ms1	Male Sterile 1	glyma.Wm82.gnm2.ann1.Glyma.13G114200
+N-21, VTL1a	vacuole iron transporter like	glyma.Wm82.gnm2.ann1.Glyma.05G121600
 N-22	nodulin-22	glyma.Wm82.gnm2.ann1.Glyma.15g045000
 N-23	nodulin-23	glyma.Wm82.gnm2.ann1.Glyma.20g024200
 N-26	nodulin-26	glyma.Wm82.gnm2.ann1.Glyma.08g120100
@@ -2588,22 +2386,22 @@ N-36A	early nodulin-36A	glyma.Wm82.gnm2.ann1.Glyma.01g028500
 N-44	nodulin-44	glyma.Wm82.gnm2.ann1.Glyma.13g364400
 N-56	probable 2-isopropylmalate synthase	glyma.Wm82.gnm2.ann1.Glyma.13g024700
 N-70	early nodulin-70	glyma.Wm82.gnm2.ann1.Glyma.18g018900
-N:IFR	Isoflavone Reductase	glyma.Wm82.gnm1.ann1.Glyma01g37810
 N479	C2H2 zinc finger protein	glyma.Wm82.gnm2.ann1.Glyma.07g135800
 N6L	nodulin 6l	glyma.Wm82.gnm2.ann1.Glyma.10g060100
+N:IFR	Isoflavone Reductase	glyma.Wm82.gnm1.ann1.Glyma01g37810
 NAB	Nucleic Acids Binding protein	glyma.Wm82.gnm1.ann1.Glyma18G40360
 NAC001	NAC Transcription Factor gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G005500
 NAC002	NAC Transcription Factor gene 2	glyma.Wm82.gnm2.ann1.Glyma.01G046800
-NAC003	NAC Transcription Factor gene 3	glyma.Wm82.gnm2.ann1.Glyma.01G051300
+NAC003, NAC1	NAC domain protein NAC1	glyma.Wm82.gnm2.ann1.Glyma.01g051300
 NAC004	NAC Transcription Factor gene 4	glyma.Wm82.gnm2.ann1.Glyma.01G088200
 NAC005	NAC Transcription Factor gene 5	glyma.Wm82.gnm2.ann1.Glyma.01G167900
 NAC006	NAC Transcription Factor gene 6	glyma.Wm82.gnm1.ann1.Glyma02g07700
 NAC007	NAC Transcription Factor gene 7	glyma.Wm82.gnm2.ann1.Glyma.02G070600.
 NAC008	NAC Transcription Factor gene 8	glyma.Wm82.gnm2.ann1.Glyma.02G100200
 NAC009	NAC Transcription Factor gene 9	glyma.Wm82.gnm2.ann1.Glyma.02G107000
-NAC010	NAC Transcription Factor gene 10	glyma.Wm82.gnm2.ann1.Glyma.02G109800
-NAC011	NAC Transcription Factor gene 11	glyma.Wm82.gnm1.ann1.Glyma02g26480
-NAC012	NAC Transcription Factor gene 12	glyma.Wm82.gnm2.ann1.Glyma.02G222300
+NAC010, NAC26, NAC29	NAC domain-containing protein	glyma.Wm82.gnm2.ann1.Glyma.02G109800
+NAC011, NAC193	NAC Transcription Factor gene 193	glyma.Wm82.gnm1.ann1.Glyma02g26480
+NAC012, NAC22	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.02g222300
 NAC013	NAC Transcription Factor gene 13	glyma.Wm82.gnm2.ann1.Glyma.02G240500
 NAC014	NAC Transcription Factor gene 14	glyma.Wm82.gnm2.ann1.Glyma.03G197900
 NAC015	NAC Transcription Factor gene 15	glyma.Wm82.gnm2.ann1.Glyma.04G078600
@@ -2623,20 +2421,20 @@ NAC031	NAC Transcription Factor gene 31	glyma.Wm82.gnm2.ann1.Glyma.05G234200
 NAC032	NAC Transcription Factor gene 32	glyma.Wm82.gnm2.ann1.Glyma.05G225100
 NAC033	NAC Transcription Factor gene 33	glyma.Wm82.gnm2.ann1.Glyma.05G202300
 NAC034	NAC Transcription Factor gene 34	glyma.Wm82.gnm2.ann1.Glyma.06G080200
-NAC035	NAC Transcription Factor gene 35	glyma.Wm82.gnm2.ann1.Glyma.06G114000
+NAC035, NAC2	NAC domain protein NAC2	glyma.Wm82.gnm2.ann1.Glyma.06g114000
 NAC036	NAC Transcription Factor gene 36	glyma.Wm82.gnm2.ann1.Glyma.06G138100
 NAC037	NAC Transcription Factor gene 37	glyma.Wm82.gnm2.ann1.Glyma.06G152900
 NAC038	NAC Transcription Factor gene 38	glyma.Wm82.gnm1.ann1.Glyma04g38990
 NAC039	NAC Transcription Factor gene 39	glyma.Wm82.gnm2.ann1.Glyma.06G157400
 NAC040	NAC Transcription Factor gene 40	glyma.Wm82.gnm2.ann1.Glyma.06G166500
-NAC041	NAC Transcription Factor gene 41	glyma.Wm82.gnm2.ann1.Glyma.06G195500
+NAC041, NAC5	NAC domain protein NAC5	glyma.Wm82.gnm2.ann1.Glyma.06g195500
 NAC042	NAC Transcription Factor gene 42	glyma.Wm82.gnm2.ann1.Glyma.06G236000
 NAC043	NAC Transcription Factor gene 43	glyma.Wm82.gnm1.ann1.Glyma06g38410
 NAC044	NAC Transcription Factor gene 44	glyma.Wm82.gnm1.ann1.Glyma06g38440
 NAC045	NAC Transcription Factor gene 45	glyma.Wm82.gnm2.ann1.Glyma.06G318900
 NAC046	NAC Transcription Factor gene 46	glyma.Wm82.gnm2.ann1.Glyma.07G048000
 NAC047	NAC Transcription Factor gene 47	glyma.Wm82.gnm2.ann1.Glyma.07G048100
-NAC048	NAC Transcription Factor gene 48	glyma.Wm82.gnm2.ann1.Glyma.07G050600
+NAC048, NST1A	NAC family transcription factor	glyma.Wm82.gnm2.ann1.Glyma.07g050600
 NAC049	NAC Transcription Factor gene 49	glyma.Wm82.gnm2.ann1.Glyma.07G092000
 NAC050	NAC Transcription Factor gene 50	glyma.Wm82.gnm2.ann1.Glyma.07G126500
 NAC051	NAC Transcription Factor gene 51	glyma.Wm82.gnm2.ann1.Glyma.07G201800
@@ -2649,27 +2447,27 @@ NAC057	NAC Transcription Factor gene 57	glyma.Wm82.gnm2.ann1.Glyma.08G075300
 NAC058	NAC Transcription Factor gene 58	glyma.Wm82.gnm2.ann1.Glyma.08G156500
 NAC059	NAC Transcription Factor gene 59	glyma.Wm82.gnm2.ann1.Glyma.08G161300
 NAC060	NAC Transcription Factor gene 60	glyma.Wm82.gnm2.ann1.Glyma.08G169400
-NAC061	NAC Transcription Factor gene 61	glyma.Wm82.gnm2.ann1.Glyma.08G173400
+NAC061, NAC34	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.08g173400
 NAC062	NAC Transcription Factor gene 62	glyma.Wm82.gnm1.ann1.Glyma08g19300
 NAC063	NAC Transcription Factor gene 63	glyma.Wm82.gnm2.ann1.Glyma.08G301100
 NAC064	NAC Transcription Factor gene 64	glyma.Wm82.gnm2.ann1.Glyma.08G307100
-NAC065	NAC Transcription Factor gene 65	glyma.Wm82.gnm2.ann1.Glyma.08G360200
+NAC065, NAC15	NAC domain-containing protein	glyma.Wm82.gnm2.ann1.Glyma.08g360200
 NAC066	NAC Transcription Factor gene 66	glyma.Wm82.gnm2.ann1.Glyma.09G167400
 NAC067	NAC Transcription Factor gene 67	glyma.Wm82.gnm2.ann1.Glyma.09G184100
 NAC068	NAC Transcription Factor gene 68	glyma.Wm82.gnm2.ann1.Glyma.09G231700
 NAC069	NAC Transcription Factor gene 69	glyma.Wm82.gnm2.ann1.Glyma.09G233600
-NAC070	NAC Transcription Factor gene 70	glyma.Wm82.gnm2.ann1.Glyma.09G235700
+NAC070, NLP2	NAC domain-containing protein 100-like	glyma.Wm82.gnm2.ann1.Glyma.09g235700
 NAC071	NAC Transcription Factor gene 71	glyma.Wm82.gnm1.ann1.Glyma10g04350
 NAC072	NAC Transcription Factor gene 72	glyma.Wm82.gnm2.ann1.Glyma.10G197500
 NAC073	NAC Transcription Factor gene 73	glyma.Wm82.gnm2.ann1.Glyma.10G216400
-NAC074	NAC Transcription Factor gene 74	glyma.Wm82.gnm2.ann1.Glyma.10G219600
+NAC074, SNAC38	NAC transcription factor	glyma.Wm82.gnm2.ann1.Glyma.10g219600
 NAC075	NAC Transcription Factor gene 75	glyma.Wm82.gnm2.ann1.Glyma.11G030600
 NAC076	NAC Transcription Factor gene 76	glyma.Wm82.gnm2.ann1.Glyma.11G075400
 NAC077	NAC Transcription Factor gene 77	glyma.Wm82.gnm2.ann1.Glyma.11G096600
-NAC078	NAC Transcription Factor gene 78	glyma.Wm82.gnm2.ann1.Glyma.11G182000
+NAC078, NAC90	PREDICTED: NAC domain-containing protein 90-like	glyma.Wm82.gnm2.ann1.Glyma.11G182000
 NAC079	NAC Transcription Factor gene 79	glyma.Wm82.gnm2.ann1.Glyma.11G212400
 NAC080	NAC Transcription Factor gene 80	glyma.Wm82.gnm2.ann1.Glyma.12G004900
-NAC081	NAC Transcription Factor gene 81	glyma.Wm82.gnm2.ann1.Glyma.12G022700
+NAC081, NAC6	NAC domain protein NAC6	glyma.Wm82.gnm2.ann1.Glyma.12g022700
 NAC082	NAC Transcription Factor gene 82	glyma.Wm82.gnm2.ann1.Glyma.12G091200
 NAC083	NAC Transcription Factor gene 83	glyma.Wm82.gnm1.ann1.Glyma12g13710
 NAC084	NAC Transcription Factor gene 84	glyma.Wm82.gnm1.ann1.Glyma12g22790
@@ -2678,44 +2476,41 @@ NAC086	NAC Transcription Factor gene 86	glyma.Wm82.gnm2.ann1.Glyma.12G161700
 NAC087	NAC Transcription Factor gene 87	glyma.Wm82.gnm2.ann1.Glyma.12G171600
 NAC088	NAC Transcription Factor gene 88	glyma.Wm82.gnm2.ann1.Glyma.12G186200
 NAC090	NAC Transcription Factor gene 90	glyma.Wm82.gnm2.ann1.Glyma.12G206900
-NAC091	NAC Transcription Factor gene 91	glyma.Wm82.gnm1.ann1.Glyma15g07620
+NAC091, NAC113	NAC Transcription Factor gene 113	glyma.Wm82.gnm1.ann1.Glyma15g07620
 NAC092	NAC Transcription Factor gene 92	glyma.Wm82.gnm1.ann1.Glyma12g35000
-NAC093	NAC Transcription Factor gene 93	glyma.Wm82.gnm2.ann1.Glyma.12G226500
+NAC093, NLP4	protein CUP-SHAPED COTYLEDON 2-like	glyma.Wm82.gnm2.ann1.Glyma.12g226500
 NAC094	NAC Transcription Factor gene 94	glyma.Wm82.gnm2.ann1.Glyma.13G063300
 NAC095	NAC Transcription Factor gene 95	glyma.Wm82.gnm1.ann1.Glyma13g05540
 NAC097	NAC Transcription Factor gene 97	glyma.Wm82.gnm2.ann1.Glyma.13G174700
 NAC098	NAC Transcription Factor gene 98	glyma.Wm82.gnm2.ann1.Glyma.13G234700
 NAC099	NAC Transcription Factor gene 99	glyma.Wm82.gnm1.ann1.Glyma13g31660
-NAC1	NAC domain protein NAC1	glyma.Wm82.gnm2.ann1.Glyma.01g051300
 NAC100	NAC Transcription Factor gene 100	glyma.Wm82.gnm2.ann1.Glyma.13G274300
 NAC101	NAC Transcription Factor gene 101	glyma.Wm82.gnm1.ann1.Glyma13g35550
 NAC102	NAC Transcription Factor gene 102	glyma.Wm82.gnm1.ann1.Glyma13g35560
 NAC103	NAC Transcription Factor gene 103	glyma.Wm82.gnm2.ann1.Glyma.13G314600
 NAC104	NAC Transcription Factor gene 104	glyma.Wm82.gnm2.ann1.Glyma.13G315300
 NAC105	NAC Transcription Factor gene 105	glyma.Wm82.gnm2.ann1.Glyma.13G327600
-NAC106	NAC Transcription Factor gene 106	glyma.Wm82.gnm2.ann1.Glyma.14G030700
+NAC106, NAC42-2	NAC domain-containing protein 42-like	glyma.Wm82.gnm2.ann1.Glyma.14g030700
 NAC107	NAC Transcription Factor gene 107	glyma.Wm82.gnm2.ann1.Glyma.14G084300
 NAC109	NAC Transcription Factor gene 109	glyma.Wm82.gnm1.ann1.Glyma14g24220
-NAC11	transcriptional factor NAC11	glyma.Wm82.gnm2.ann1.Glyma.19g108800
+NAC11, NAC181	NAC Transcription Factor gene 181	glyma.Wm82.gnm2.ann1.Glyma.19G108800
 NAC110	NAC Transcription Factor gene 110	glyma.Wm82.gnm2.ann1.Glyma.14G189300
 NAC111	NAC Transcription Factor gene 111	glyma.Wm82.gnm2.ann1.Glyma.14G210000
 NAC112	NAC Transcription Factor gene 112	glyma.Wm82.gnm2.ann1.Glyma.15G051200
-NAC113	NAC Transcription Factor gene 113	glyma.Wm82.gnm1.ann1.Glyma15g07620
 NAC114	NAC Transcription Factor gene 114	glyma.Wm82.gnm2.ann1.Glyma.15G078300
-NAC115	NAC Transcription Factor gene 115	glyma.Wm82.gnm2.ann1.Glyma.15G254000
+NAC115, NAC35	transcriptional factor NAC35	glyma.Wm82.gnm2.ann1.Glyma.15g254000
 NAC116	NAC Transcription Factor gene 116	glyma.Wm82.gnm2.ann1.Glyma.15G257700
 NAC117	NAC Transcription Factor gene 117	glyma.Wm82.gnm2.ann1.Glyma.15G264100
 NAC118	NAC Transcription Factor gene 118	glyma.Wm82.gnm2.ann1.Glyma.15G266500
-NAC12	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.16g043200
+NAC12, NAC124	NAC Transcription Factor gene 124	glyma.Wm82.gnm2.ann1.Glyma.16G043200
 NAC120	NAC Transcription Factor gene 120	glyma.Wm82.gnm2.ann1.Glyma.16G016600
 NAC121	NAC Transcription Factor gene 121	glyma.Wm82.gnm2.ann1.Glyma.16G016700
-NAC122	NAC Transcription Factor gene 122	glyma.Wm82.gnm2.ann1.Glyma.16G019400
+NAC122, SHAT1-5	NAC domain-containing protein 43-like	glyma.Wm82.gnm2.ann1.Glyma.16g019400
 NAC123	NAC Transcription Factor gene 123	glyma.Wm82.gnm2.ann1.Glyma.16G042900
-NAC124	NAC Transcription Factor gene 124	glyma.Wm82.gnm2.ann1.Glyma.16G043200
 NAC125	NAC Transcription Factor gene 125	glyma.Wm82.gnm2.ann1.Glyma.16G051800
 NAC126	NAC Transcription Factor gene 126	glyma.Wm82.gnm2.ann1.Glyma.16G130200
 NAC127	NAC Transcription Factor gene 127	glyma.Wm82.gnm2.ann1.Glyma.16G151500
-NAC128	NAC Transcription Factor gene 128	glyma.Wm82.gnm2.ann1.Glyma.16G152100
+NAC128, NAC23	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.16g152100
 NAC129	NAC Transcription Factor gene 129	glyma.Wm82.gnm2.ann1.Glyma.16G217400
 NAC130	NAC Transcription Factor gene 130	glyma.Wm82.gnm2.ann1.Glyma.17G002800
 NAC131	NAC Transcription Factor gene 131	glyma.Wm82.gnm2.ann1.Glyma.17G101500
@@ -2726,8 +2521,8 @@ NAC135	NAC Transcription Factor gene 135	glyma.Wm82.gnm2.ann1.Glyma.17G240700
 NAC136	NAC Transcription Factor gene 136	glyma.Wm82.gnm2.ann1.Glyma.18G043900
 NAC137	NAC Transcription Factor gene 137	glyma.Wm82.gnm2.ann1.Glyma.18G110700
 NAC138	NAC Transcription Factor gene 138	glyma.Wm82.gnm2.ann1.Glyma.18G119300
-NAC139	NAC Transcription Factor gene 139	glyma.Wm82.gnm2.ann1.Glyma.18G261300
-NAC14	NAC domain-containing protein	glyma.Wm82.gnm2.ann1.Glyma.18g301500
+NAC139, NLP1	NAC domain-containing protein 100-like	glyma.Wm82.gnm2.ann1.Glyma.18g261300
+NAC14, NAC179	NAC Transcription Factor gene 179	glyma.Wm82.gnm2.ann1.Glyma.18G301500
 NAC140	NAC Transcription Factor gene 140	glyma.Wm82.gnm2.ann1.Glyma.19G021900
 NAC141	NAC Transcription Factor gene 141	glyma.Wm82.gnm2.ann1.Glyma.19G024500
 NAC142	NAC Transcription Factor gene 142	glyma.Wm82.gnm2.ann1.Glyma.19G056400
@@ -2738,11 +2533,10 @@ NAC146	NAC Transcription Factor gene 146	glyma.Wm82.gnm2.ann1.Glyma.19G259500
 NAC147	NAC Transcription Factor gene 147	glyma.Wm82.gnm2.ann1.Glyma.19G259700
 NAC148	NAC Transcription Factor gene 148	glyma.Wm82.gnm1.ann1.Glyma20g04400
 NAC149	NAC Transcription Factor gene 149	glyma.Wm82.gnm2.ann1.Glyma.20G172100
-NAC15	NAC domain-containing protein	glyma.Wm82.gnm2.ann1.Glyma.08g360200
 NAC150	NAC Transcription Factor gene 150	glyma.Wm82.gnm2.ann1.Glyma.20G185800
 NAC151	NAC Transcription Factor gene 151	glyma.Wm82.gnm2.ann1.Glyma.20G192300
 NAC152	NAC Transcription Factor gene 152	glyma.Wm82.gnm2.ann1.Glyma.20G192500
-NAC154	NAC Transcription Factor gene 154	glyma.Wm82.gnm2.ann1.Glyma.02G284300
+NAC154, NAC42-1	transcription factor JUNGBRUNNEN 1	glyma.Wm82.gnm2.ann1.Glyma.02g284300
 NAC156	NAC Transcription Factor gene 156	glyma.Wm82.gnm2.ann1.Glyma.03G179600
 NAC161	NAC Transcription Factor gene 161	glyma.Wm82.gnm2.ann1.Glyma.05G108700
 NAC164	NAC Transcription Factor gene 164	glyma.Wm82.gnm2.ann1.Glyma.07G047900
@@ -2751,29 +2545,13 @@ NAC172	NAC domain-containing protein 172	glyma.Wm82.gnm2.ann1.Glyma.12g145100
 NAC174	NAC Transcription Factor gene 174	glyma.Wm82.gnm2.ann1.Glyma.12G186900
 NAC176	NAC domain-containing protein 176	glyma.Wm82.gnm2.ann1.Glyma.14g140100
 NAC178	NAC Transcription Factor gene 178	glyma.Wm82.gnm2.ann1.Glyma.16G069300
-NAC179	NAC Transcription Factor gene 179	glyma.Wm82.gnm2.ann1.Glyma.18G301500
-NAC181	NAC Transcription Factor gene 181	glyma.Wm82.gnm2.ann1.Glyma.19G108800
 NAC183	NAC Transcription Factor gene 183	glyma.Wm82.gnm2.ann1.Glyma.19G195800
-NAC184	NAC Transcription Factor gene 184	glyma.Wm82.gnm2.ann1.Glyma.20G175500
 NAC19	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.13g030900
-NAC193	NAC Transcription Factor gene 193	glyma.Wm82.gnm1.ann1.Glyma02g26480
-NAC2	NAC domain protein NAC2	glyma.Wm82.gnm2.ann1.Glyma.06g114000
 NAC21	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.14g152700
-NAC22	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.02g222300
-NAC23	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.16g152100
-NAC26	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.02g109800
 NAC27	NAC transcription factor NAC27	glyma.Wm82.gnm2.ann1.Glyma.13g279900
-NAC29	NAC domain-containing protein	glyma.Wm82.gnm2.ann1.Glyma.02G109800
 NAC3	NAC domain protein NAC3	glyma.Wm82.gnm2.ann1.Glyma.06g248900
-NAC34	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.08g173400
-NAC35	transcriptional factor NAC35	glyma.Wm82.gnm2.ann1.Glyma.15g254000
 NAC4	NAC domain protein NAC4	glyma.Wm82.gnm2.ann1.Glyma.12g221500
-NAC42-1	transcription factor JUNGBRUNNEN 1	glyma.Wm82.gnm2.ann1.Glyma.02g284300
-NAC42-2	NAC domain-containing protein 42-like	glyma.Wm82.gnm2.ann1.Glyma.14g030700
-NAC5	NAC domain protein NAC5	glyma.Wm82.gnm2.ann1.Glyma.06g195500
 NAC51	transcription factor NAC51	glyma.Wm82.gnm2.ann1.Glyma.07g229100
-NAC6	NAC domain protein NAC6	glyma.Wm82.gnm2.ann1.Glyma.12g022700
-NAC90	PREDICTED: NAC domain-containing protein 90-like	glyma.Wm82.gnm2.ann1.Glyma.11G182000
 NARK	nodule autoregulation receptor kinase	glyma.Wm82.gnm2.ann1.Glyma.12g040000
 NCED2	9-cis-epoxycarotenoid dioxygenase 2	glyma.Wm82.gnm2.ann1.Glyma.08g096200
 NCED3	NINE-CIS-EPOXYCAROTENOID DIOXYGENASE3	glyma.Wm82.gnm1.ann1.Glyma15g40070
@@ -2803,8 +2581,8 @@ NF-YA20	nuclear transcription factor Y subunit A-20	glyma.Wm82.gnm2.ann1.Glyma.1
 NF-YB3a	Nuclear Transcripiton Factor Y Subunit Beta 3 gene a	glyma.Wm82.gnm2.ann1.Glyma.09G014100
 NF-YB3b	Nuclear Transcripiton Factor Y Subunit Beta 3 gene b	glyma.Wm82.gnm2.ann1.Glyma.15G118800
 NF-YC02	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.03g239400
-NF-YC03	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.04g196200
-NF-YC04	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.06g169600
+NF-YC03, NF-YC4-2	NF-Y subunit C 4 gene 2	glyma.Wm82.gnm2.ann1.Glyma.04g196200
+NF-YC04, NF-YC4-1	NF-Y subunit C 4 gene 1	glyma.Wm82.gnm2.ann1.Glyma.06g169600
 NF-YC05	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.08g148200
 NF-YC06	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.08g165700
 NF-YC07	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.10g155900
@@ -2816,8 +2594,6 @@ NF-YC12	nuclear factor Y transcription factor	glyma.Wm82.gnm2.ann1.Glyma.13g2840
 NF-YC13	nuclear factor Y transcription factor	glyma.Wm82.gnm2.ann1.Glyma.15g261300
 NF-YC14	nuclear factor Y transcription factor	glyma.Wm82.gnm2.ann1.Glyma.19g236400
 NF-YC15	nuclear factor Y transcription factor	glyma.Wm82.gnm2.ann1.Glyma.20g232400
-NF-YC4-1	NF-Y subunit C 4 gene 1	glyma.Wm82.gnm2.ann1.Glyma.06g169600
-NF-YC4-2	NF-Y subunit C 4 gene 2	glyma.Wm82.gnm2.ann1.Glyma.04g196200
 NFR1B	LysM-type receptor kinase NFR1B	glyma.Wm82.gnm2.ann1.Glyma.14g046200
 NFR5A	Nod factor receptor protein 5A	glyma.Wm82.gnm2.ann1.Glyma.11g063100
 NFR5B	Nod-factor receptor 5B	glyma.Wm82.gnm2.ann1.Glyma.01g179100
@@ -2841,13 +2617,8 @@ NIP6-2	aquaporin NIP6-2	glyma.Wm82.gnm2.ann1.Glyma.08g217400
 NIP6-3	aquaporin NIP6-3	glyma.Wm82.gnm2.ann1.Glyma.15g003900
 NIP7-1	aquaporin NIP7-1	glyma.Wm82.gnm2.ann1.Glyma.02g140500
 NIP7-2	aquaporin NIP7-2	glyma.Wm82.gnm2.ann1.Glyma.10g033600
-NIR	nitrate reductase	glyma.Wm82.gnm2.ann1.Glyma.02g132100
-NIR1-1	nitrate reductase 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02g132100
+NIR, NIR1-1	nitrate reductase 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02g132100
 NLP	NAC domain-containing protein	glyma.Wm82.gnm2.ann1.Glyma.04g167200
-NLP1	NAC domain-containing protein 100-like	glyma.Wm82.gnm2.ann1.Glyma.18g261300
-NLP2	NAC domain-containing protein 100-like	glyma.Wm82.gnm2.ann1.Glyma.09g235700
-NLP4	protein CUP-SHAPED COTYLEDON 2-like	glyma.Wm82.gnm2.ann1.Glyma.12g226500
-NMH7	MADS-box protein NMH7	glyma.Wm82.gnm2.ann1.Glyma.06g027200
 NMHC5	MADS-box transcription factor NMHC5	glyma.Wm82.gnm2.ann1.Glyma.13g2552001
 NOD33	putative nod33	glyma.Wm82.gnm2.ann1.Glyma.10g248900
 NPR1-2 	nonexpressor of PR1	glyma.Wm82.gnm1.ann1.Glyma09g02430
@@ -2875,13 +2646,11 @@ NRT1-3	putative nitrate transporter NRT1-3	glyma.Wm82.gnm2.ann1.Glyma.10g183900
 NRT2	NRT2 protein	glyma.Wm82.gnm2.ann1.Glyma.13g323800
 NSP1	nodulation-signaling pathway 1 protein	glyma.Wm82.gnm2.ann1.Glyma.07g039400
 NSP2	nodulation-signaling pathway 2 protein	glyma.Wm82.gnm2.ann1.Glyma.04g251900
-NST1A	NAC family transcription factor	glyma.Wm82.gnm2.ann1.Glyma.07g050600
 NTF2B-1	nucleus transporter2B gene 1	glyma.Wm82.gnm2.ann1.Glyma.08G105100
 NTF2B-2	nucleus transporter 2B gene 2	glyma.Wm82.gnm2.ann1.Glyma.05g148200
 NTF2B-3	nucleus transporter 2B gene 3	glyma.Wm82.gnm2.ann1.Glyma.11g251700
 NTF2B-4	nucleus transporter 2B gene 4	glyma.Wm82.gnm2.ann1.Glyma.18g005300
-NTF2B-5	nucleus transporter 2B gene 5	glyma.Wm82.gnm2.ann1.Glyma.02g156200
-NTF2B-6	nucleus transporter 2B gene 6	glyma.Wm82.gnm2.ann1.Glyma.02g156200
+NTF2B-5, NTF2B-6	nucleus transporter 2B gene 6	glyma.Wm82.gnm2.ann1.Glyma.02g156200
 NYC1_1	protein NON-YELLOW COLORING 1	glyma.Wm82.gnm2.ann1.Glyma.07g085700
 NYC1_2	protein NON-YELLOW COLORING 1	glyma.Wm82.gnm2.ann1.Glyma.09g191200
 O-MT	O-methyltransferase	glyma.Wm82.gnm1.ann1.Glyma07g05480
@@ -2899,7 +2668,6 @@ OSBP	oxysterol-binding protein	glyma.Wm82.gnm2.ann1.Glyma.06g109500
 OXR17	Oxidoreductase 17	glyma.Wm82.gnm2.ann1.Glyma.17G021200
 P34	P34 probable thiol protease	glyma.Wm82.gnm2.ann1.Glyma.08g116300
 P42-1	conversion of hydroxypyruvate to glycerate	glyma.Wm82.gnm2.ann1.Glyma.20g107800
-P5CD	delta-pyrroline-5-corboxylate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.05G029200
 P5CR	pyrroline-5-carboxylate reductase	glyma.Wm82.gnm2.ann1.Glyma.19g131500
 P5CS1	DELTA1-PYRROLINE-5-CARBOXYLATE SYNTHASE 1	glyma.Wm82.gnm1.ann1.Glyma01g24530
 P89	P24 oleosin isoform A	glyma.Wm82.gnm2.ann1.Glyma.19g063400
@@ -2920,39 +2688,25 @@ PAP01	purple acid phosphatase 18-like	glyma.Wm82.gnm2.ann1.Glyma.08g314800
 PAP02	multiple inositol polyphosphate phosphatase 1-like	glyma.Wm82.gnm2.ann1.Glyma.18g024700
 PAP10	Purple acid phosphatase gene 10	glyma.Wm82.gnm1.ann1.Glyma05g33640
 PAP11	Purple acid phosphatase 11 gene	glyma.Wm82.gnm1.ann1.Glyma06g03100
-PAP11	Purple acid phosphatase gene 11	glyma.Wm82.gnm1.ann1.Glyma06g03100
-PAP13	Purple acid phosphatase 13 gene	glyma.Wm82.gnm1.ann1.Glyma08g06090
-PAP13 	Purple acid phosphatase gene 12	glyma.Wm82.gnm1.ann1.Glyma08g06090
+PAP13, PAP13 	Purple acid phosphatase gene 12	glyma.Wm82.gnm1.ann1.Glyma08g06090
 PAP16	Purple acid phosphatase 16 gene	glyma.Wm82.gnm1.ann1.Glyma08g09910
-PAP16	Purple acid phosphatase gene 16	glyma.Wm82.gnm1.ann1.Glyma08g09910
 PAP18	Purple acid phosphatase 18 gene	glyma.Wm82.gnm1.ann1.Glyma08g42670
-PAP18	Purple acid phosphatase gene 18	glyma.Wm82.gnm1.ann1.Glyma08g42670
 PAP19	Purple acid phosphatase 19 gene	glyma.Wm82.gnm1.ann1.Glyma08g46550
-PAP19	Purple acid phosphatase gene 19	glyma.Wm82.gnm1.ann1.Glyma08g46550
 PAP2	Purple acid phosphatase gene 2	glyma.Wm82.gnm1.ann1.Glyma02g45950
 PAP20	Purple acid phosphatase gene 20	glyma.Wm82.gnm1.ann1.Glyma09g36360
 PAP23	Purple acid phosphatase gene 23	glyma.Wm82.gnm1.ann1.Glyma12g01000
 PAP24	Purple acid phosphatase 24 gene	glyma.Wm82.gnm1.ann1.Glyma12g34960
-PAP24	Purple acid phosphatase gene 24	glyma.Wm82.gnm1.ann1.Glyma12g34960
 PAP27	Purple acid phosphatase gene 27	glyma.Wm82.gnm1.ann1.Glyma14g02790
 PAP28	Purple acid phosphatase 28 gene	glyma.Wm82.gnm1.ann1.Glyma17g11790
-PAP28	Purple acid phosphatase gene 28	glyma.Wm82.gnm1.ann1.Glyma17g11790
 PAP29	Purple acid phosphatase 29 gene	glyma.Wm82.gnm1.ann1.Glyma18g00410
-PAP29	Purple acid phosphatase gene 29	glyma.Wm82.gnm1.ann1.Glyma18g00410
 PAP32	Purple acid phosphatase 32 gene	glyma.Wm82.gnm1.ann1.Glyma19g37850
-PAP32	Purple acid phosphatase gene 32	glyma.Wm82.gnm1.ann1.Glyma19g37850
 PAP33	Purple acid phosphatase 33 gene	glyma.Wm82.gnm1.ann1.Glyma19g37860
-PAP33	Purple acid phosphatase gene 33	glyma.Wm82.gnm1.ann1.Glyma19g37860
 PAP34	Purple acid phosphatase 34 gene	glyma.Wm82.gnm1.ann1.Glyma20g01470
-PAP34	Purple acid phosphatase gene 34	glyma.Wm82.gnm1.ann1.Glyma20g01470
 PAP35	Purple acid phosphatase 35 gene	glyma.Wm82.gnm1.ann1.Glyma20g03260
-PAP35	Purple acid phosphatase gene 35	glyma.Wm82.gnm1.ann1.Glyma20g03260
 PAP36	purple acid phosphatase 36	glyma.Wm82.gnm2.ann1.Glyma.12g007500
 PAP4	Purple acid phosphatase gene 4	glyma.Wm82.gnm1.ann1.Glyma03g35200
 PAP5	Purple acid phosphatase 5 gene	glyma.Wm82.gnm1.ann1.Glyma04g37180
-PAP5	Purple acid phosphatase gene 5	glyma.Wm82.gnm1.ann1.Glyma04g37180
 PAP6	Purple acid phosphatase 6 gene	glyma.Wm82.gnm1.ann1.Glyma05g03320
-PAP6	Purple acid phosphatase gene 6	glyma.Wm82.gnm1.ann1.Glyma05g03320
 PAP7	Purple acid phosphatase gene 7	glyma.Wm82.gnm1.ann1.Glyma05g26920
 PAP8	Purple acid phosphatase gene 8	glyma.Wm82.gnm1.ann1.Glyma05g26930
 PARP3	seed maturation protein PM38	glyma.Wm82.gnm2.ann1.Glyma.12g088300
@@ -2973,11 +2727,9 @@ PDR12	PDR-like ABC-transporter	glyma.Wm82.gnm2.ann1.Glyma.03g168000
 PDS1	phytoene desaturase	glyma.Wm82.gnm2.ann1.Glyma.18g003900
 PEAMT1	Phosphoethanolamine methyltransferase 1	glyma.Wm82.gnm1.ann1.Glyma05g33790
 PEAMT2	Phosphoethanolamine methyltransferase 2	glyma.Wm82.gnm1.ann1.Glyma07g11580
-PEPC	phosphoenolpyruvate carboxylase	glyma.Wm82.gnm2.ann1.Glyma.12g229400
-PEPC15	phosphoenolpyruvate carboxylase	glyma.Wm82.gnm2.ann1.Glyma.12g229400
+PEPC, PEPC15, PEPCase	phosphoenolpyruvate carboxylase	glyma.Wm82.gnm2.ann1.Glyma.12g229400
 PEPC16	phosphoenolpyruvate carboxylase	glyma.Wm82.gnm2.ann1.Glyma.12G161300
-PEPC17	phosphoenolpyruvate carboxylase	glyma.Wm82.gnm2.ann1.Glyma.10G205500
-PEPCase	phosphoenolpyruvate carboxylase	glyma.Wm82.gnm2.ann1.Glyma.12g229400
+PEPC17, ppc17	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.10G205500
 PER1	peroxidase	glyma.Wm82.gnm2.ann1.Glyma.18g055300
 PERK1	putative receptor protein kinase PERK1	glyma.Wm82.gnm2.ann1.Glyma.09g191300
 PETC	Rieske iron-sulphur protein precursor	glyma.Wm82.gnm2.ann1.Glyma.12g199400
@@ -2991,11 +2743,10 @@ PGIP4	polygalacturonase inhibitor 4 gene	glyma.Wm82.gnm2.ann1.Glyma.08g079200
 PGLCAT8	glycosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.11g053000
 PGM	phosphoglycerate mutase-like protein	glyma.Wm82.gnm2.ann1.Glyma.04g090300
 PGM1	phosphoglucomutase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.03g042000
-PGM2	phosphoglucomutase 2 gene	glyma.Wm82.gnm2.ann1.Glyma.08g044100
+PGM2, PGMb	beta-phosphoglucomutase-like	glyma.Wm82.gnm2.ann1.Glyma.08g044100
 PGM3	phosphoglucomutase 3 gene	glyma.Wm82.gnm2.ann1.Glyma.10g241000
 PGM4	Phosphoglucomutase 4 gene	glyma.Wm82.gnm2.ann1.Glyma.20g153600
 PGM5	phosphoglucomutase 5 gene	glyma.Wm82.gnm2.ann1.Glyma.20g179900
-PGMb	beta-phosphoglucomutase-like	glyma.Wm82.gnm2.ann1.Glyma.08g044100
 PGMPM10	51 kDa seed maturation protein	glyma.Wm82.gnm2.ann1.Glyma.13g119400
 PGMPM18	35 kDa seed maturation protein	glyma.Wm82.gnm2.ann1.Glyma.03g189200
 PGMPM19	type 4 metallothionein MT4	glyma.Wm82.gnm2.ann1.Glyma.08g346600
@@ -3007,9 +2758,8 @@ PHANa	phantastica transcription factor a	glyma.Wm82.gnm2.ann1.Glyma.07g132400
 PHANb	phantastica transcription factor b	glyma.Wm82.gnm2.ann1.Glyma.03g081900
 PHD4	PHD finger superfamily protein	glyma.Wm82.gnm2.ann1.Glyma.14g099700
 PHD6	PHD finger protein GmPHD6	glyma.Wm82.gnm2.ann1.Glyma.09g068500
-Phi-1	phosphate-induced protein	glyma.Wm82.gnm2.ann1.Glyma.14G176500
 PHO1-H1	phosphate transporter PHO1-like	glyma.Wm82.gnm2.ann1.Glyma.02g003700
-PHO1-H10	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.20g032500
+PHO1-H10, PHO1;H10	Phosphate responsive 1 gene H10	glyma.Wm82.gnm2.ann1.Glyma.20G032500
 PHO1-H11	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.20g032600
 PHO1-H12	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.01g091800
 PHO1-H13	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.02g110600
@@ -3021,9 +2771,7 @@ PHO1-H5	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.10g183300
 PHO1-H6	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.18g261900
 PHO1-H7	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.20g031700
 PHO1-H8	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.20g206900
-PHO1-H9	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.20g032400
-PHO1;H10	Phosphate responsive 1 gene H10	glyma.Wm82.gnm2.ann1.Glyma.20G032500
-PHO1;H9	phosphate responsive 1 gene H9	glyma.Wm82.gnm2.ann1.Glyma.20G032400
+PHO1-H9, PHO1;H9	phosphate responsive 1 gene H9	glyma.Wm82.gnm2.ann1.Glyma.20G032400
 PHP1	Ubiquitous, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma07g03390
 PHP2	Root Preferential, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma08g22720
 PHP3	Root Specific, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma15g01010
@@ -3077,20 +2825,15 @@ PHT1-6	inorganic phosphate transporter 1-6	glyma.Wm82.gnm2.ann1.Glyma.10g186400
 PHT1-7	inorganic phosphate transporter 1-7	glyma.Wm82.gnm2.ann1.Glyma.19g164300
 PHT1-8	inorganic phosphate transporter 1-8	glyma.Wm82.gnm2.ann1.Glyma.20g021600
 PHT1-9	inorganic phosphate transporter 1-9	glyma.Wm82.gnm2.ann1.Glyma.07g222700
-PHYA	phytochrome A	glyma.Wm82.gnm2.ann1.Glyma.10g141400
-PHYA1	Phytochrome A gene 1	glyma.Wm82.gnm2.ann1.Glyma.10g141400
+PHYA, PHYA1	Phytochrome A gene 1	glyma.Wm82.gnm2.ann1.Glyma.10g141400
 PHYA2	Phytochrome A gene 2	glyma.Wm82.gnm2.ann1.Glyma.20g090000
 PHYA3	Phytochrome A gene 3	glyma.Wm82.gnm2.ann1.Glyma.19g224200
 PHYA4	Phytochrome A gene 4	glyma.Wm82.gnm1.ann1.Glyma03g38620
-PHYB	phytochrome B-like	glyma.Wm82.gnm2.ann1.Glyma.09g035500
-PHYB1	Phytochrome B gene 1	glyma.Wm82.gnm2.ann1.Glyma.09g035500
+PHYB, PHYB1	Phytochrome B gene 1	glyma.Wm82.gnm2.ann1.Glyma.09g035500
 PHYB2	Phytochrome B gene 2	glyma.Wm82.gnm2.ann1.Glyma.15g140000
 PHYE1	Phytochrome E gene 1	glyma.Wm82.gnm2.ann1.Glyma.09g088500
 PHYE2	Phytochrome E gene 2	glyma.Wm82.gnm2.ann1.Glyma.15g196500
 PHYTASE	purple acid phosphatase 18-like	glyma.Wm82.gnm2.ann1.Glyma.14g024700
-PIa	Pistillata gene a	glyma.Wm82.gnm2.ann1.Glyma.13G034100
-PIb	Pistillata gene b	glyma.Wm82.gnm2.ann1.Glyma.04G245500
-PIc	Pistillata gene c	glyma.Wm82.gnm2.ann1.Glyma.14G155100
 PIF3	bHLH transcription factor PIF3	glyma.Wm82.gnm2.ann1.Glyma.19g222000
 PIN1d	PIN-formed 1 gene d	glyma.Wm82.gnm2.ann1.Glyma.03G126000
 PIN1e	PIN-formed 1 gene e	glyma.Wm82.gnm2.ann1.Glyma.19G128800
@@ -3126,6 +2869,9 @@ PIP2-6	aquaporin PIP2-6	glyma.Wm82.gnm2.ann1.Glyma.13g325900
 PIP2-7	aquaporin PIP2-7	glyma.Wm82.gnm2.ann1.Glyma.03g180900
 PIP2-8	aquaporin PIP2-8	glyma.Wm82.gnm2.ann1.Glyma.19g181300
 PIP2-9	aquaporin PIP2-9	glyma.Wm82.gnm2.ann1.Glyma.02g073600
+PIa	Pistillata gene a	glyma.Wm82.gnm2.ann1.Glyma.13G034100
+PIb	Pistillata gene b	glyma.Wm82.gnm2.ann1.Glyma.04G245500
+PIc	Pistillata gene c	glyma.Wm82.gnm2.ann1.Glyma.14G155100
 PK3	pyruvate kinase	glyma.Wm82.gnm2.ann1.Glyma.20g024800
 PK6	protein kinase	glyma.Wm82.gnm2.ann1.Glyma.15g074900
 PKR19	protein kinase R	glyma.Wm82.gnm2.ann1.Glyma.19G193100
@@ -3141,8 +2887,6 @@ PM1	Late embryogenesis abundant protein 1 gene	glyma.Wm82.gnm2.ann1.Glyma.19g147
 PM12	dehydrin	glyma.Wm82.gnm2.ann1.Glyma.04g009900
 PM13	Ca+2-binding EF hand protein	glyma.Wm82.gnm2.ann1.Glyma.10g189900
 PM16	Late embryogenesis abundant protein 16 gene	glyma.Wm82.gnm2.ann1.Glyma.17g155000
-PM2	maturation polypeptide 2 gene	glyma.Wm82.gnm2.ann1.Glyma.13g149000
-PM22	Maturation protein 22 gene	glyma.Wm82.gnm2.ann1.Glyma.16g031300
 PM23	seed maturation protein PM23	glyma.Wm82.gnm2.ann1.Glyma.10g260200
 PM24	seed maturation protein PM24	glyma.Wm82.gnm2.ann1.Glyma.10g247500
 PM25	seed maturation protein PM25	glyma.Wm82.gnm2.ann1.Glyma.20g147600
@@ -3161,17 +2905,11 @@ PM40	seed maturation protein PM40	glyma.Wm82.gnm2.ann1.Glyma.05g055700
 PM41	seed maturation protein PM41	glyma.Wm82.gnm2.ann1.Glyma.08g160800
 PM9	late embryogenesis abundant group 4 protein PM9	glyma.Wm82.gnm2.ann1.Glyma.03g144400
 POD	peroxidase	glyma.Wm82.gnm2.ann1.Glyma.02g171600
-POD1	Peroxidase 1	glyma.Wm82.gnm2.ann1.Glyma.03G038700
 POLD1	DNA polymerase delta	glyma.Wm82.gnm2.ann1.Glyma.04g210700
 POT	proton-dependent oligopeptide transport  family protein  	glyma.Wm82.gnm1.ann1.Glyma17g25390
 PP2C	protein phosphatase 2C	glyma.Wm82.gnm1.ann1.Glyma14g32430
 PP2C;L1	phloem-specific pumpkin2C gene L1	glyma.Wm82.gnm2.ann1.Glyma.20G207600
 PP2C;L2	phloem-specific pumpkin2C gene L2	glyma.Wm82.gnm2.ann1.Glyma.06G059700
-ppc17	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.10G205500
-ppc2	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.06g229900
-ppc3	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.06g277500
-ppc4	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.12G210600
-ppc7	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.13G270400
 PPR1	Psudo-Response Regulator gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G003400
 PPR10	Psudo-Response Regulator gene 10	glyma.Wm82.gnm2.ann1.Glyma.01G237100
 PPR100	Psudo-Response Regulator gene 100	glyma.Wm82.gnm2.ann1.Glyma.09G286300
@@ -3352,8 +3090,7 @@ PPR98	Psudo-Response Regulator gene 98	glyma.Wm82.gnm2.ann1.Glyma.09G251000
 PPR99	Psudo-Response Regulator gene 99	glyma.Wm82.gnm2.ann1.Glyma.09G272000
 PR-10	stress-induced protein SAM22	glyma.Wm82.gnm2.ann1.Glyma.07g243700
 PR08-Bet VI	pathogenesis-related protein	glyma.Wm82.gnm2.ann1.Glyma.08G230500
-PR1	Pathogenesis related 1 protein	glyma.Wm82.gnm2.ann1.Glyma.13g251600
-PR1-1	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.13g251600
+PR1, PR1-1	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.13g251600
 PR1-2	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.13g251700
 PR1-3	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.13g252300
 PR1-4	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.13g252000
@@ -3373,23 +3110,20 @@ PRR39	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma06g14150
 PRR3B	Psudo-Response Regulator 3 gene B	glyma.Wm82.gnm1.ann1.Glyma12g07861
 PRR40	Root Preferential, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma19g44970
 PRR41	Root Preferential, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma13g19870
-PRR42	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma12g07860
-PRR43	Root Preferential, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma04g40640
+PRR42, PRR7	Pseudo-response regulator gene 7	glyma.Wm82.gnm1.ann1.Glyma12g07860
+PRR43, PRR5	Pseudo-response regulator gene 5	glyma.Wm82.gnm1.ann1.Glyma04g40640
 PRR44	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma16g02050
 PRR45	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma07g05530
 PRR46	Shoot preferential, Pseudo Response Regulator	glyma.Wm82.gnm1.ann1.Glyma05g06070
 PRR47	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma17g16360
 PRR48	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma01g40900
 PRR49	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma11g04440
-PRR5	Pseudo-response regulator gene 5	glyma.Wm82.gnm1.ann1.Glyma04g40640
 PRR5a	Pseudo Response Regultor 5 gene a	glyma.Wm82.gnm2.ann1.Glyma.06G136600
 PRR5b	Pseudo Response Regultor 5 gene b	glyma.Wm82.gnm2.ann1.Glyma.04G228300
-PRR7	Pseudo-response regulator gene 7	glyma.Wm82.gnm1.ann1.Glyma12g07860
 PRR7a	Pseudo Response Regultor 7 gene a	glyma.Wm82.gnm2.ann1.Glyma.U034500
 PRR7b	Pseudo Response Regultor 7 gene b	glyma.Wm82.gnm2.ann1.Glyma.12G073900
 PRR7c	Pseudo Response Regultor 7 gene c	glyma.Wm82.gnm2.ann1.Glyma.13G135900
 PRR7d	Pseudo Response Regultor 7 gene d	glyma.Wm82.gnm2.ann1.Glyma.10G048100
-PRX1	Peroxidase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.09g022300
 PRX2	Cationic peroxidase 2 gene	glyma.Wm82.gnm2.ann1.Glyma.17g013600
 PRX2B	peroxidase	glyma.Wm82.gnm2.ann1.Glyma.07g260300
 PRX3	peroxidase 43	glyma.Wm82.gnm2.ann1.Glyma.15g050800
@@ -3424,21 +3158,11 @@ PUB8	E3 ubiquitin-protein ligase PUB8	glyma.Wm82.gnm2.ann1.Glyma.02g195900
 PUR1	glutamine phosphoribosylpyrophosphate amidotransferase	glyma.Wm82.gnm2.ann1.Glyma.04g007300
 PUR3	glycinamide ribonucleotide transformylase	glyma.Wm82.gnm2.ann1.Glyma.19g115900
 PURD	phosphoribosylamine--glycine ligase	glyma.Wm82.gnm2.ann1.Glyma.10g156900
+Phi-1	phosphate-induced protein	glyma.Wm82.gnm2.ann1.Glyma.14G176500
 RAB2	guanine nucleotide regulatory protein	glyma.Wm82.gnm2.ann1.Glyma.09g016700
 RAB7P	ras-related protein RABD1-like	glyma.Wm82.gnm2.ann1.Glyma.12g165300
 RAD51a	Radiation- repair 51 gene a	glyma.Wm82.gnm2.ann1.Glyma.13G175300
 RAD51b	Radiation- repair 51 gene b	glyma.Wm82.gnm2.ann1.Glyma.17G049800
-Raf1-2	Raf1 proto-oncogene serine/threonine protein kinase gene 2	glyma.Wm82.gnm2.ann1.Glyma.10G066000
-Raf19-1	Raf19 proto-oncogene serine/threonine protein kinase gene 1	glyma.Wm82.gnm2.ann1.Glyma.07G264700
-Raf30-2	Raf30 proto-oncogene serine/threonine protein kinase gene 2	glyma.Wm82.gnm2.ann1.Glyma.20G105300
-Raf41-1	Raf41 proto-oncogene serine/threonine protein kinase gene 1	glyma.Wm82.gnm2.ann1.Glyma.05G002600
-Raf42-3	Raf42 proto-oncogene serine/threonine protein kinase gene 3	glyma.Wm82.gnm2.ann1.Glyma.17G105100
-Raf47-1	Raf47proto-oncogene serine/threonine protein kinase gene 1	glyma.Wm82.gnm2.ann1.Glyma.14G026700
-Raf49-1	Raf49 proto-oncogene serine/threonine protein kinase gene 1	glyma.Wm82.gnm2.ann1.Glyma.14G099300
-Raf49-2	Raf49 proto-oncogene serine/threonine protein kinase gene 2	glyma.Wm82.gnm2.ann1.Glyma.17G225400
-Raf49-3	Raf49 proto-oncogene serine/threonine protein kinase gene 3	glyma.Wm82.gnm2.ann1.Glyma.06G055300
-Raf52	Raf52 proto-oncogene serine/threonine protein kinase	glyma.Wm82.gnm2.ann1.Glyma.04G020100
-Raf6-4	Raf6 proto-oncogene serine/threonine protein kinase gene 4	glyma.Wm82.gnm2.ann1.Glyma.02G215300
 RAP2.7	Target of Early Activation	glyma.Wm82.gnm2.ann1.Glyma.19G178200
 RAR1-1	RAR1 protein	glyma.Wm82.gnm2.ann1.Glyma.10g242200
 RAR1-2	CHORD superfamily protein	glyma.Wm82.gnm2.ann1.Glyma.20g151900
@@ -3453,12 +3177,11 @@ RCABETA	ribulose bisphosphate carboxylase/oxygenase activase, chloroplastic-like
 RCC1	Regulator of chromosome condensation 1	glyma.Wm82.gnm2.ann1.Glyma.10G226900
 RDR3	RNA-dependent RNA polymerase	glyma.Wm82.gnm2.ann1.Glyma.01g008700
 RFP1	RING-type E3 ubiquitin ligase	glyma.Wm82.gnm2.ann1.Glyma.13g071600
-RHA	RNA helicase A	glyma.Wm82.gnm2.ann1.Glyma.08G113000
 RHG4	receptor-like kinase RHG4	glyma.Wm82.gnm2.ann1.Glyma.08g107700
 RIC1	CLE-related protein RIC1	glyma.Wm82.gnm1.ann1.Glyma13g36830
 RIC2	CLE-related protein RIC2	glyma.Wm82.gnm2.ann1.Glyma.06g284100
-RIN4a	RIN4a protein	glyma.Wm82.gnm2.ann1.Glyma.03g084000
 RIN4B	RPM1-interacting protein 4-like	glyma.Wm82.gnm2.ann1.Glyma.16g090700
+RIN4a	RIN4a protein	glyma.Wm82.gnm2.ann1.Glyma.03g084000
 RIN4c	RIN4c protein	glyma.Wm82.gnm2.ann1.Glyma.18g166800
 RIN4d	RIN4d protein	glyma.Wm82.gnm2.ann1.Glyma.08g349500
 RIP1	RIP1-like peroxidase	glyma.Wm82.gnm2.ann1.Glyma.11g161800
@@ -3524,36 +3247,39 @@ RTRP2	probable E3 ubiquitin-protein ligase rbrA-like protein	glyma.Wm82.gnm2.ann
 RTRP3	reverse transcriptase-like domain-containing RBR protein	glyma.Wm82.gnm2.ann1.Glyma.09g020000
 RTRP4	reverse transcriptase-like domain-containing RBR protein	glyma.Wm82.gnm2.ann1.Glyma.15g126500
 RTRP5	RING/U-box superfamily protein	glyma.Wm82.gnm2.ann1.Glyma.09g074200
+Raf1-2	Raf1 proto-oncogene serine/threonine protein kinase gene 2	glyma.Wm82.gnm2.ann1.Glyma.10G066000
+Raf19-1	Raf19 proto-oncogene serine/threonine protein kinase gene 1	glyma.Wm82.gnm2.ann1.Glyma.07G264700
+Raf30-2	Raf30 proto-oncogene serine/threonine protein kinase gene 2	glyma.Wm82.gnm2.ann1.Glyma.20G105300
+Raf41-1	Raf41 proto-oncogene serine/threonine protein kinase gene 1	glyma.Wm82.gnm2.ann1.Glyma.05G002600
+Raf42-3	Raf42 proto-oncogene serine/threonine protein kinase gene 3	glyma.Wm82.gnm2.ann1.Glyma.17G105100
+Raf47-1	Raf47proto-oncogene serine/threonine protein kinase gene 1	glyma.Wm82.gnm2.ann1.Glyma.14G026700
+Raf49-1	Raf49 proto-oncogene serine/threonine protein kinase gene 1	glyma.Wm82.gnm2.ann1.Glyma.14G099300
+Raf49-2	Raf49 proto-oncogene serine/threonine protein kinase gene 2	glyma.Wm82.gnm2.ann1.Glyma.17G225400
+Raf49-3	Raf49 proto-oncogene serine/threonine protein kinase gene 3	glyma.Wm82.gnm2.ann1.Glyma.06G055300
+Raf52	Raf52 proto-oncogene serine/threonine protein kinase	glyma.Wm82.gnm2.ann1.Glyma.04G020100
+Raf6-4	Raf6 proto-oncogene serine/threonine protein kinase gene 4	glyma.Wm82.gnm2.ann1.Glyma.02G215300
 S6K1A	S6 Kinase 1	glyma.Wm82.gnm2.ann1.Glyma.09g273600
 S6K1B	S6 Kinase 1	glyma.Wm82.gnm2.ann1.Glyma.18g212800
 SABATH1	salicylic acid methyl transferase-like protein	glyma.Wm82.gnm2.ann1.Glyma.01g063100
-SABATH2	salicylic acid methyl transferase-like protein	glyma.Wm82.gnm2.ann1.Glyma.02g054200
-SAc3	Actin 3 gene	glyma.Wm82.gnm2.ann1.Glyma.08g146500
-SAc4	Actin 4 gene	glyma.Wm82.gnm2.ann1.Glyma.12g063400
-SAc6	Actin 6 gene	glyma.Wm82.gnm2.ann1.Glyma.18g290800
-SACPD	stearoyl-acyl carrier protein desaturase	glyma.Wm82.gnm2.ann1.Glyma.02g138100
-SACPD-A	stearoyl-acyl carrier protein desaturase	glyma.Wm82.gnm1.ann1.Glyma07g32850 
-SACPD-B	stearoyl-acyl carrier protein desaturase	glyma.Wm82.gnm1.ann1.Glyma02g15600 
-SACPD-C	stearoyl-acyl carrier protein desaturase	glyma.Wm82.gnm2.ann1.Glyma.14g121400
-SAD1	stearoyl-acyl carrier protein desaturase	glyma.Wm82.gnm2.ann1.Glyma.02g138100
-SAD2	stearoyl-ACP desaturase 2	glyma.Wm82.gnm2.ann1.Glyma.07g207200
+SABATH2, SAMT1.02	salicylic acid methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.02G054200
+SACPD-A	stearoyl-acyl carrier protein desaturase	glyma.Wm82.gnm1.ann1.Glyma07g32850
+SACPD-B	stearoyl-acyl carrier protein desaturase	glyma.Wm82.gnm1.ann1.Glyma02g15600
 SALI5-4A	sali5-4a protein	glyma.Wm82.gnm2.ann1.Glyma.12g217300
 SALT3	K+/H+ antiporter gene 1	glyma.Wm82.gnm1.ann1.Glyma03g32900
 SAMDC	S-adenosylmethionine decarboxylase	glyma.Wm82.gnm2.ann1.Glyma.02g128000
-SAMT1.02	salicylic acid methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.02G054200
 SAN1A	senescence-associated nodulin 1A	glyma.Wm82.gnm2.ann1.Glyma.07g209100
 SAN1B	senescence-associated nodulin 1B	glyma.Wm82.gnm2.ann1.Glyma.07g208900
 SARK	senescence-associated receptor-like kinase	glyma.Wm82.gnm2.ann1.Glyma.13g266100
 SAT1	serine O-acetyltransferase 1	glyma.Wm82.gnm2.ann1.Glyma.18g080000
+SAc3	Actin 3 gene	glyma.Wm82.gnm2.ann1.Glyma.08g146500
+SAc4	Actin 4 gene	glyma.Wm82.gnm2.ann1.Glyma.12g063400
 SB100	heat shock protein	glyma.Wm82.gnm2.ann1.Glyma.05g022200
 SBP2	sucrose-binding protein 2	glyma.Wm82.gnm2.ann1.Glyma.02g145700
 SBP56	56kDa selenium binding protein 56	glyma.Wm82.gnm2.ann1.Glyma.08G108000
 SBP65	Late embryonic abundant protein 65 kd	glyma.Wm82.gnm2.ann1.Glyma.13g291800
 SBPRP	proline-rich protein	glyma.Wm82.gnm2.ann1.Glyma.14g115500
-SBZ1	bZIP transcription factor protein SBZ1	glyma.Wm82.gnm2.ann1.Glyma.10g162100
 SC-03	thiamin biosynthetic enzyme	glyma.Wm82.gnm2.ann1.Glyma.12g135000
 SC-04	thiamin biosynthetic enzyme	glyma.Wm82.gnm2.ann1.Glyma.06g269700
-SC514	lipoxygenase	glyma.Wm82.gnm2.ann1.Glyma.07g007000
 SCA1	plasma membrane Ca2+-ATPase	glyma.Wm82.gnm2.ann1.Glyma.01g193600
 SCA2	plasma membrane Ca2+-ATPase	glyma.Wm82.gnm2.ann1.Glyma.06g046000
 SCAM-1	calmodulin	glyma.Wm82.gnm2.ann1.Glyma.03g004100
@@ -3564,7 +3290,7 @@ SCAM-5	calmodulin	glyma.Wm82.gnm2.ann1.Glyma.02g002100
 SCB1	Seed coat BURP domian protein 1	glyma.Wm82.gnm2.ann1.Glyma.07g176700
 SCHI	chilling-induced protein	glyma.Wm82.gnm2.ann1.Glyma.13g275000
 SCOF-1	scof-1 protein	glyma.Wm82.gnm2.ann1.Glyma.17g236200
-SCTF-1	zinc finger protein ZAT10	glyma.Wm82.gnm2.ann1.Glyma.06g045400
+SCTF-1, ZAT6	C2H2-type Zinc Finger transcription factor 6	glyma.Wm82.gnm2.ann1.Glyma.06G045400
 SDP1	triacylglycerol lipase SDP1	glyma.Wm82.gnm2.ann1.Glyma.10g105200
 SDP1-1	triacylglycerol lipase SDP1	glyma.Wm82.gnm2.ann1.Glyma.02g190000
 SDP1-3	triacylglycerol lipase SDP1	glyma.Wm82.gnm2.ann1.Glyma.19g132900
@@ -3594,42 +3320,29 @@ SEP1	transcription factor SEP1	glyma.Wm82.gnm2.ann1.Glyma.19g034500
 SEPB2	peroxidase sEPb2	glyma.Wm82.gnm2.ann1.Glyma.11g080300
 SERK1	somatic embryogenesis receptor kinase	glyma.Wm82.gnm2.ann1.Glyma.10g218800
 SF	serine/arginine-rich splicing factor	glyma.Wm82.gnm2.ann1.Glyma.05G117600
-SF3'H1	flavonoid 3'-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.06g202300
+SF3'H1, T	Tawny	glyma.Wm82.gnm2.ann1.Glyma.06g202300
 SFERH-2	ferritin	glyma.Wm82.gnm2.ann1.Glyma.01g124500
 SFERH-3	ferritin	glyma.Wm82.gnm2.ann1.Glyma.11g232600
 SFERH-4	ferritin	glyma.Wm82.gnm2.ann1.Glyma.14g056800
 SFR2	beta-glycosidase-like	glyma.Wm82.gnm2.ann1.Glyma.17g037100
 SFT	seed-flooding tolerance	glyma.Wm82.gnm2.ann1.Glyma.13g248000
 SG-1-LIKE	putative UDP-glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.07g254900
-SG-3	putative glycosyltransferase UGT91H9	glyma.Wm82.gnm2.ann1.Glyma.10g104700
-SG-4	UDP-arabinose glycosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.01g046300
+SG-3, UGT91H4	Plant uridine 5' -diphosphate glycosyltransferase 91H4	glyma.Wm82.gnm2.ann1.Glyma.10g104700
+SG-4, UGT73P10	Plant uridine 5' -diphosphate glycosyltransferase 73P10	glyma.Wm82.gnm2.ann1.Glyma.01g046300
 SG-9	UDP-glycosyltransferase UGT73B4	glyma.Wm82.gnm2.ann1.Glyma.16g033700
+SGF14G	14-3-3 protein SGF14g	glyma.Wm82.gnm2.ann1.Glyma.02g208700
 SGF14e	14-3-3 protein SGF14e	glyma.Wm82.gnm2.ann1.Glyma.01g058000
 SGF14f	14-3-3 protein SGF14f	glyma.Wm82.gnm2.ann1.Glyma.02g115900
-SGF14G	14-3-3 protein SGF14g	glyma.Wm82.gnm2.ann1.Glyma.02g208700
-SGF14h	14-3-3 protein SGF14h	glyma.Wm82.gnm2.ann1.Glyma.04g099900
-SGF14I	14-3-3 protein SGF14i	glyma.Wm82.gnm2.ann1.Glyma.06g101500
-SGF14J	14-3-3 protein SGF14j	glyma.Wm82.gnm2.ann1.Glyma.06g094400
-SGF14K	14-3-3 protein SGF14k	glyma.Wm82.gnm2.ann1.Glyma.14g176900
-SGF14L	14-3-3 protein SGF14l	glyma.Wm82.gnm2.ann1.Glyma.08g115800
-SGF14M	14-3-3 protein SGF14m	glyma.Wm82.gnm2.ann1.Glyma.08g363800
-SGF14n	14-3-3 protein SGF14n	glyma.Wm82.gnm2.ann1.Glyma.12g229200
-SGF14O	14-3-3 protein SGF14o	glyma.Wm82.gnm2.ann1.Glyma.12g210400
-SGF14P	14-3-3 protein SGF14p	glyma.Wm82.gnm2.ann1.Glyma.13g270600
-SGF14Q	putative 14-3-3 protein SGF14q	glyma.Wm82.gnm2.ann1.Glyma.07g226000
-SGF14R	putative 14-3-3 protein SGF14r	glyma.Wm82.gnm2.ann1.Glyma.20g025900
-SGlu4	glucan endo-1,3-beta-glucosidase	glyma.Wm82.gnm2.ann1.Glyma.15g142400
 SGR	AP2-domain transcription factor SGR	glyma.Wm82.gnm2.ann1.Glyma.02g264700
 SGR1	Stay-green gene 1	glyma.Wm82.gnm2.ann1.Glyma.11g027400
 SGR2	Stay-green gene 2	glyma.Wm82.gnm2.ann1.Glyma.01g214600
 SGS3	sRNA biogenesis gene 3	glyma.Wm82.gnm2.ann1.Glyma.04G203600
 SGT1-1	Suppressor of the G2 allele of SKP1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.01g222400
 SGT1-2	Suppressor of the G2 allele of SKP1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.09g128800
-SGT2	soyasapogenol B glucuronide galactosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.11g053400
-SGT3	soyasaponin III rhamnosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.08g181000
-SHAT1-5	NAC domain-containing protein 43-like	glyma.Wm82.gnm2.ann1.Glyma.16g019400
-SHMT	serine hydroxylmethyltransferase	glyma.Wm82.gnm2.ann1.Glyma.08g108900
-SHMT08	serine hyrdroxmethyltransferase	glyma.Wm82.gnm2.ann1.Glyma.08g108900
+SGT2, UGT73P2	Plant uridine 5' -diphosphate glycosyltransferase 73P2	glyma.Wm82.gnm2.ann1.Glyma.11G053400
+SGT3, UGT91H	Plant uridine 5' -diphosphate glycosyltransferase 91H	glyma.Wm82.gnm2.ann1.Glyma.08G181000
+SGlu4	glucan endo-1,3-beta-glucosidase	glyma.Wm82.gnm2.ann1.Glyma.15g142400
+SHMT, SHMT08	serine hyrdroxmethyltransferase	glyma.Wm82.gnm2.ann1.Glyma.08g108900
 SHOOT2	SHOOT2 protein	glyma.Wm82.gnm2.ann1.Glyma.19g190000
 SIG5B	RNA polymerase sigma factor sigE, chloroplastic/mitochondrial-like	glyma.Wm82.gnm2.ann1.Glyma.06g125700
 SIK1	stress-induced receptor-like kinase	glyma.Wm82.gnm2.ann1.Glyma.02g100300
@@ -3647,28 +3360,23 @@ SIZ1B	E3 SUMO-protein ligase SIZ1b	glyma.Wm82.gnm2.ann1.Glyma.u020100
 SKIP16	F-box protein SKIP16-like	glyma.Wm82.gnm2.ann1.Glyma.11g126500
 SKP2A	protein binding  	glyma.Wm82.gnm1.ann1.Glyma14g26660
 SLD1.1	delta8-sphingolipid desaturase 1	glyma.Wm82.gnm2.ann1.Glyma.01g046000
-SLD1.2	delta8-sphingolipid desaturase 1	glyma.Wm82.gnm2.ann1.Glyma.02g106300
-SLD1.3	delta(8)-fatty-acid desaturase 2-like	glyma.Wm82.gnm2.ann1.Glyma.08g299900
+SLD1.2, SLD2-1	delta(8)-fatty-acid desaturase 2 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02g106300
+SLD1.3, SLD2-2	delta(8)-fatty-acid desaturase 2 gene 2	glyma.Wm82.gnm2.ann1.Glyma.08g299900
 SLD1.4	sphingolipid delta-8 desaturase	glyma.Wm82.gnm2.ann1.Glyma.14g095400
 SLD1.5	delta8-sphingolipid desaturase	glyma.Wm82.gnm2.ann1.Glyma.17g228400
 SLD1.6	sphingolipid delta-8 desaturase	glyma.Wm82.gnm2.ann1.Glyma.18g120400
-SLD2-1	delta(8)-fatty-acid desaturase 2 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02g106300
-SLD2-2	delta(8)-fatty-acid desaturase 2 gene 2	glyma.Wm82.gnm2.ann1.Glyma.08g299900
-SLR1	auxin-induced protein ali50	glyma.Wm82.gnm2.ann1.Glyma.10g180100
 SLTI114	matrix metalloproteinase	glyma.Wm82.gnm2.ann1.Glyma.02g028100
 SLTI248	DEAD-box RNA helicase	glyma.Wm82.gnm2.ann1.Glyma.01g010400
 SMEP1	metalloproteinase	glyma.Wm82.gnm2.ann1.Glyma.02g215700
 SMT2-1	sterol 24-C methyltransferase 2-1	glyma.Wm82.gnm2.ann1.Glyma.04g020600
 SMT2-2	24-methylenesterol C-methyltransferase 2-2	glyma.Wm82.gnm2.ann1.Glyma.06g020700
-SNAC38	NAC transcription factor	glyma.Wm82.gnm2.ann1.Glyma.10g219600
 SNAC41	NAC domain-containing protein 18-like	glyma.Wm82.gnm2.ann1.Glyma.06g249100
 SNAP-1	nucleosome assembly protein 1	glyma.Wm82.gnm2.ann1.Glyma.15g170700
 SNAP09	soluble NSF attachment protein 9	glyma.Wm82.gnm2.ann1.Glyma.09g279400
 SNF5	chromatin structure-remodeling complex protein BSH-like	glyma.Wm82.gnm2.ann1.Glyma.13g117200
 SNRK1	SNF-1-like serine/threonine protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13g060400
 SNRK1.1	sucrose non-fermenting-1 related protein kinase	glyma.Wm82.gnm2.ann1.Glyma.08g240300
-SOD	Super Oxide Dismutase	glyma.Wm82.gnm2.ann1.Glyma.19G240400
-SOD1	superoxide dismutase [Cu-Zn]	glyma.Wm82.gnm2.ann1.Glyma.19g240400
+SOD, SOD1	superoxide dismutase [Cu-Zn]	glyma.Wm82.gnm2.ann1.Glyma.19g240400
 SODB	Fe-superoxide dismutase	glyma.Wm82.gnm2.ann1.Glyma.20g196900
 SODB2	iron-superoxide dismutase	glyma.Wm82.gnm2.ann1.Glyma.10g193500
 SOMT-2	flavonoid 4'-O-methyltransferase SOMT-2	glyma.Wm82.gnm2.ann1.Glyma.08g2467002
@@ -3677,7 +3385,6 @@ SOS1	Na+/H+ antiporter	glyma.Wm82.gnm2.ann1.Glyma.08g092000
 SOY69	actin	glyma.Wm82.gnm2.ann1.Glyma.05g000900
 SOYAP1	aspartic proteinase 1	glyma.Wm82.gnm2.ann1.Glyma.17g011500
 SOYAP2	aspartic proteinase 2	glyma.Wm82.gnm2.ann1.Glyma.19g225500
-SOYCHS	chalcone synthase	glyma.Wm82.gnm2.ann1.Glyma.08g109300
 SOYCTA	putative cadmium-transporting ATPase	glyma.Wm82.gnm2.ann1.Glyma.05g098800
 SOYGBFA	G-box binding factor	glyma.Wm82.gnm2.ann1.Glyma.11g065000
 SOYSTGA	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.11g236300
@@ -3694,7 +3401,6 @@ SPL9A	squamosa promoter-binding-like protein 9a	glyma.Wm82.gnm2.ann1.Glyma.02g17
 SPL9B	squamosa promoter-binding-like protein 9b	glyma.Wm82.gnm2.ann1.Glyma.09g113800
 SPL9C	squamosa promoter-binding-like protein 9c	glyma.Wm82.gnm2.ann1.Glyma.03g143100
 SPL9D	squamosa promoter-binding-like protein 9d	glyma.Wm82.gnm2.ann1.Glyma.19g146000
-SPOD4.1	Ep, peroxidase	glyma.Wm82.gnm2.ann1.Glyma.09g022300
 SPX1	SPX domain-containing protein 1	glyma.Wm82.gnm2.ann1.Glyma.01g135500
 SPX2	SPX domain-containing protein 2	glyma.Wm82.gnm2.ann1.Glyma.04g067400
 SPX3	SPX domain-containing protein 3	glyma.Wm82.gnm2.ann1.Glyma.04g147600
@@ -3708,7 +3414,6 @@ SR1	Serine racemase-1 involved in D-Serine biosynthetic process	glyma.Wm82.gnm1.
 SR2	Serine racemase-2	glyma.Wm82.gnm1.ann1.Glyma08G01670
 SRA2	GTP binding protein	glyma.Wm82.gnm2.ann1.Glyma.09g243300
 SRC1	src1 protein	glyma.Wm82.gnm2.ann1.Glyma.17g187600
-SRC2	SOYBEAN GENE REGULATED BY COLD 2	glyma.Wm82.gnm2.ann1.Glyma.15g152900
 SRT1	NAD-dependent protein deacylase SRT2-like	glyma.Wm82.gnm2.ann1.Glyma.04g210000
 SRT2	NAD-dependent protein deacylase SRT2-like	glyma.Wm82.gnm2.ann1.Glyma.06g156000
 SRT4	NAD-dependent protein deacetylase SRT1-like	glyma.Wm82.gnm2.ann1.Glyma.18g076300
@@ -3717,8 +3422,6 @@ SSH1	polyphosphoinositide binding protein Ssh1p	glyma.Wm82.gnm2.ann1.Glyma.07g26
 SSTP-1	subtilisin-type protease precursor	glyma.Wm82.gnm2.ann1.Glyma.06g022600
 SSTP-2	subtilisin-type protease precursor	glyma.Wm82.gnm2.ann1.Glyma.06g022500
 ST1	sulfotransferase 1	glyma.Wm82.gnm2.ann1.Glyma.13G191400
-stAPX-a	Ascorbate peroxidase gene a	glyma.Wm82.gnm2.ann1.Glyma.06G114400
-stAPX-b	Ascorbate peroxidase gene b	glyma.Wm82.gnm2.ann1.Glyma.04G248300
 STF-3	zinc finger protein ZAT10-like	glyma.Wm82.gnm2.ann1.Glyma.14g088300
 STF2	transcription factor STF2	glyma.Wm82.gnm2.ann1.Glyma.08g302500
 STM	Short Transmembrane Mitochondrial Protein	glyma.Wm82.gnm2.ann1.Glyma.07G263600
@@ -3727,7 +3430,7 @@ STP	sorbitol-like transporter	glyma.Wm82.gnm2.ann1.Glyma.11g119500
 STP1	monosaccharide transporter	glyma.Wm82.gnm2.ann1.Glyma.07g189500
 STV2B	sialyltransferase-like	glyma.Wm82.gnm2.ann1.Glyma.08g051300
 SUB1	SUB1 homolog (S. cerevisiae)	glyma.Wm82.gnm2.ann1.Glyma.08g109000
-SUBI-1	polyubiquitin	glyma.Wm82.gnm2.ann1.Glyma.20g141600
+SUBI-1, Ubiqutin	Ubiqutin	glyma.Wm82.gnm2.ann1.Glyma.20G141600
 SUBI-2	polyubiquitin	glyma.Wm82.gnm2.ann1.Glyma.13g117900
 SUT1	sucrose transporter	glyma.Wm82.gnm2.ann1.Glyma.10g217900
 SVPL	MADS-box protein SVP-like	glyma.Wm82.gnm2.ann1.Glyma.02g041500
@@ -3742,14 +3445,13 @@ SWEET6	sucrose effluxer gene 6	glyma.Wm82.gnm1.ann1.Glyma04g37530
 SYMRK-ALPHA	symbiosis receptor kinase SymRK-alpha	glyma.Wm82.gnm2.ann1.Glyma.01g020100
 SYMRK-BETA	symbiosis receptor kinase SymRK-beta	glyma.Wm82.gnm2.ann1.Glyma.09g202300
 SYP38	syntaxin	glyma.Wm82.gnm1.ann1.Glyma14g06610
-T	Tawny	glyma.Wm82.gnm2.ann1.Glyma.06g202300
 TAP1	acetyltransferase TAP1	glyma.Wm82.gnm2.ann1.Glyma.18g216900
 TBP1	TATA-box binding protein	glyma.Wm82.gnm2.ann1.Glyma.16g140200
 TBP2	TATA BINDING PROTEIN 2	glyma.Wm82.gnm1.ann1.Glyma16g25450
 TCHQD1	glutathione S-transferase TCHQD-like	glyma.Wm82.gnm2.ann1.Glyma.06g117800
 TCHQD2	glutathione S-transferase TCHQD-like	glyma.Wm82.gnm2.ann1.Glyma.13g034200
 TCHQD3	Glutathione S-transferase TCHQD3	glyma.Wm82.gnm2.ann1.Glyma.14g155200
-TCP	TEOSINTE-BRANCHED1/CYCLOIDEA/PCF Transcription Factor	glyma.Wm82.gnm2.ann1.Glyma.15G092500
+TCP, TCP42	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 42	glyma.Wm82.gnm2.ann1.Glyma.15G092500
 TCP1	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G045500
 TCP10	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 10	glyma.Wm82.gnm2.ann1.Glyma.08G299400
 TCP11	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 11	glyma.Wm82.gnm2.ann1.Glyma.09G284300
@@ -3785,13 +3487,11 @@ TCP39	Teosinte branched1 and cycloidea and proliferating cell factor family prot
 TCP4	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 4	glyma.Wm82.gnm2.ann1.Glyma.04G170600
 TCP40	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 40	glyma.Wm82.gnm2.ann1.Glyma.13G271700
 TCP41	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 41	glyma.Wm82.gnm2.ann1.Glyma.13G292500
-TCP42	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 42	glyma.Wm82.gnm2.ann1.Glyma.15G092500
 TCP43	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 43	glyma.Wm82.gnm2.ann1.Glyma.17G079900
 TCP44	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 44	glyma.Wm82.gnm2.ann1.Glyma.18G268700
 TCP45	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 45	glyma.Wm82.gnm2.ann1.Glyma.19G030900
 TCP46	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 46	glyma.Wm82.gnm2.ann1.Glyma.04G152400
 TCP47	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 47	glyma.Wm82.gnm2.ann1.Glyma.05G013300
-TCP48	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 48	glyma.Wm82.gnm2.ann1.Glyma.06G210600
 TCP49	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 49	glyma.Wm82.gnm2.ann1.Glyma.08G256400
 TCP5	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 5	glyma.Wm82.gnm2.ann1.Glyma.05G027400
 TCP50	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 50	glyma.Wm82.gnm2.ann1.Glyma.10G246200
@@ -3811,21 +3511,11 @@ TFIIB1	transcription factor TFIIB	glyma.Wm82.gnm2.ann1.Glyma.10g108600
 TFL1.4	terminal flowering 1-like protein 4	glyma.Wm82.gnm2.ann1.Glyma.09g143500
 TFL1b	Terminal Flower 1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.19g194300
 TGA01	bZIP transcription factor 1	glyma.Wm82.gnm2.ann1.Glyma.01g084200
-TGA02	bZIP transcription factor 2	glyma.Wm82.gnm2.ann1.Glyma.02g097900
 TGA03	bZIP transcription factor 3	glyma.Wm82.gnm2.ann1.Glyma.02g176800
 TGA04	bZIP transcription factor 4	glyma.Wm82.gnm2.ann1.Glyma.03g127600
-TGA05	bZIP transcription factor 5	glyma.Wm82.gnm2.ann1.Glyma.03g128200
 TGA08	bZIP transcription factor 8	glyma.Wm82.gnm2.ann1.Glyma.05g182500
-TGA09	bZIP transcription factor 9	glyma.Wm82.gnm2.ann1.Glyma.06g107300
-TGA11	bZIP transcription factor 11	glyma.Wm82.gnm2.ann1.Glyma.10g092100
-TGA12	bZIP transcription factor 12	glyma.Wm82.gnm2.ann1.Glyma.10g276100
 TGA17	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.12g184500
 TGA2.13	Transcription Factor	glyma.Wm82.gnm2.ann1.Glyma.13G193700
-TGA21	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.14g167000
-TGA23	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.18g020900
-TGA25	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.19g145300
-TGA26	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.20g113600
-TGA27	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.20g246400
 TIL	temperature-induced lipocalin	glyma.Wm82.gnm2.ann1.Glyma.09g098900
 TIL'	temperature-induced lipocalin'	glyma.Wm82.gnm2.ann1.Glyma.15g205900
 TIP2-4	aquaporin TIP2-4	glyma.Wm82.gnm2.ann1.Glyma.08g203000
@@ -3867,7 +3557,6 @@ TPS19	terpene synthase 19	glyma.Wm82.gnm2.ann1.Glyma.13g285200
 TPS2	terpene synthase 2	glyma.Wm82.gnm2.ann1.Glyma.03g154700
 TPS20	terpene synthase 20	glyma.Wm82.gnm2.ann1.Glyma.13g304500
 TPS21	terpene synthase 21	glyma.Wm82.gnm2.ann1.Glyma.13g321100
-TPS22	terpene synthase 22	glyma.Wm82.gnm2.ann1.Glyma.19g157000
 TPS23	terpene synthase 23	glyma.Wm82.gnm2.ann1.Glyma.20g074400
 TPS27	terpene synthase 27	glyma.Wm82.gnm2.ann1.Glyma.12g179500
 TPS3	geraniol synthase	glyma.Wm82.gnm2.ann1.Glyma.06g302200
@@ -3881,137 +3570,118 @@ TSB	tryptophan synthase beta subunit	glyma.Wm82.gnm2.ann1.Glyma.11g003500
 TSF1	Twin sister of FT gene 1	glyma.Wm82.gnm2.ann1.Glyma.18g299000
 TSF2	Twin sister of FT gene 2	glyma.Wm82.gnm2.ann1.Glyma.18g298900
 TUBB	tubulin beta chain	glyma.Wm82.gnm2.ann1.Glyma.15g132200
-TUBB1	tubulin beta-1	glyma.Wm82.gnm2.ann1.Glyma.08g014200
+TUBB1, Tubulin	tubulin	glyma.Wm82.gnm2.ann1.Glyma.08G014200
 TUBB2	tubulin beta-2	glyma.Wm82.gnm2.ann1.Glyma.03g074400
 TUBB3	beta-tubulin	glyma.Wm82.gnm2.ann1.Glyma.03g124400
 TUBG1	tubulin gamma-1 chain	glyma.Wm82.gnm2.ann1.Glyma.03g255800
 TUBG2	tubulin gamma-2 chain	glyma.Wm82.gnm2.ann1.Glyma.19g2533001
-Tubulin	tubulin	glyma.Wm82.gnm2.ann1.Glyma.08G014200
 TUFA	elongation factor Tu, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.06g176900
 TUFB1	elongation factor Tu	glyma.Wm82.gnm2.ann1.Glyma.05g041900
 TYRA-A	arogenate dehydrogenase 2	glyma.Wm82.gnm2.ann1.Glyma.17g122300
 UBC4	ubiquitin carrier protein 4	glyma.Wm82.gnm2.ann1.Glyma.07g069300
-Ubiqutin	Ubiqutin	glyma.Wm82.gnm2.ann1.Glyma.20G141600
-UBQ10	polyubiquitin 10	glyma.Wm82.gnm2.ann1.Glyma.19G147900
 UC1	Uncharacterized protein 1, but possessing aMyb-DNA binding domain	glyma.Wm82.gnm1.ann1.Glyma20G32540
 UC2	Uncharacterized protein 2	glyma.Wm82.gnm1.ann1.Glyma17G07200
 UF3GT1-1	anthocyanidin 3-O-glucosyltransferase 7 gene 1	glyma.Wm82.gnm2.ann1.Glyma.07g183300
 UF3GT1-2	anthocyanidin 3-O-glucosyltransferase 7 gene 2	glyma.Wm82.gnm2.ann1.Glyma.07g183400
-UF3GT1-3	UDP-glucose:flavonoid 3-O-glucosyltransferase gene 1	glyma.Wm82.gnm2.ann1.Glyma.07g183200
+UF3GT1-3, UGT78K1	UDP-glucose:flavonoid 3-O-glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.07g183200
 UGD1	UDP-glucose dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.08g243000
 UGT1	glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.03g256500
 UGT2	isoflavone 7-O-glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.16g175300
 UGT4	isoflavone 7-O-glucosyltransferase UGT4	glyma.Wm82.gnm2.ann1.Glyma.16g175400
 UGT7	isoflavone 7-O-glucosyltransferase UGT7	glyma.Wm82.gnm2.ann1.Glyma.16g175900
 UGT708D1	UDP-glucose:2-hydroxyflavanone C-glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.09g162400
-UGT73F2	Plant uridine 5' -diphosphate glycosyltransferase 73F2	glyma.Wm82.gnm2.ann1.Glyma.07G254600
-UGT73P10	Plant uridine 5' -diphosphate glycosyltransferase 73P10	glyma.Wm82.gnm2.ann1.Glyma.01g046300
-UGT73P2	Plant uridine 5' -diphosphate glycosyltransferase 73P2	glyma.Wm82.gnm2.ann1.Glyma.11G053400
-UGT78K1	UDP-glucose:flavonoid 3-O-glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.07g183200
-UGT78K2	UDP-glucose:flavonoid 3-O-glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.08g066800
-UGT78K2-1	UDP-glucose:flavonoid 3-O-glucosyltransferase gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g066800
-UGT79A6	flavonol 3-O-glucoside (1->6) rhamnosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.10g194000
-UGT79A6-1	flavonol 3-O-glucoside (1->6) rhamnosyltransferase gene 1	glyma.Wm82.gnm2.ann1.Glyma.10g194000
-UGT79B30	anthocyanidin 3-O-glucoside 2''-O-glucosyltransferase-like gene 1	glyma.Wm82.gnm2.ann1.Glyma.06g285700
-UGT79B30-1	anthocyanidin 3-O-glucoside 2''-O-glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.06g285700
+UGT78K2, UGT78K2-1	UDP-glucose:flavonoid 3-O-glucosyltransferase gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g066800
 UGT8	isoflavone 7-O-glucosyltransferase UGT8	glyma.Wm82.gnm2.ann1.Glyma.16g175500
-UGT91H	Plant uridine 5' -diphosphate glycosyltransferase 91H	glyma.Wm82.gnm2.ann1.Glyma.08G181000
-UGT91H4	Plant uridine 5' -diphosphate glycosyltransferase 91H4	glyma.Wm82.gnm2.ann1.Glyma.10g104700
 UO1	Urate Oxidase 1 gene	glyma.Wm82.gnm1.ann1.Glyma10g23790
 URE	urease	glyma.Wm82.gnm2.ann1.Glyma.11g248700
 USP1	UDP-sugar pyrophosphorylase	glyma.Wm82.gnm2.ann1.Glyma.04g245100
 UVR8	UVB-RESISTANCE 8  	glyma.Wm82.gnm1.ann1.Glyma05g32790
 VAD1	protein VASCULAR ASSOCIATED DEATH 1, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.20g070800
 VAMP721D	vesicle-associated membrane protein 721d	glyma.Wm82.gnm2.ann1.Glyma.09g019800
-VLXB	lipoxygenase L-5	glyma.Wm82.gnm2.ann1.Glyma.15g026500
 VLXC	lipoxygenase	glyma.Wm82.gnm2.ann1.Glyma.07g006900
 VPE	vacuolar-processing enzyme	glyma.Wm82.gnm2.ann1.Glyma.17g137800
 VPE2	vacuolar processing enzyme 2	glyma.Wm82.gnm2.ann1.Glyma.14g092800
 VPS-like	Vacuolar protein sorting -like 	glyma.Wm82.gnm2.ann1.Glyma.09G196600
-VQ1	VQ motif containing protein gene 1	glyma.Wm82.gnm1.ann1.Glyma01g018700
+VQ1	VQ motif containing protein gene 1	glyma.Wm82.gnm1.ann1.Glyma01g02280
 VQ10	VQ motif containing protein gene 10	glyma.Wm82.gnm1.ann1.Glyma04g10780
-VQ11	VQ motif containing protein gene 11	glyma.Wm82.gnm1.ann1.Glyma04g103300
+VQ11	VQ motif containing protein gene 11	glyma.Wm82.gnm1.ann1.Glyma04g11211
 VQ12	VQ motif containing protein gene 12	glyma.Wm82.gnm1.ann1.Glyma04g16880
 VQ13	VQ motif containing protein gene 13	glyma.Wm82.gnm1.ann1.Glyma04g39270
-VQ14	VQ motif containing protein gene 14	glyma.Wm82.gnm1.ann1.Glyma04g239400
+VQ14	VQ motif containing protein gene 14	glyma.Wm82.gnm1.ann1.Glyma04g41820
 VQ15	VQ motif containing protein gene 15	glyma.Wm82.gnm1.ann1.Glyma05g22760
 VQ16	VQ motif containing protein gene 16	glyma.Wm82.gnm1.ann1.Glyma05g26340
 VQ17	VQ motif containing protein gene 17	glyma.Wm82.gnm1.ann1.Glyma05g27220
 VQ18	VQ motif containing protein gene 18	glyma.Wm82.gnm1.ann1.Glyma05g31341
 VQ19	VQ motif containing protein gene 19	glyma.Wm82.gnm1.ann1.Glyma05g32350
-VQ2	VQ motif containing protein gene 2	glyma.Wm82.gnm1.ann1.Glyma01g096800
-VQ20	VQ motif containing protein gene 20	glyma.Wm82.gnm1.ann1.Glyma05g198400
+VQ2	VQ motif containing protein gene 2	glyma.Wm82.gnm1.ann1.Glyma01g12940
+VQ20	VQ motif containing protein gene 20	glyma.Wm82.gnm1.ann1.Glyma05g33250
 VQ21	VQ motif containing protein gene 21	glyma.Wm82.gnm1.ann1.Glyma06g10630
 VQ22	VQ motif containing protein gene 22	glyma.Wm82.gnm1.ann1.Glyma06g10951
 VQ23	VQ motif containing protein gene 23	glyma.Wm82.gnm1.ann1.Glyma06g10960
 VQ24	VQ motif containing protein gene 24	glyma.Wm82.gnm1.ann1.Glyma06g12960
 VQ25	VQ motif containing protein gene 25	glyma.Wm82.gnm1.ann1.Glyma06g15650
 VQ26	VQ motif containing protein gene 26	glyma.Wm82.gnm1.ann1.Glyma06g36640
-VQ27	VQ motif containing protein gene 27	glyma.Wm82.gnm1.ann1.Glyma07g028700
+VQ27	VQ motif containing protein gene 27	glyma.Wm82.gnm1.ann1.Glyma07g03240
 VQ28	VQ motif containing protein gene 28	glyma.Wm82.gnm1.ann1.Glyma07g10290
-VQ29	VQ motif containing protein gene 29	glyma.Wm82.gnm1.ann1.Glyma07g198000
+VQ29	VQ motif containing protein gene 29	glyma.Wm82.gnm1.ann1.Glyma07g31781
 VQ3	VQ motif containing protein gene 3	glyma.Wm82.gnm1.ann1.Glyma01g40320
-VQ30	VQ motif containing protein gene 30	glyma.Wm82.gnm1.ann1.Glyma08g005700
-VQ31	VQ motif containing protein gene 31	glyma.Wm82.gnm1.ann1.Glyma08g041900
+VQ30	VQ motif containing protein gene 30	glyma.Wm82.gnm1.ann1.Glyma08g00850
+VQ31	VQ motif containing protein gene 31	glyma.Wm82.gnm1.ann1.Glyma08g04651
 VQ32	VQ motif containing protein gene 32	glyma.Wm82.gnm1.ann1.Glyma08g09250
 VQ33	VQ motif containing protein gene 33	glyma.Wm82.gnm1.ann1.Glyma08g10166
 VQ34	VQ motif containing protein gene 34	glyma.Wm82.gnm1.ann1.Glyma08g14581
 VQ35	VQ motif containing protein gene 35	glyma.Wm82.gnm1.ann1.Glyma08g15620
 VQ36	VQ motif containing protein gene 36	glyma.Wm82.gnm1.ann1.Glyma08g16790
 VQ37	VQ motif containing protein gene 37	glyma.Wm82.gnm1.ann1.Glyma08g18820
-VQ38	VQ motif containing protein gene 38	glyma.Wm82.gnm1.ann1.Glyma08g214100
+VQ38	VQ motif containing protein gene 38	glyma.Wm82.gnm1.ann1.Glyma08g22860
 VQ39	VQ motif containing protein gene 39	glyma.Wm82.gnm1.ann1.Glyma08g36730
 VQ4	VQ motif containing protein gene 4	glyma.Wm82.gnm1.ann1.Glyma02g29281
 VQ40	VQ motif containing protein gene 40	glyma.Wm82.gnm1.ann1.Glyma08g36740
-VQ41	VQ motif containing protein gene 41	glyma.Wm82.gnm1.ann1.Glyma08g272200
+VQ41	VQ motif containing protein gene 41	glyma.Wm82.gnm1.ann1.Glyma08g36750
 VQ42	VQ motif containing protein gene 42	glyma.Wm82.gnm1.ann1.Glyma08g42125
 VQ43	VQ motif containing protein gene 43	glyma.Wm82.gnm1.ann1.Glyma09g05700
-VQ44	VQ motif containing protein gene 44	glyma.Wm82.gnm1.ann1.Glyma09g111800
-VQ48	VQ motif containing protein gene 48	glyma.Wm82.gnm1.ann1.Glyma11g239600
-VQ49	VQ motif containing protein gene 49	glyma.Wm82.gnm1.ann1.Glyma12g153600
-VQ5	VQ motif containing protein gene 5	glyma.Wm82.gnm1.ann1.Glyma02g208800
-VQ50	VQ motif containing protein gene 50	glyma.Wm82.gnm1.ann1.Glyma12g225200
+VQ44	VQ motif containing protein gene 44	glyma.Wm82.gnm1.ann1.Glyma09g17151
+VQ45	VQ motif containing protein gene 45	glyma.Wm82.gnm1.ann1.Glyma09g31600
+VQ46	VQ motif containing protein gene 46	glyma.Wm82.gnm1.ann1.Glyma10g41970
+VQ47	VQ motif containing protein gene 47	glyma.Wm82.gnm1.ann1.Glyma11g04970
+VQ48	VQ motif containing protein gene 48	glyma.Wm82.gnm1.ann1.Glyma11g38180
+VQ49	VQ motif containing protein gene 49	glyma.Wm82.gnm1.ann1.Glyma12g24250
+VQ5	VQ motif containing protein gene 5	glyma.Wm82.gnm1.ann1.Glyma02g37135
+VQ50	VQ motif containing protein gene 50	glyma.Wm82.gnm1.ann1.Glyma12g35380
 VQ51	VQ motif containing protein gene 51	glyma.Wm82.gnm1.ann1.Glyma13g08831
-VQ52	VQ motif containing protein gene 52	glyma.Wm82.gnm1.ann1.Glyma13g005100
-VQ53	VQ motif containing protein gene 53	glyma.Wm82.gnm1.ann1.Glyma13g178500
+VQ52	VQ motif containing protein gene 52	glyma.Wm82.gnm1.ann1.Glyma13g10840
+VQ53	VQ motif containing protein gene 53	glyma.Wm82.gnm1.ann1.Glyma13g24700
 VQ54	VQ motif containing protein gene 54	glyma.Wm82.gnm1.ann1.Glyma13g26290
 VQ55	VQ motif containing protein gene 55	glyma.Wm82.gnm1.ann1.Glyma13g29005
-VQ56	VQ motif containing protein gene 56	glyma.Wm82.gnm1.ann1.Glyma13g238100
-VQ57	VQ motif containing protein gene 57	glyma.Wm82.gnm1.ann1.Glyma13g276100
-VQ58	VQ motif containing protein gene 58	glyma.Wm82.gnm1.ann1.Glyma14g002800
+VQ56	VQ motif containing protein gene 56	glyma.Wm82.gnm1.ann1.Glyma13g31180
+VQ57	VQ motif containing protein gene 57	glyma.Wm82.gnm1.ann1.Glyma13g35130
+VQ58	VQ motif containing protein gene 58	glyma.Wm82.gnm1.ann1.Glyma14g00570
 VQ59	VQ motif containing protein gene 59	glyma.Wm82.gnm1.ann1.Glyma14g29580
 VQ6	VQ motif containing protein gene 6	glyma.Wm82.gnm1.ann1.Glyma03g27560
-VQ60	VQ motif containing protein gene 60	glyma.Wm82.gnm1.ann1.Glyma14g172200
-VQ61	VQ motif containing protein gene 61	glyma.Wm82.gnm1.ann1.Glyma15g075200
-VQ62	VQ motif containing protein gene 62	glyma.Wm82.gnm1.ann1.Glyma15g158200
-VQ63	VQ motif containing protein gene 63	glyma.Wm82.gnm1.ann1.Glyma15g232200
+VQ60	VQ motif containing protein gene 60	glyma.Wm82.gnm1.ann1.Glyma14g34681
+VQ61	VQ motif containing protein gene 61	glyma.Wm82.gnm1.ann1.Glyma15g08160
+VQ62	VQ motif containing protein gene 62	glyma.Wm82.gnm1.ann1.Glyma15g16990
+VQ63	VQ motif containing protein gene 63	glyma.Wm82.gnm1.ann1.Glyma15g37230
 VQ64	VQ motif containing protein gene 64	glyma.Wm82.gnm1.ann1.Glyma15g40000
 VQ65	VQ motif containing protein gene 65	glyma.Wm82.gnm1.ann1.Glyma15g42280
-VQ66	VQ motif containing protein gene 66	glyma.Wm82.gnm1.ann1.Glyma17g159600
-VQ67	VQ motif containing protein gene 67	glyma.Wm82.gnm1.ann1.Glyma18g017800
+VQ66	VQ motif containing protein gene 66	glyma.Wm82.gnm1.ann1.Glyma17g17210
+VQ67	VQ motif containing protein gene 67	glyma.Wm82.gnm1.ann1.Glyma18g02140
 VQ68	VQ motif containing protein gene 68	glyma.Wm82.gnm1.ann1.Glyma18g13001
-VQ69	VQ motif containing protein gene 69	glyma.Wm82.gnm1.ann1.Glyma19g125300
+VQ69	VQ motif containing protein gene 69	glyma.Wm82.gnm1.ann1.Glyma19g30531
 VQ7	VQ motif containing protein gene 7	glyma.Wm82.gnm1.ann1.Glyma03g28360
 VQ70	VQ motif containing protein gene 70	glyma.Wm82.gnm1.ann1.Glyma19g31080
 VQ71	VQ motif containing protein gene 71	glyma.Wm82.gnm1.ann1.Glyma19g38980
 VQ72	VQ motif containing protein gene 72	glyma.Wm82.gnm1.ann1.Glyma19g43590
-VQ73	VQ motif containing protein gene 73	glyma.Wm82.gnm1.ann1.Glyma20g064500
+VQ73	VQ motif containing protein gene 73	glyma.Wm82.gnm1.ann1.Glyma20g15230
 VQ74	VQ motif containing protein gene 74	glyma.Wm82.gnm1.ann1.Glyma20g25070
 VQ8	VQ motif containing protein gene 8	glyma.Wm82.gnm1.ann1.Glyma03g36330
 VQ9	VQ motif containing protein gene 9	glyma.Wm82.gnm1.ann1.Glyma03g40941
-VSP25	Vegetative storage protein 25 kd	glyma.Wm82.gnm2.ann1.Glyma.07g014500
-VSP27	Vegetative storage protein 27 kD	glyma.Wm82.gnm2.ann1.Glyma.08g200100
-VSP94	Vegitative storage protein 94 Kd gene	glyma.Wm82.gnm2.ann1.Glyma.13g347700
-VSPA	28 kDa protein	glyma.Wm82.gnm2.ann1.Glyma.07g014500
-VSPA28	Vegetative storage protein A 28 kD	glyma.Wm82.gnm2.ann1.Glyma.07g014500
+VSPA, VSPA28	Vegetative storage protein A 28 kD	glyma.Wm82.gnm2.ann1.Glyma.07g014500
 VSPB	Vegetative storage protein B	glyma.Wm82.gnm2.ann1.Glyma.08g200100
 VTE2-1	homogentisate phytyltransferase 1, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.13g097800
 VTE2-2	homogentisate phytyltransferase VTE2-2	glyma.Wm82.gnm2.ann1.Glyma.02g168000
-VTL1a	vacuole iron transporter like	glyma.Wm82.gnm2.ann1.Glyma.05G121600
 VTL1b	vacuole iron transporter like	glyma.Wm82.gnm2.ann1.Glyma.08G076300
 W2	White flower 2	glyma.Wm82.gnm2.ann1.Glyma.14g154400
-W3	White flower 3	glyma.Wm82.gnm2.ann1.Glyma.14g072700
-W4	White flower 4	glyma.Wm82.gnm2.ann1.Glyma.17g252200
 WI12	wound-inducible protein 12	glyma.Wm82.gnm2.ann1.Glyma.18g022700
 WIN	wound-induced protein	glyma.Wm82.gnm2.ann1.Glyma.19g245400
 WNK1	with no lysine kinase 1	glyma.Wm82.gnm2.ann1.Glyma.20g228000
@@ -4026,7 +3696,7 @@ WNK5	with no lysine kinase 5	glyma.Wm82.gnm2.ann1.Glyma.03g036500
 WNK6	with no lysine kinase 6	glyma.Wm82.gnm2.ann1.Glyma.07g053500
 WNK7	with no lysine kinase 7	glyma.Wm82.gnm2.ann1.Glyma.06g176800
 WNK8	with no lysine kinase 8	glyma.Wm82.gnm2.ann1.Glyma.20g066900
-WNK9	with no lysine kinase 9	glyma.Wm82.gnm2.ann1.Glyma.19g242900
+WNK9, ZIK9-2	Zinc Finger Protein Interacting With K Protein 9 gene 2	glyma.Wm82.gnm2.ann1.Glyma.19G242900
 WRI1	WRINKLED1	glyma.Wm82.gnm1.ann1.Glyma15g34770
 WRI1A	ethylene-responsive transcription factor WRI1a	glyma.Wm82.gnm2.ann1.Glyma.08g227700
 WRI1B	ethylene-responsive transcription factor WRI1b	glyma.Wm82.gnm2.ann1.Glyma.15g221600
@@ -4059,7 +3729,6 @@ XTH43f	xyloglucan endotransglycosylase/hydrolase	glyma.Wm82.gnm1.ann1.Glyma17g07
 YSL1	probable metal-nicotianamine transporter YSL7-like	glyma.Wm82.gnm2.ann1.Glyma.11g203400
 YUC2A	indole-3-pyruvate monooxygenase YUCCA2	glyma.Wm82.gnm2.ann1.Glyma.08g038600
 ZAT4	zinc finger protein ZAT4	glyma.Wm82.gnm2.ann1.Glyma.17g076900
-ZAT6	C2H2-type Zinc Finger transcription factor 6	glyma.Wm82.gnm2.ann1.Glyma.06G045400
 ZEP	zeaxanthin epoxidase	glyma.Wm82.gnm2.ann1.Glyma.17g174500
 ZF351	tandem CCCH zinc finger protein 351	glyma.Wm82.gnm1.ann1.Glyma06g44440
 ZFP1	Cys2-His2 zinc finger protein	glyma.Wm82.gnm2.ann1.Glyma.17g165600
@@ -4067,7 +3736,6 @@ ZFP3	C2H2-type zinc finger protein 3	glyma.Wm82.gnm2.ann1.Glyma.12g178900
 ZFP5	zinc finger protein ZAT4-like	glyma.Wm82.gnm2.ann1.Glyma.17g142300
 ZFP6	C2H2-type zinc finger protein 6	glyma.Wm82.gnm2.ann1.Glyma.19g186200
 ZIK8-1	Zinc Finger Protein Interacting With K Protein 8 gene 1	glyma.Wm82.gnm2.ann1.Glyma.18G081500
-ZIK9-2	Zinc Finger Protein Interacting With K Protein 9 gene 2	glyma.Wm82.gnm2.ann1.Glyma.19G242900
 ZIP	homeobox-leucine zipper	glyma.Wm82.gnm2.ann1.Glyma.08g124400
 ZIP43	bZIP transcription factor 43	glyma.Wm82.gnm2.ann1.Glyma.14g204100
 ZOU-1	bHLH transcription factor ZOU-1	glyma.Wm82.gnm2.ann1.Glyma.02g103200
@@ -4079,3 +3747,99 @@ ZPR3A	protein LITTLE ZIPPER 3-like	glyma.Wm82.gnm2.ann1.Glyma.11g209700
 ZTL	adagio protein 1	glyma.Wm82.gnm2.ann1.Glyma.15g162300
 ZTL1	PAS protein ZEITLUPE 1	glyma.Wm82.gnm2.ann1.Glyma.17g062000
 ZTL2	clock-associated PAS protein ZEITLUPE 2	glyma.Wm82.gnm2.ann1.Glyma.13g097600
+bHLH15	bHLH protein	glyma.Wm82.gnm2.ann1.Glyma.15G005100
+bHLH35	PREDICTED: transcription factor bHLH35-like	glyma.Wm82.gnm2.ann1.Glyma.13G101100
+bHLH5	bHLH protein	glyma.Wm82.gnm2.ann1.Glyma.05G134400
+bHLH7	bHLH protein	glyma.Wm82.gnm2.ann1.Glyma.07G205800
+bZIP100	Basic leucine zipper transcription factor-like protein gene 100	glyma.Wm82.gnm2.ann1.Glyma.12G088700
+bZIP102	Basic leucine zipper transcription factor-like protein gene 102	glyma.Wm82.gnm2.ann1.Glyma.12G121000
+bZIP103	Basic leucine zipper transcription factor-like protein gene 103	glyma.Wm82.gnm2.ann1.Glyma.12G184400
+bZIP106	Basic leucine zipper transcription factor-like protein gene 106	glyma.Wm82.gnm2.ann1.Glyma.12G227700
+bZIP107	Basic leucine zipper transcription factor-like protein gene 107	glyma.Wm82.gnm2.ann1.Glyma.13G050700
+bZIP116	Basic leucine zipper transcription factor-like protein gene 116	glyma.Wm82.gnm2.ann1.Glyma.13G316900
+bZIP118	Basic leucine zipper transcription factor-like protein gene 118	glyma.Wm82.gnm2.ann1.Glyma.13G345200
+bZIP12, TGA02	bZIP transcription factor 2	glyma.Wm82.gnm2.ann1.Glyma.02g097900
+bZIP120, TGA21	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.14g167000
+bZIP127	Basic leucine zipper transcription factor-like protein gene 127	glyma.Wm82.gnm2.ann1.Glyma.15G129700
+bZIP129	Basic leucine zipper transcription factor-like protein gene 129	glyma.Wm82.gnm2.ann1.Glyma.15G232000
+bZIP13	Basic leucine zipper transcription factor-like protein gene 13	glyma.Wm82.gnm2.ann1.Glyma.02G126100
+bZIP131	Basic leucine zipper transcription factor-like protein gene 131	glyma.Wm82.gnm2.ann1.Glyma.16G092700
+bZIP133	Basic leucine zipper transcription factor-like protein gene 133	glyma.Wm82.gnm2.ann1.Glyma.16G141500
+bZIP134	Basic leucine zipper transcription factor-like protein gene 134	glyma.Wm82.gnm2.ann1.Glyma.16G168400
+bZIP135	Basic leucine zipper transcription factor-like protein gene 135	glyma.Wm82.gnm2.ann1.Glyma.17G158900
+bZIP136	Basic leucine zipper transcription factor-like protein gene 136	glyma.Wm82.gnm2.ann1.Glyma.17G188500
+bZIP137	Basic leucine zipper transcription factor-like protein gene 137	glyma.Wm82.gnm2.ann1.Glyma.17G197300
+bZIP138	Basic leucine zipper transcription factor-like protein gene 138	glyma.Wm82.gnm2.ann1.Glyma.17G253200
+bZIP139	Basic leucine zipper transcription factor-like protein gene 139	glyma.Wm82.gnm2.ann1.Glyma.17G255800
+bZIP140, TGA23	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.18g020900
+bZIP141	Basic leucine zipper transcription factor-like protein gene 141	glyma.Wm82.gnm2.ann1.Glyma.18G052500
+bZIP142	Basic leucine zipper transcription factor-like protein gene 142	glyma.Wm82.gnm2.ann1.Glyma.18G117100
+bZIP143, BZIP73A	bZIP transcription factor bZIP73A	glyma.Wm82.gnm2.ann1.Glyma.18g277100
+bZIP144	Basic leucine zipper transcription factor-like protein gene 144	glyma.Wm82.gnm2.ann1.Glyma.19G037900
+bZIP145	Basic leucine zipper transcription factor-like protein gene 145	glyma.Wm82.gnm2.ann1.Glyma.19G067900
+bZIP146	Basic leucine zipper transcription factor-like protein gene 146	glyma.Wm82.gnm2.ann1.Glyma.19G122800
+bZIP147	Basic leucine zipper transcription factor-like protein gene 147	glyma.Wm82.gnm2.ann1.Glyma.19G126800
+bZIP148	Basic leucine zipper transcription factor-like protein gene 148	glyma.Wm82.gnm2.ann1.Glyma.19G130200
+bZIP149, TGA25	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.19g145300
+bZIP15	Basic leucine zipper transcription factor-like protein gene 15	glyma.Wm82.gnm2.ann1.Glyma.02G161100
+bZIP150	Basic leucine zipper transcription factor-like protein gene 150	glyma.Wm82.gnm2.ann1.Glyma.19G193400
+bZIP151	Basic leucine zipper transcription factor-like protein gene 151	glyma.Wm82.gnm2.ann1.Glyma.19G194500
+bZIP152, BZIP53B	bZIP transcription factor 53B	glyma.Wm82.gnm2.ann1.Glyma.19g216200
+bZIP153	Basic leucine zipper transcription factor-like protein gene 153	glyma.Wm82.gnm2.ann1.Glyma.19G244800
+bZIP154	Basic leucine zipper transcription factor-like protein gene 154	glyma.Wm82.gnm2.ann1.Glyma.19G252600
+bZIP155	Basic leucine zipper transcription factor-like protein gene 155	glyma.Wm82.gnm2.ann1.Glyma.20G007700
+bZIP156	Basic leucine zipper transcription factor-like protein gene 156	glyma.Wm82.gnm2.ann1.Glyma.20G032700
+bZIP157	Basic leucine zipper transcription factor-like protein gene 157	glyma.Wm82.gnm2.ann1.Glyma.20G049200
+bZIP158, TGA26	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.20g113600
+bZIP159	Basic leucine zipper transcription factor-like protein gene 159	glyma.Wm82.gnm2.ann1.Glyma.20G224500
+bZIP160, TGA27	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.20g246400
+bZIP17	Basic leucine zipper transcription factor-like protein gene 17	glyma.Wm82.gnm2.ann1.Glyma.02G236200
+bZIP18	Basic leucine zipper transcription factor-like protein gene 18	glyma.Wm82.gnm2.ann1.Glyma.03G003400
+bZIP2	Basic leucine zipper transcription factor-like protein gene 2	glyma.Wm82.gnm2.ann1.Glyma.01G069300
+bZIP20	Basic leucine zipper transcription factor-like protein gene 20	glyma.Wm82.gnm2.ann1.Glyma.03G081700
+bZIP23, TGA05	bZIP transcription factor 5	glyma.Wm82.gnm2.ann1.Glyma.03g128200
+bZIP26	Basic leucine zipper transcription factor-like protein gene 26	glyma.Wm82.gnm2.ann1.Glyma.03G219300
+bZIP29	Basic leucine zipper transcription factor-like protein gene 29	glyma.Wm82.gnm2.ann1.Glyma.04G010300
+bZIP31	Basic leucine zipper transcription factor-like protein gene 31	glyma.Wm82.gnm2.ann1.Glyma.04G026200
+bZIP32	Basic leucine zipper transcription factor-like protein gene 32	glyma.Wm82.gnm2.ann1.Glyma.04G029600
+bZIP34	Basic leucine zipper transcription factor-like protein gene 34	glyma.Wm82.gnm2.ann1.Glyma.04G078300
+bZIP39	Basic leucine zipper transcription factor-like protein gene 39	glyma.Wm82.gnm2.ann1.Glyma.05G017400
+bZIP40	Basic leucine zipper transcription factor-like protein gene 40	glyma.Wm82.gnm2.ann1.Glyma.05G079800
+bZIP41	Basic leucine zipper transcription factor-like protein gene 41	glyma.Wm82.gnm2.ann1.Glyma.05G108200
+bZIP43	Basic leucine zipper transcription factor-like protein gene 43	glyma.Wm82.gnm2.ann1.Glyma.05G157000
+bZIP45	Basic leucine zipper transcription factor-like protein gene 45	glyma.Wm82.gnm2.ann1.Glyma.05G168100
+bZIP49	Basic leucine zipper transcription factor-like protein gene 49	glyma.Wm82.gnm2.ann1.Glyma.06G029600
+bZIP52	Basic leucine zipper transcription factor-like protein gene 52	glyma.Wm82.gnm2.ann1.Glyma.06G062000
+bZIP53	Basic leucine zipper transcription factor-like protein gene 53	glyma.Wm82.gnm2.ann1.Glyma.06G079800
+bZIP54, TGA09	bZIP transcription factor 9	glyma.Wm82.gnm2.ann1.Glyma.06g107300
+bZIP56	Basic leucine zipper transcription factor-like protein gene 56	glyma.Wm82.gnm2.ann1.Glyma.06G307200
+bZIP57	Basic leucine zipper transcription factor-like protein gene 57	glyma.Wm82.gnm2.ann1.Glyma.06G314400
+bZIP6	Basic leucine zipper transcription factor-like protein gene 6	glyma.Wm82.gnm2.ann1.Glyma.01G177400
+bZIP65	Basic leucine zipper transcription factor-like protein gene 65	glyma.Wm82.gnm2.ann1.Glyma.08G183600
+bZIP66	Basic leucine zipper transcription factor-like protein gene 66	glyma.Wm82.gnm2.ann1.Glyma.08G227000
+bZIP67, BZIP73B	BZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g254400
+bZIP7	Basic leucine zipper transcription factor-like protein gene 7	glyma.Wm82.gnm2.ann1.Glyma.01G195800
+bZIP73	Basic leucine zipper transcription factor-like protein gene 73	glyma.Wm82.gnm2.ann1.Glyma.10G013300
+bZIP75, TGA11	bZIP transcription factor 11	glyma.Wm82.gnm2.ann1.Glyma.10g092100
+bZIP76, SBZ1	bZIP transcription factor protein SBZ1	glyma.Wm82.gnm2.ann1.Glyma.10g162100
+bZIP78	Basic leucine zipper transcription factor-like protein gene 78	glyma.Wm82.gnm2.ann1.Glyma.10G226000
+bZIP79, TGA12	bZIP transcription factor 12	glyma.Wm82.gnm2.ann1.Glyma.10g276100
+bZIP84	Basic leucine zipper transcription factor-like protein gene 84	glyma.Wm82.gnm2.ann1.Glyma.11G108100
+bZIP86	Basic leucine zipper transcription factor-like protein gene 86	glyma.Wm82.gnm2.ann1.Glyma.11G114800
+bZIP88	Basic leucine zipper transcription factor-like protein gene 88	glyma.Wm82.gnm2.ann1.Glyma.11G167400
+bZIP91	Basic leucine zipper transcription factor-like protein gene 91	glyma.Wm82.gnm2.ann1.Glyma.11G168000
+bZIP92	Basic leucine zipper transcription factor-like protein gene 92	glyma.Wm82.gnm2.ann1.Glyma.11G183700
+bZIP95	Basic leucine zipper transcription factor-like protein gene 95	glyma.Wm82.gnm2.ann1.Glyma.12G033000
+bZIP96	Basic leucine zipper transcription factor-like protein gene 96	glyma.Wm82.gnm2.ann1.Glyma.12G036400
+bZIP97	Basic leucine zipper transcription factor-like protein gene 97	glyma.Wm82.gnm2.ann1.Glyma.12G040600
+chs6, CHS6b	Chalcone and stilbene synthases, C-terminal domain; Chalcone and stilbene synthases, N-terminal domain 6 gene b	glyma.Wm82.gnm2.ann1.Glyma.09G075200
+glycinin A2B1a	glycinin A2B1a subunit	glyma.Wm82.gnm2.ann1.Glyma.03g163500
+glycinin A3B4	glycinin A3B4 subunit	glyma.Wm82.gnm2.ann1.Glyma.13g123500
+glycinin A5A4B3	glycinin A5A4B3 subunit	glyma.Wm82.gnm2.ann1.Glyma.10g037100
+jmjC	transcription factor; jumonji (jmjC) domain-containing protein	glyma.Wm82.gnm1.ann1.Glyma12g05890
+ppc2	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.06g229900
+ppc3	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.06g277500
+ppc4	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.12G210600
+ppc7	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.13G270400
+stAPX-a	Ascorbate peroxidase gene a	glyma.Wm82.gnm2.ann1.Glyma.06G114400
+stAPX-b	Ascorbate peroxidase gene b	glyma.Wm82.gnm2.ann1.Glyma.04G248300

--- a/_data/gene_symbols.tsv
+++ b/_data/gene_symbols.tsv
@@ -1,1147 +1,14 @@
 gene_symbol	gene_symbol_long	identifier
-1-3-1A	syringolide-induced protein 1-3-1A	glyma.Wm82.gnm2.ann1.Glyma.10g277800
-1-3-1B	syringolide-induced protein 1-3-1B	glyma.Wm82.gnm2.ann1.Glyma.20g111800
-13-1-1	syringolide-induced protein 13-1-1	glyma.Wm82.gnm2.ann1.Glyma.18g042100
-14-1-1	syringolide-induced protein 14-1-1	glyma.Wm82.gnm2.ann1.Glyma.04g020700
-19-1-5	syringolide-induced protein 19-1-5	glyma.Wm82.gnm2.ann1.Glyma.17g065000
-2A6		glyma.Wm82.gnm1.ann1.Glyma02g09290
-4CL	4-coumarate--CoA ligase-like 7-like	glyma.Wm82.gnm2.ann1.Glyma.13g323000
-4CL1	4-coumarate:coenzyme A ligase gene 1	glyma.Wm82.gnm2.ann1.Glyma.17g064600
-4CL2	4-coumarate:coenzyme A ligase gene 2	glyma.Wm82.gnm2.ann1.Glyma.13g372000
-4CL3	4-coumarate:coenzyme A ligase gene 3	glyma.Wm82.gnm2.ann1.Glyma.11g010500
-4CL4	4-coumarate:coenzyme A ligase gene 4	glyma.Wm82.gnm2.ann1.Glyma.01g232400
-A1	albumin 1	glyma.Wm82.gnm2.ann1.Glyma.13g194400
-AAH	allantoate amidohydrolase	glyma.Wm82.gnm2.ann1.Glyma.15g156900
-AAH2	allantoate deiminase 2	glyma.Wm82.gnm2.ann1.Glyma.09g050800
-AAT	aspartate aminotransferase glyoxysomal isozyme AAT1 precursor	glyma.Wm82.gnm2.ann1.Glyma.06g082400
-ABA3	molybdenum cofactor sulfurtransferase 3	glyma.Wm82.gnm2.ann1.Glyma.09G002300
-ABCC8	ABC Transporter C8	glyma.Wm82.gnm2.ann1.Glyma.07G011600
-ABF1, bZIP14	Basic leucine zipper transcription factor-like protein gene 14	glyma.Wm82.gnm2.ann1.Glyma.02G131700
-ABF2, bZIP33	Basic leucine zipper transcription factor-like protein gene 33	glyma.Wm82.gnm2.ann1.Glyma.04G039300
-ABI5, bZIP74	Basic leucine zipper transcription factor-like protein gene 74	glyma.Wm82.gnm2.ann1.Glyma.10G071700
-ACCA-1	alpha-carboxyltransferase aCT-1 precursor	glyma.Wm82.gnm2.ann1.Glyma.18g195700
-ACCA-2	alfa-carboxyltransferase precursor	glyma.Wm82.gnm2.ann1.Glyma.18g195900
-ACCA-3	carboxyl transferase alpha subunit	glyma.Wm82.gnm2.ann1.Glyma.18g196000
-ACCB-1	biotin carboxyl carrier protein precursor	glyma.Wm82.gnm2.ann1.Glyma.18g243500
-ACCB-2	biotin carboxyl carrier protein subunit	glyma.Wm82.gnm2.ann1.Glyma.18g265300
-ACCC-3	biotin carboxylase precursor	glyma.Wm82.gnm2.ann1.Glyma.08g027600
-ACCase	acetyl-CoA carboxylase	glyma.Wm82.gnm2.ann1.Glyma.05g221100
-ACP1	acid phosphatase 1	glyma.Wm82.gnm2.ann1.Glyma.08g195100
-ACPD, ACPD-1, FAB2, SACPD, SAD1	stearoyl-acyl carrier protein desaturase	glyma.Wm82.gnm2.ann1.Glyma.02g138100
-ACPD-2, SAD2	stearoyl-ACP desaturase 2	glyma.Wm82.gnm2.ann1.Glyma.07g207200
-ACPD-3, SACPD-C	stearoyl-acyl carrier protein desaturase	glyma.Wm82.gnm2.ann1.Glyma.14g121400
-ACS10a	ACC Synthase 10 gene a	glyma.Wm82.gnm2.ann1.Glyma.01G213700
-ACS10b	ACC Synthase 10 gene b	glyma.Wm82.gnm2.ann1.Glyma.11G028200
-ACSL2	long-chain acyl-CoA synthetase ACSL2	glyma.Wm82.gnm2.ann1.Glyma.05g151200
-ACT2/7, UBQ10	polyubiquitin 10	glyma.Wm82.gnm2.ann1.Glyma.19G147900
-ACTIN, SAc6	Actin 6 gene	glyma.Wm82.gnm2.ann1.Glyma.18g290800
-ACX1;1	acyl-CoA oxidase	glyma.Wm82.gnm2.ann1.Glyma.11g035200
-ACX1;2	acyl-CoA oxidase	glyma.Wm82.gnm2.ann1.Glyma.05g062200
-ADC	arginine decarboxylase	glyma.Wm82.gnm2.ann1.Glyma.06g007500
-ADF1	actin depolymerizing factor 1	glyma.Wm82.gnm2.ann1.Glyma.15g125300
-ADO3, FKF2	Flavin-binding Kelch Repeat F-Box 2 gene	glyma.Wm82.gnm2.ann1.Glyma.08g046500
-ADR11	AAI_LTSS superfamily protein	glyma.Wm82.gnm2.ann1.Glyma.17g111100
-ADT2 	AROGENATE DEHYDRATASE 2	glyma.Wm82.gnm1.ann1.Glyma12g07720
-AFB2, AFB3A	auxin signaling F-box 3 protein	glyma.Wm82.gnm2.ann1.Glyma.19g100200
-AFB3B	auxin signaling F-box 3 protein	glyma.Wm82.gnm2.ann1.Glyma.16g050500
-AG1	arginase	glyma.Wm82.gnm2.ann1.Glyma.03g0280001
-AGL1	agamous-like MADS-box protein AGL1	glyma.Wm82.gnm2.ann1.Glyma.14g027200
-AGL11	MADS domain transporter AGL11	glyma.Wm82.gnm2.ann1.Glyma.06g324400
-AGL15	AGL15 protein	glyma.Wm82.gnm2.ann1.Glyma.u018000
-AGL1L	agamous-like MADS-box protein AGL1-like	glyma.Wm82.gnm2.ann1.Glyma.08g310100
-AGL20	Agamous-Like 20	glyma.Wm82.gnm2.ann1.Glyma.07G080900
-AGL3L	agamous-like MADS-box protein AGL3-like	glyma.Wm82.gnm2.ann1.Glyma.08g105400
-AGL8a	Agamous 8-Like gene a	glyma.Wm82.gnm2.ann1.Glyma.17G081200
-AGL8b, AP1A, FULa	Fruitfull gene a	glyma.Wm82.gnm2.ann1.Glyma.06g205800
-AGL8c	Agamous 8-Like gene c	glyma.Wm82.gnm2.ann1.Glyma.13G052100
-AGL8d	Agamous 8-Like gene d	glyma.Wm82.gnm2.ann1.Glyma.19G034600
-AGO2	Argonaut 2 ranscription factor	glyma.Wm82.gnm2.ann1.Glyma.20G022900
-AGO4	Argonaut 4 ranscription factor	glyma.Wm82.gnm2.ann1.Glyma.02G274900
-AHAS1, ALS-1, ALS1	Acetolactate synthase gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g196100
-AHAS2, ALS-2, ALS2	Acetolactate synthase gene 2	glyma.Wm82.gnm2.ann1.Glyma.06g169700
-AHAS3, ALS-3, ALS3	Acetolactate synthase gene 3	glyma.Wm82.gnm2.ann1.Glyma.13g241000
-AHAS4, ALS-4, ALS4	Acetolactate synthase gene 4	glyma.Wm82.gnm2.ann1.Glyma.15g072500
-AIR12	plasma membrane ascorbate-reducible b-type cytochrome family protein	glyma.Wm82.gnm2.ann1.Glyma.03g088900
-AK-HSDH	aspartokinase-homoserine dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.08g107800
-AKR1	probable aldo-keto reductase 1	glyma.Wm82.gnm2.ann1.Glyma.03g248400
-AKT2	Potassium channel AKT2 gene	glyma.Wm82.gnm2.ann1.Glyma.08g187600
-ALAAT1	alanine aminotransferase 1	glyma.Wm82.gnm2.ann1.Glyma.16g013900
-ALAAT2	alanine aminotransferase 2	glyma.Wm82.gnm2.ann1.Glyma.01g026700
-ALAD, HEMB	aminolevulinate, delta-, dehydratase	glyma.Wm82.gnm2.ann1.Glyma.04g247700
-ALDH10A1	betaine aldehyde dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.05g033500
-ALDH10A2	betaine aldehyde dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.06g186300
-ALDH11A1	aldehyde dehydrogenase 11A1	glyma.Wm82.gnm2.ann1.Glyma.02g202500
-ALDH11A2	aldehyde dehydrogenase 11A2	glyma.Wm82.gnm2.ann1.Glyma.17g075300
-ALDH11A3	aldehyde dehydrogenase 11A3	glyma.Wm82.gnm2.ann1.Glyma.17g218200
-ALDH12A1	aldehyde dehydrogenase 12A1	glyma.Wm82.gnm2.ann1.Glyma.05g029100
-ALDH12A2, P5CD	delta-pyrroline-5-corboxylate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.05G029200
-ALDH12A3	aldehyde dehydrogenase 12A3	glyma.Wm82.gnm2.ann1.Glyma.17g097800
-ALDH18B1	delta-1-pyrroline-5-carboxylate synthase	glyma.Wm82.gnm2.ann1.Glyma.01g099800
-ALDH18B2	delta-1-pyrroline-5-carboxylate synthase	glyma.Wm82.gnm2.ann1.Glyma.02g251100
-ALDH18B3	delta-1-pyrroline-5-carboxylate synthase	glyma.Wm82.gnm2.ann1.Glyma.03g069400
-ALDH18B4	delta-1-pyrroline-5-carboxylate synthase	glyma.Wm82.gnm2.ann1.Glyma.14g065600
-ALDH22A1	aldehyde dehydrogenase 22A1	glyma.Wm82.gnm2.ann1.Glyma.07g240300
-ALDH22A2	aldehyde dehydrogenase 22A2	glyma.Wm82.gnm2.ann1.Glyma.09g036000
-ALDH22A3	aldehyde dehydrogenase 22A3	glyma.Wm82.gnm2.ann1.Glyma.15g140900
-ALDH22A4	aldehyde dehydrogenase 22A4	glyma.Wm82.gnm2.ann1.Glyma.17g033100
-ALDH2B1	aldehyde dehydrogenase family 2 member B1	glyma.Wm82.gnm2.ann1.Glyma.01g031500
-ALDH2B2	aldehyde dehydrogenase family 2 member B2	glyma.Wm82.gnm2.ann1.Glyma.02g034000
-ALDH2B4	aldehyde dehydrogenase family 2 member B4, mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.06g183900
-ALDH2B5	aldehyde dehydrogenase family 2 member B5, mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.08g288000
-ALDH2B6	aldehyde dehydrogenase family 2 member B6	glyma.Wm82.gnm2.ann1.Glyma.13g170600
-ALDH2B8	aldehyde dehydrogenase family 2 member B8	glyma.Wm82.gnm2.ann1.Glyma.18g137300
-ALDH2C1	aldehyde dehydrogenase family 2 member C1	glyma.Wm82.gnm2.ann1.Glyma.05g231800
-ALDH2C3	aldehyde dehydrogenase family 2 member C3	glyma.Wm82.gnm2.ann1.Glyma.07g087400
-ALDH2C4	aldehyde dehydrogenase family 2 member C4	glyma.Wm82.gnm2.ann1.Glyma.07g087500
-ALDH2C5	aldehyde dehydrogenase family 2 member C5	glyma.Wm82.gnm2.ann1.Glyma.08g039200
-ALDH2C6	aldehyde dehydrogenase family 2 member C6	glyma.Wm82.gnm2.ann1.Glyma.08g039300
-ALDH2C7	aldehyde dehydrogenase family 2 member C7	glyma.Wm82.gnm2.ann1.Glyma.09g189200
-ALDH2C8	aldehyde dehydrogenase family 2 member C8	glyma.Wm82.gnm2.ann1.Glyma.09g189300
-ALDH2C9	aldehyde dehydrogenase family 2 member C9	glyma.Wm82.gnm2.ann1.Glyma.09g189500
-ALDH3F1	aldehyde dehydrogenase family 3 member F1	glyma.Wm82.gnm2.ann1.Glyma.02g051500
-ALDH3F2	aldehyde dehydrogenase family 3 member F2	glyma.Wm82.gnm2.ann1.Glyma.16g131700
-ALDH3H1	aldehyde dehydrogenase family 3 member H1	glyma.Wm82.gnm2.ann1.Glyma.04g248500
-ALDH3H2	aldehyde dehydrogenase family 3 member H2	glyma.Wm82.gnm2.ann1.Glyma.06g114300
-ALDH3H3	aldehyde dehydrogenase family 3 member H3	glyma.Wm82.gnm2.ann1.Glyma.13g030400
-ALDH3H4	aldehyde dehydrogenase family 3 member H4	glyma.Wm82.gnm2.ann1.Glyma.14g152100
-ALDH3I1	aldehyde dehydrogenase family 3 member I1	glyma.Wm82.gnm2.ann1.Glyma.08g002700
-ALDH3J1	aldehyde dehydrogenase family 3 member J1	glyma.Wm82.gnm2.ann1.Glyma.11g133300
-ALDH3J2	aldehyde dehydrogenase family 3 member J2	glyma.Wm82.gnm2.ann1.Glyma.12g057400
-ALDH3J3	aldehyde dehydrogenase family 3 member J3	glyma.Wm82.gnm2.ann1.Glyma.13g340000
-ALDH3J4	aldehyde dehydrogenase family 3 member J4	glyma.Wm82.gnm2.ann1.Glyma.15g034400
-ALDH5F1	putative succinate-semialdehyde dehydrogenase, mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.08g163700
-ALDH5F2	putative succinate-semialdehyde dehydrogenase, mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.15g263500
-ALDH6B1	putative methylmalonate-semialdehyde dehydrogenase [acylating], mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.07g183600
-ALDH6B2	putative methylmalonate-semialdehyde dehydrogenase [acylating], mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.08g0666001
-ALDH6B3	putative methylmalonate-semialdehyde dehydrogenase [acylating]	glyma.Wm82.gnm2.ann1.Glyma.15g058900
-ALDH7B1	aldehyde dehydrogenase family 7 member B1	glyma.Wm82.gnm2.ann1.Glyma.09g070300
-ALDH7B2	aldehyde dehydrogenase family 7 member B2	glyma.Wm82.gnm2.ann1.Glyma.15g178400
-ALMT1	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.01g083700
-ALMT11	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.07g090300
-ALMT12	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.08g040700
-ALMT13	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.08g260200
-ALMT14	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.09g185600
-ALMT16	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.10g173400
-ALMT17	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.10g275700
-ALMT18	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.10g287700
-ALMT2	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.01g199400
-ALMT21	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.11g042500
-ALMT22	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.11g179100
-ALMT23	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.12g094400
-ALMT24	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.12g188400
-ALMT25	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.12g188500
-ALMT26	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.17g154200
-ALMT27	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.17g154300
-ALMT28	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.19g155200
-ALMT29	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.19g199900
-ALMT3	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.01g223300
-ALMT32	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.20g101600
-ALMT33	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.20g114100
-ALMT34	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.20g216800
-ALMT4	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.02g097700
-ALMT5	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.02g147900
-ALMT6	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.03g152700
-ALMT8	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.05g112700
-AMF3	ammonium-facilitator 3	glyma.Wm82.gnm1.ann1.Glyma15g06660
-AMF5	ammonium-facilitator 5	glyma.Wm82.gnm1.ann1.Glyma09g33680
-AMS1	beta-amyrin synthase	glyma.Wm82.gnm2.ann1.Glyma.07g001300
-AMT1.2	ammonium transporter AMT1.2	glyma.Wm82.gnm2.ann1.Glyma.10g132300
-AMT1.3	ammonium transporter AMT1.3	glyma.Wm82.gnm2.ann1.Glyma.10g167800
-AMT1.4	ammonium transporter AMT1.4	glyma.Wm82.gnm2.ann1.Glyma.10g168100
-AMT1.5	ammonium transporter AMT1.5	glyma.Wm82.gnm2.ann1.Glyma.10g168200
-AMT1.6	ammonium transporter AMT1.6	glyma.Wm82.gnm2.ann1.Glyma.20g221400
-AMT2.1	ammonium transporter AMT2.1	glyma.Wm82.gnm2.ann1.Glyma.07g153800
-AMT2.2	ammonium transporter AMT2.2	glyma.Wm82.gnm2.ann1.Glyma.18g204800
-AMT2.3	ammonium transporter AMT2.3	glyma.Wm82.gnm2.ann1.Glyma.01g123400
-AMT4.1	ammonium transporter 4.1	glyma.Wm82.gnm2.ann1.Glyma.09g281600
-AMT4.2	ammonium transporter AMT4.2	glyma.Wm82.gnm2.ann1.Glyma.20g004100
-AMT4.3	ammonium transporter AMT4.3	glyma.Wm82.gnm2.ann1.Glyma.19g244400
-AMT4.4	ammonium transporter AMT4.4	glyma.Wm82.gnm2.ann1.Glyma.02g043700
-AMT4.5	ammonium transporter AMT4.5	glyma.Wm82.gnm2.ann1.Glyma.02g143500
-AN1	zinc finger A20 and AN1 domain-containing stress-associated protein 5-like	glyma.Wm82.gnm2.ann1.Glyma.08g153200
-ANK4	ankyrin repeats-containing protein	glyma.Wm82.gnm2.ann1.Glyma.01g150400
-ANK6	ankyrin repeats-containing protein	glyma.Wm82.gnm2.ann1.Glyma.02g033700
-ANN11	annexin D4-like	glyma.Wm82.gnm2.ann1.Glyma.15g238400
-ANN14	annexin A7-like	glyma.Wm82.gnm2.ann1.Glyma.13g191200
-ANNEXIN	annexin D1-like	glyma.Wm82.gnm2.ann1.Glyma.13g088700
-ANR1	Anthocyanidin reductase 1	glyma.Wm82.gnm1.ann1.Glyma08g06630
-ANR2	Anthocyanidin reductase 2	glyma.Wm82.gnm1.ann1.Glyma08g06640
-ANS2	Anthocyanidin synthase 2	glyma.Wm82.gnm2.ann1.Glyma.01g214200
-ANS3	Anthocyanidin synthase 3	glyma.Wm82.gnm2.ann1.Glyma.11g027700
-AO, Lac84	Laccase 84	glyma.Wm82.gnm2.ann1.Glyma.20G051700
-AOC1	allene oxide cyclase 4, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.01g086900
-AOC3	amine oxidase, copper containing 3 (vascular adhesion protein 1)	glyma.Wm82.gnm2.ann1.Glyma.19g044900
-AOC4	allene oxide cyclase 3, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.13g047300
-AOC5	allene oxide cyclase 4, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.08g256600
-AOC6	allene oxide cyclase 4, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.18g280900
-AOMT	Anthocyanin O-methyltransferase	glyma.Wm82.gnm1.ann1.Glyma05g36210
-AOS1	allene oxide synthase	glyma.Wm82.gnm2.ann1.Glyma.14g078600
-AOS2	allene oxide synthase	glyma.Wm82.gnm2.ann1.Glyma.17g246500
-AOX1	ubiquinol oxidase 1, mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.04g123800
-AOX1A	alternative oxidase 1A  	glyma.Wm82.gnm1.ann1.Glyma04g14800
-AOX2	alternative oxidase 2a	glyma.Wm82.gnm2.ann1.Glyma.08g072300
-AOX3	alternative oxidase 3, mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.08g072200
-AP1b	Apetella 1 gene b	glyma.Wm82.gnm2.ann1.Glyma.01g064200
-AP1c	Apetella 1 gene c	glyma.Wm82.gnm2.ann1.Glyma.08g250800
-AP2-1	dehydration-responsive element-binding protein 3-like	glyma.Wm82.gnm2.ann1.Glyma.06g085700
-AP2-2	AP2 domain-containing transcription factor 2	glyma.Wm82.gnm2.ann1.Glyma.04g084000
-AP2-3, ERF96	Ethylene-responsive factor gene 96	glyma.Wm82.gnm2.ann1.Glyma.13G081600
-AP2-4, ERF115	Ethylene-responsive factor gene 115	glyma.Wm82.gnm2.ann1.Glyma.14G147500
-AP2-5, ERF44	Ethylene-responsive factor gene 44	glyma.Wm82.gnm2.ann1.Glyma.06G111300
-AP2-6	AP2 domain-containing transcription factor 6	glyma.Wm82.gnm2.ann1.Glyma.04g251400
-AP2-8	dehydration-responsive element-binding protein 2C-like	glyma.Wm82.gnm2.ann1.Glyma.02g261700
-AP2-9	AP2-EREBP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.11g018100
-AP3a	Apetala 3 gene a	glyma.Wm82.gnm2.ann1.Glyma.01G169600
-AP3b, NMH7	MADS-box protein NMH7	glyma.Wm82.gnm2.ann1.Glyma.06g027200
-APS-5a2	Ascorbate peroxidase 5 gene a2	glyma.Wm82.gnm2.ann1.Glyma.11g080900
-APX, POD1	Peroxidase 1	glyma.Wm82.gnm2.ann1.Glyma.03G038700
-APX-1, APX1	ascorbate peroxidase 1, cytosolic	glyma.Wm82.gnm2.ann1.Glyma.u021900
-APX-2, APX2	L-ascorbate peroxidase 2	glyma.Wm82.gnm2.ann1.Glyma.12g073100
-APX-3a1	Ascorbate peroxidase 3 gene a1	glyma.Wm82.gnm2.ann1.Glyma.11G107200
-APX-3a2	Ascorbate peroxidase 3 gene a2	glyma.Wm82.gnm2.ann1.Glyma.11G078400
-APX-4a	Ascorbate peroxidase 4 gene a	glyma.Wm82.gnm2.ann1.Glyma.02G209000
-APX-4b	Ascorbate peroxidase 6 gene b	glyma.Wm82.gnm2.ann1.Glyma.14G177200
-APX-5a1	Ascorbate peroxidase 5 gene a1	glyma.Wm82.gnm2.ann1.Glyma.01G164700
-APX6	Ascorbate peroxidase 6 	glyma.Wm82.gnm2.ann1.Glyma.06G068200
-AR791	actin binding	glyma.Wm82.gnm1.ann1.Glyma13g42970
-ARF	ADP-ribosylation factor	glyma.Wm82.gnm2.ann1.Glyma.19g006400
-ARF8A	auxin response factor 8a	glyma.Wm82.gnm2.ann1.Glyma.02g239600
-ARF8B	auxin response factor 8b	glyma.Wm82.gnm2.ann1.Glyma.14g208500
-ARGS	arginyl-tRNA synthetase	glyma.Wm82.gnm2.ann1.Glyma.01g006400
-ARI1	putative E3 ubiquitin-protein ligase ARI1	glyma.Wm82.gnm2.ann1.Glyma.11g129000
-ARI2	putative E3 ubiquitin-protein ligase ARI2	glyma.Wm82.gnm2.ann1.Glyma.12g053500
-ARI3	putative E3 ubiquitin-protein ligase ARI3	glyma.Wm82.gnm2.ann1.Glyma.15g031100
-ARI7	ariadne A subfamily protein ARI7	glyma.Wm82.gnm2.ann1.Glyma.11g121300
-ARPC4	ARP2/3 complex 20 kDa subunit  4	glyma.Wm82.gnm2.ann1.Glyma.08G111500
-AS1, ASNS	glutamine-dependent asparagine synthetase	glyma.Wm82.gnm2.ann1.Glyma.18G061100
-AS2	asparagine synthetase 2	glyma.Wm82.gnm2.ann1.Glyma.14g195000
-ASP1	L-asparaginase	glyma.Wm82.gnm2.ann1.Glyma.14g086300
-AT-1SNBP	HMG I/Y like protein	glyma.Wm82.gnm2.ann1.Glyma.08g052600
-AT133	malonyl-CoA:isoflavone 7-O-glucoside-6''-O-malonyltransferase	glyma.Wm82.gnm2.ann1.Glyma.19g030500
-ATG18b	yeast autophagy 18 gene b	glyma.Wm82.gnm1.ann1.Glyma02g36960
-ATG3A	autophagy-related protein 3a	glyma.Wm82.gnm2.ann1.Glyma.12g005700
-ATG6	beclin 1 protein	glyma.Wm82.gnm2.ann1.Glyma.11g153900
-ATG7	autophagy-related protein ATG7	glyma.Wm82.gnm2.ann1.Glyma.12g010000
-ATG8C	autophagy-related protein 8c	glyma.Wm82.gnm2.ann1.Glyma.15g108200
-ATG8d	autophagy-related protein 8d	glyma.Wm82.gnm2.ann1.Glyma.12g098400
-ATG8i	autophagy-related protein 8i	glyma.Wm82.gnm2.ann1.Glyma.02g008800
-ATPC	ATP synthase gamma chain, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.15g107900
-ATS9	NON-ATPASE SUBUNIT 9	glyma.Wm82.gnm1.ann1.Glyma04g08280
-AUX28, IAA56	Indole-3-Acetic Acid Responsive Gene 56	glyma.Wm82.gnm2.ann1.Glyma.19G161100
-Actin11	Actin 11	glyma.Wm82.gnm1.ann1.Glyma02g10170
-Amy1	Alpha-amylase 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g017700
-Amy3	Alpha-amylase 3 gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g296800
-B12	AS3/PDS5-related	glyma.Wm82.gnm2.ann1.Glyma.06g062700
-B13-1-1, Lac93	Laccase 93	glyma.Wm82.gnm2.ann1.Glyma.U040600
-B13-1-9, LEA2-15	late embryogenesis abundant 2 gene 15	glyma.Wm82.gnm2.ann1.Glyma.03G201300
-B15-3-5	syringolide-induced protein B15-3-5	glyma.Wm82.gnm2.ann1.Glyma.03g001500
-B3	B3 domain protein	glyma.Wm82.gnm2.ann1.Glyma.10g076100
-BAG6A	BAG family molecular chaperone regulator 6	glyma.Wm82.gnm2.ann1.Glyma.07g061500
-BBI	Bowman-Birk proteinase inhibitor	glyma.Wm82.gnm2.ann1.Glyma.09g158900
-BBI-1	putative Bowman-Birk type protease inhibitor	glyma.Wm82.gnm2.ann1.Glyma.18g231500
-BBI-2	Bowman-Birk type proteinase inhibitor	glyma.Wm82.gnm2.ann1.Glyma.18g231400
-BBI-CII	Bowman-Birk type proteinase inhibitor C-II	glyma.Wm82.gnm2.ann1.Glyma.09g158800
-BCAT	Branched-chain amino acid aminotransferase	glyma.Wm82.gnm2.ann1.Glyma.06G050100
-BCCP2	Biotin carboxyl carrier protein 2	glyma.Wm82.gnm1.ann1.Glyma19g03530
-BCH2	beta-carotene hydroxylase BCH2	glyma.Wm82.gnm2.ann1.Glyma.16g179100
-BCH3	beta-carotene hydroxylase BCH3	glyma.Wm82.gnm2.ann1.Glyma.10g231200
-BCH4	beta-carotene hydroxylase 4	glyma.Wm82.gnm2.ann1.Glyma.20g162600
-BCH5	beta-carotene hydroxylase 5	glyma.Wm82.gnm2.ann1.Glyma.09g132200
-BEHL1	BES1/BZR1 family protein	glyma.Wm82.gnm2.ann1.Glyma.01g178000
-BEN1	Brassinosteriod Insensitive 1 Enhanced 1 gene	glyma.Wm82.gnm1.ann1.Glyma09g40590
-BES1, BZL3	protein BRASSINAZOLE-RESISTANT 1-like	glyma.Wm82.gnm2.ann1.Glyma.06g034000
-BES1-1	protein BRI1-EMS-SUPPRESSOR 1	glyma.Wm82.gnm2.ann1.Glyma.17g248900
-BES1-10	protein BRI1-EMS-SUPPRESSOR 1	glyma.Wm82.gnm2.ann1.Glyma.12g231400
-BES1-11	protein BRI1-EMS-SUPPRESSOR 1	glyma.Wm82.gnm2.ann1.Glyma.13g266500
-BES1-12	protein BRI1-EMS-SUPPRESSOR 1	glyma.Wm82.gnm2.ann1.Glyma.12g231500
-BES1-4	protein BRASSINAZOLE-RESISTANT 1-like	glyma.Wm82.gnm2.ann1.Glyma.04g033800
-BES1-6	protein BRI1-EMS-SUPPRESSOR 1	glyma.Wm82.gnm2.ann1.Glyma.11g064300
-BES1-7	protein BRI1-EMS-SUPPRESSOR 1	glyma.Wm82.gnm2.ann1.Glyma.07g099100
-BES1-8	protein BRI1-EMS-SUPPRESSOR 1	glyma.Wm82.gnm2.ann1.Glyma.14g127400
-BES1-9	protein BRI1-EMS-SUPPRESSOR 1	glyma.Wm82.gnm2.ann1.Glyma.13g266600
-BFA3	chloroplast stromal protein BFA3	glyma.Wm82.gnm2.ann1.Glyma.12g038800
-BFT	phosphatidylethanolamine-binding protein BFT	glyma.Wm82.gnm2.ann1.Glyma.16g196300
-BG7S-1	basic 7S globulin	glyma.Wm82.gnm2.ann1.Glyma.03g239700
-BG7S-2	basic 7S globulin 2	glyma.Wm82.gnm2.ann1.Glyma.19g236600
-BHLH30	Basic helix-loop-helix transcription factor 30	glyma.Wm82.gnm2.ann1.Glyma.02G100700
-BHLH300	bHLH transcription factor bHLH300	glyma.Wm82.gnm2.ann1.Glyma.03g130600
-BHLH320	bHLH transcription factor bHLH320	glyma.Wm82.gnm2.ann1.Glyma.03g130400
-BHLH322	bHLH transcription factor bHLH322	glyma.Wm82.gnm2.ann1.Glyma.19g132600
-BHLH56	basic helix-loop-helix transcription factor	glyma.Wm82.gnm2.ann1.Glyma.13g322100
-BHLH57	bHLH transcription factor	glyma.Wm82.gnm2.ann1.Glyma.12g178500
-BHLH59	basic helix-loop-helix transcription factor bHLH59	glyma.Wm82.gnm2.ann1.Glyma.11g192800
-BIK1-2	BOTRYTIS INDUCED KINASE1 gene 2	glyma.Wm82.gnm1.ann1.Glyma02g41490
-BIK1-6	BOTRYTIS INDUCED KINASE1 gene 6	glyma.Wm82.gnm1.ann1.Glyma14g07460
-BIP2, MED37-7	Mediator Complex 37 gene 7	glyma.Wm82.gnm2.ann1.Glyma.08g025900
-BMY1, BMY1-2	Beta-amylase 1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.15g098100
-BMY1-1	Beta-amylase 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.06g301500
-BMY1-3	Beta-amylase 1 gene 3	glyma.Wm82.gnm2.ann1.Glyma.08g025500
-BMY2	Beta-amylase 2	glyma.Wm82.gnm2.ann1.Glyma.17g150100
-BMY3-1	Beta-amylase 3 gene 1	glyma.Wm82.gnm2.ann1.Glyma.05g068000
-BMY3-2	Beta-amylase 3 gene 2	glyma.Wm82.gnm2.ann1.Glyma.01g203400
-BMY3-3	Beta-amylase 3 gene 3	glyma.Wm82.gnm2.ann1.Glyma.11g039400
-BMY9	Beta-amylase 9	glyma.Wm82.gnm2.ann1.Glyma.13g215000
-BOR2	boron transporter BOR2	glyma.Wm82.gnm2.ann1.Glyma.06g181900
-BRC1, TCP48	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 48	glyma.Wm82.gnm2.ann1.Glyma.06G210600
-BRI1A	brassinosteroid receptor	glyma.Wm82.gnm2.ann1.Glyma.06g147600
-BRI1B	brassinosteroid receptor	glyma.Wm82.gnm2.ann1.Glyma.04g218300
-BRL1A	brassinosteroid receptor-like protein	glyma.Wm82.gnm2.ann1.Glyma.04g115700
-BRL1B	brassinosteroid receptor-like protein	glyma.Wm82.gnm2.ann1.Glyma.06g320600
-BRL2A	brassinosteroid receptor-like protein	glyma.Wm82.gnm2.ann1.Glyma.05g136900
-BRL2B	brassinosteroid receptor-like protein	glyma.Wm82.gnm2.ann1.Glyma.08g092200
-BSAS	beta-substituted alanine synthase	glyma.Wm82.gnm2.ann1.Glyma.19g119100
-BURP2	BURP domain protein 2	glyma.Wm82.gnm2.ann1.Glyma.14g140900
-BZL2	protein BRASSINAZOLE-RESISTANT 1-like	glyma.Wm82.gnm2.ann1.Glyma.14g076900
-Bic-C1, RHA	RNA helicase A	glyma.Wm82.gnm2.ann1.Glyma.08G113000
-Bic-c2	Bicaudal- C gene 2	glyma.Wm82.gnm2.ann1.Glyma.03G064800
-C/VIF1	pectinesterase inhibitor 	glyma.Wm82.gnm1.ann1.Glyma17g04050
-C2-1	C2 domain containing protein gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G162100
-C2-10	C2 domain containing protein gene 10	glyma.Wm82.gnm2.ann1.Glyma.02G220300
-C2-100	C2 domain containing protein gene 100	glyma.Wm82.gnm2.ann1.Glyma.10G092200
-C2-101	C2 domain containing protein gene 101	glyma.Wm82.gnm2.ann1.Glyma.10G130100
-C2-102	C2 domain containing protein gene 102	glyma.Wm82.gnm2.ann1.Glyma.10G130800
-C2-103	C2 domain containing protein gene 103	glyma.Wm82.gnm2.ann1.Glyma.10G165300
-C2-104	C2 domain containing protein gene 104	glyma.Wm82.gnm2.ann1.Glyma.10G210000
-C2-105	C2 domain containing protein gene 105	glyma.Wm82.gnm2.ann1.Glyma.11G000700
-C2-106	C2 domain containing protein gene 106	glyma.Wm82.gnm2.ann1.Glyma.11G024300
-C2-107	C2 domain containing protein gene 107	glyma.Wm82.gnm2.ann1.Glyma.11G040600
-C2-108	C2 domain containing protein gene 108	glyma.Wm82.gnm2.ann1.Glyma.11G081500
-C2-109	C2 domain containing protein gene 108	glyma.Wm82.gnm2.ann1.Glyma.11G103300
-C2-11	C2 domain containing protein gene 11	glyma.Wm82.gnm2.ann1.Glyma.02G226800
-C2-110	C2 domain containing protein gene 110	glyma.Wm82.gnm2.ann1.Glyma.11G107300
-C2-111	C2 domain containing protein gene 111	glyma.Wm82.gnm2.ann1.Glyma.11G130400
-C2-112	C2 domain containing protein gene 112	glyma.Wm82.gnm2.ann1.Glyma.11G154100
-C2-113	C2 domain containing protein gene 113	glyma.Wm82.gnm2.ann1.Glyma.11G216900
-C2-114	C2 domain containing protein gene 114	glyma.Wm82.gnm2.ann1.Glyma.11G219000
-C2-115	C2 domain containing protein gene 115	glyma.Wm82.gnm2.ann1.Glyma.11G227500
-C2-116	C2 domain containing protein gene 116	glyma.Wm82.gnm2.ann1.Glyma.11G229900
-C2-117	C2 domain containing protein gene 117	glyma.Wm82.gnm2.ann1.Glyma.11G230000
-C2-118	C2 domain containing protein gene 118	glyma.Wm82.gnm2.ann1.Glyma.11G230100
-C2-119	C2 domain containing protein gene 119	glyma.Wm82.gnm2.ann1.Glyma.11G239900
-C2-12	C2 domain containing protein gene 12	glyma.Wm82.gnm2.ann1.Glyma.02G247900
-C2-120	C2 domain containing protein gene 120	glyma.Wm82.gnm2.ann1.Glyma.12G001500
-C2-121	C2 domain containing protein gene 121	glyma.Wm82.gnm2.ann1.Glyma.12G028200
-C2-122	C2 domain containing protein gene 122	glyma.Wm82.gnm2.ann1.Glyma.12G032400
-C2-123	C2 domain containing protein gene 123	glyma.Wm82.gnm2.ann1.Glyma.12G239600
-C2-124	C2 domain containing protein gene 124	glyma.Wm82.gnm2.ann1.Glyma.13G003100
-C2-125	C2 domain containing protein gene 125	glyma.Wm82.gnm2.ann1.Glyma.13G003800
-C2-126	C2 domain containing protein gene 126	glyma.Wm82.gnm2.ann1.Glyma.13G198600
-C2-127	C2 domain containing protein gene 127	glyma.Wm82.gnm2.ann1.Glyma.13G261200
-C2-128	C2 domain containing protein gene 128	glyma.Wm82.gnm2.ann1.Glyma.13G342700
-C2-129	C2 domain containing protein gene 129	glyma.Wm82.gnm2.ann1.Glyma.13G364900
-C2-13	C2 domain containing protein gene 13	glyma.Wm82.gnm2.ann1.Glyma.02G248000
-C2-130	C2 domain containing protein gene 130	glyma.Wm82.gnm2.ann1.Glyma.14G016700
-C2-131	C2 domain containing protein gene 131	glyma.Wm82.gnm2.ann1.Glyma.14G034900
-C2-132	C2 domain containing protein gene 132	glyma.Wm82.gnm2.ann1.Glyma.14G059200
-C2-133	C2 domain containing protein gene 133	glyma.Wm82.gnm2.ann1.Glyma.14G059300
-C2-134	C2 domain containing protein gene 134	glyma.Wm82.gnm2.ann1.Glyma.14G059400
-C2-135	C2 domain containing protein gene 135	glyma.Wm82.gnm2.ann1.Glyma.14G068400
-C2-136	C2 domain containing protein gene 136	glyma.Wm82.gnm2.ann1.Glyma.14G098500
-C2-137	C2 domain containing protein gene 137	glyma.Wm82.gnm2.ann1.Glyma.14G187500
-C2-138	C2 domain containing protein gene 138	glyma.Wm82.gnm2.ann1.Glyma.14G193800
-C2-139	C2 domain containing protein gene 139	glyma.Wm82.gnm2.ann1.Glyma.14G220000
-C2-14	C2 domain containing protein gene 14	glyma.Wm82.gnm2.ann1.Glyma.02G248100
-C2-140	C2 domain containing protein gene 140	glyma.Wm82.gnm2.ann1.Glyma.15G008400
-C2-141	C2 domain containing protein gene 141	glyma.Wm82.gnm2.ann1.Glyma.15G008500
-C2-142	C2 domain containing protein gene 142	glyma.Wm82.gnm2.ann1.Glyma.15G031600
-C2-143	C2 domain containing protein gene 143	glyma.Wm82.gnm2.ann1.Glyma.15G120400
-C2-144	C2 domain containing protein gene 144	glyma.Wm82.gnm2.ann1.Glyma.15G121500
-C2-145	C2 domain containing protein gene 145	glyma.Wm82.gnm2.ann1.Glyma.15G130300
-C2-146, SRC2	SOYBEAN GENE REGULATED BY COLD 2	glyma.Wm82.gnm2.ann1.Glyma.15g152900
-C2-147	C2 domain containing protein gene 147	glyma.Wm82.gnm2.ann1.Glyma.15G236900
-C2-148	C2 domain containing protein gene 148	glyma.Wm82.gnm2.ann1.Glyma.15G245600
-C2-149	C2 domain containing protein gene 149	glyma.Wm82.gnm2.ann1.Glyma.15G271400
-C2-15	C2 domain containing protein gene 15	glyma.Wm82.gnm2.ann1.Glyma.02G257000
-C2-150	C2 domain containing protein gene 150	glyma.Wm82.gnm2.ann1.Glyma.16G180300
-C2-151	C2 domain containing protein gene 151	glyma.Wm82.gnm2.ann1.Glyma.16G180400
-C2-152	C2 domain containing protein gene 152	glyma.Wm82.gnm2.ann1.Glyma.17G004700
-C2-153	C2 domain containing protein gene 153	glyma.Wm82.gnm2.ann1.Glyma.17G109500
-C2-154	C2 domain containing protein gene 154	glyma.Wm82.gnm2.ann1.Glyma.17G166900
-C2-155	C2 domain containing protein gene 155	glyma.Wm82.gnm2.ann1.Glyma.17G259000
-C2-156	C2 domain containing protein gene 156	glyma.Wm82.gnm2.ann1.Glyma.18G017500
-C2-157	C2 domain containing protein gene 157	glyma.Wm82.gnm2.ann1.Glyma.18G027100
-C2-158	C2 domain containing protein gene 158	glyma.Wm82.gnm2.ann1.Glyma.18G027200
-C2-159	C2 domain containing protein gene 159	glyma.Wm82.gnm2.ann1.Glyma.18G027300
-C2-16	C2 domain containing protein gene 16	glyma.Wm82.gnm2.ann1.Glyma.02G257100
-C2-160	C2 domain containing protein gene 160	glyma.Wm82.gnm2.ann1.Glyma.18G030000
-C2-161	C2 domain containing protein gene 161	glyma.Wm82.gnm2.ann1.Glyma.18G038400
-C2-162	C2 domain containing protein gene 162	glyma.Wm82.gnm2.ann1.Glyma.18G039700
-C2-163	C2 domain containing protein gene 163	glyma.Wm82.gnm2.ann1.Glyma.18G081900
-C2-164	C2 domain containing protein gene 164	glyma.Wm82.gnm2.ann1.Glyma.18G224000
-C2-165	C2 domain containing protein gene 165	glyma.Wm82.gnm2.ann1.Glyma.18G224800
-C2-166	C2 domain containing protein gene 166	glyma.Wm82.gnm2.ann1.Glyma.18G225300
-C2-167	C2 domain containing protein gene 167	glyma.Wm82.gnm2.ann1.Glyma.18G225400
-C2-168	C2 domain containing protein gene 168	glyma.Wm82.gnm2.ann1.Glyma.18G230800
-C2-169	C2 domain containing protein gene 169	glyma.Wm82.gnm2.ann1.Glyma.18G288600
-C2-17	C2 domain containing protein gene 17	glyma.Wm82.gnm2.ann1.Glyma.02G257200
-C2-170	C2 domain containing protein gene 170	glyma.Wm82.gnm2.ann1.Glyma.19G070700
-C2-171	C2 domain containing protein gene 171	glyma.Wm82.gnm2.ann1.Glyma.19G070800
-C2-172	C2 domain containing protein gene 172	glyma.Wm82.gnm2.ann1.Glyma.19G145400
-C2-173	C2 domain containing protein gene 173	glyma.Wm82.gnm2.ann1.Glyma.19G239500
-C2-174	C2 domain containing protein gene 174	glyma.Wm82.gnm2.ann1.Glyma.19G247300
-C2-175	C2 domain containing protein gene 175	glyma.Wm82.gnm2.ann1.Glyma.19G252000
-C2-176	C2 domain containing protein gene 176	glyma.Wm82.gnm2.ann1.Glyma.20G037600
-C2-177	C2 domain containing protein gene 177	glyma.Wm82.gnm2.ann1.Glyma.20G081500
-C2-178	C2 domain containing protein gene 178	glyma.Wm82.gnm2.ann1.Glyma.20G081900
-C2-179	C2 domain containing protein gene 179	glyma.Wm82.gnm2.ann1.Glyma.20G180600
-C2-18	C2 domain containing protein gene 18	glyma.Wm82.gnm2.ann1.Glyma.02G279900
-C2-180	C2 domain containing protein gene 180	glyma.Wm82.gnm2.ann1.Glyma.20G199700
-C2-19	C2 domain containing protein gene 19	glyma.Wm82.gnm2.ann1.Glyma.02G296900
-C2-2	C2 domain containing protein gene 2	glyma.Wm82.gnm2.ann1.Glyma.01G202200
-C2-20	C2 domain containing protein gene 20	glyma.Wm82.gnm2.ann1.Glyma.03G012600
-C2-21	C2 domain containing protein gene 21	glyma.Wm82.gnm2.ann1.Glyma.03G015400
-C2-22	C2 domain containing protein gene 22	glyma.Wm82.gnm2.ann1.Glyma.03G015800
-C2-23	C2 domain containing protein gene 23	glyma.Wm82.gnm2.ann1.Glyma.03G016000
-C2-24	C2 domain containing protein gene 24	glyma.Wm82.gnm2.ann1.Glyma.03G016100
-C2-25	C2 domain containing protein gene 25	glyma.Wm82.gnm2.ann1.Glyma.03G016200
-C2-26	C2 domain containing protein gene 26	glyma.Wm82.gnm2.ann1.Glyma.03G016300
-C2-27	C2 domain containing protein gene 27	glyma.Wm82.gnm2.ann1.Glyma.03G016400
-C2-28	C2 domain containing protein gene 28	glyma.Wm82.gnm2.ann1.Glyma.03G020800
-C2-29	C2 domain containing protein gene 29	glyma.Wm82.gnm2.ann1.Glyma.03G142500
-C2-3	C2 domain containing protein gene 3	glyma.Wm82.gnm2.ann1.Glyma.01G215100
-C2-30	C2 domain containing protein gene 30	glyma.Wm82.gnm2.ann1.Glyma.03G242100
-C2-31	C2 domain containing protein gene 31	glyma.Wm82.gnm2.ann1.Glyma.03G242200
-C2-32	C2 domain containing protein gene 32	glyma.Wm82.gnm2.ann1.Glyma.03G249700
-C2-33	C2 domain containing protein gene 33	glyma.Wm82.gnm2.ann1.Glyma.03G254400
-C2-34	C2 domain containing protein gene 34	glyma.Wm82.gnm2.ann1.Glyma.04G020400
-C2-35	C2 domain containing protein gene 35	glyma.Wm82.gnm2.ann1.Glyma.04G141600
-C2-36	C2 domain containing protein gene 36	glyma.Wm82.gnm2.ann1.Glyma.04G187900
-C2-37	C2 domain containing protein gene 37	glyma.Wm82.gnm2.ann1.Glyma.04G201500
-C2-38	C2 domain containing protein gene 38	glyma.Wm82.gnm2.ann1.Glyma.04G224600
-C2-39	C2 domain containing protein gene 39	glyma.Wm82.gnm2.ann1.Glyma.05G029600
-C2-4	C2 domain containing protein gene 4	glyma.Wm82.gnm2.ann1.Glyma.01G219200
-C2-40	C2 domain containing protein gene 40	glyma.Wm82.gnm2.ann1.Glyma.05G098700
-C2-41	C2 domain containing protein gene 41	glyma.Wm82.gnm2.ann1.Glyma.05G165900
-C2-42	C2 domain containing protein gene 42	glyma.Wm82.gnm2.ann1.Glyma.05G168300
-C2-43	C2 domain containing protein gene 43	glyma.Wm82.gnm2.ann1.Glyma.05G204900
-C2-44	C2 domain containing protein gene 44	glyma.Wm82.gnm2.ann1.Glyma.05G246400
-C2-45	C2 domain containing protein gene 45	glyma.Wm82.gnm2.ann1.Glyma.06G003700
-C2-46	C2 domain containing protein gene 46	glyma.Wm82.gnm2.ann1.Glyma.06G020500
-C2-47	C2 domain containing protein gene 47	glyma.Wm82.gnm2.ann1.Glyma.06G066600
-C2-48	C2 domain containing protein gene 48	glyma.Wm82.gnm2.ann1.Glyma.06G068600
-C2-49	C2 domain containing protein gene 49	glyma.Wm82.gnm2.ann1.Glyma.06G068700
-C2-5	C2 domain containing protein gene 5	glyma.Wm82.gnm2.ann1.Glyma.01G244500
-C2-50	C2 domain containing protein gene 50	glyma.Wm82.gnm2.ann1.Glyma.06G140100
-C2-51	C2 domain containing protein gene 51	glyma.Wm82.gnm2.ann1.Glyma.06G163800
-C2-52	C2 domain containing protein gene 52	glyma.Wm82.gnm2.ann1.Glyma.06G177800
-C2-53	C2 domain containing protein gene 53	glyma.Wm82.gnm2.ann1.Glyma.06G241700
-C2-54	C2 domain containing protein gene 54	glyma.Wm82.gnm2.ann1.Glyma.06G292000
-C2-55	C2 domain containing protein gene 55	glyma.Wm82.gnm2.ann1.Glyma.07G010900
-C2-56	C2 domain containing protein gene 56	glyma.Wm82.gnm2.ann1.Glyma.07G031100
-C2-57	C2 domain containing protein gene 57	glyma.Wm82.gnm2.ann1.Glyma.07G072500
-C2-58	C2 domain containing protein gene 58	glyma.Wm82.gnm2.ann1.Glyma.07G075300
-C2-59	C2 domain containing protein gene 59	glyma.Wm82.gnm2.ann1.Glyma.07G076100
-C2-6	C2 domain containing protein gene 6	glyma.Wm82.gnm2.ann1.Glyma.02G093500
-C2-60	C2 domain containing protein gene 60	glyma.Wm82.gnm2.ann1.Glyma.07G076200
-C2-61	C2 domain containing protein gene 61	glyma.Wm82.gnm2.ann1.Glyma.07G076300
-C2-62	C2 domain containing protein gene 62	glyma.Wm82.gnm2.ann1.Glyma.07G076400
-C2-63	C2 domain containing protein gene 63	glyma.Wm82.gnm2.ann1.Glyma.07G076600
-C2-64	C2 domain containing protein gene 64	glyma.Wm82.gnm2.ann1.Glyma.07G080400
-C2-65	C2 domain containing protein gene 65	glyma.Wm82.gnm2.ann1.Glyma.07G082700
-C2-66	C2 domain containing protein gene 66	glyma.Wm82.gnm2.ann1.Glyma.07G089100
-C2-67	C2 domain containing protein gene 67	glyma.Wm82.gnm2.ann1.Glyma.07G092400
-C2-68	C2 domain containing protein gene 68	glyma.Wm82.gnm2.ann1.Glyma.07G102400
-C2-69	C2 domain containing protein gene 69	glyma.Wm82.gnm2.ann1.Glyma.07G177900
-C2-7	C2 domain containing protein gene 7	glyma.Wm82.gnm2.ann1.Glyma.02G137500
-C2-70	C2 domain containing protein gene 70	glyma.Wm82.gnm2.ann1.Glyma.07G207700
-C2-71	C2 domain containing protein gene 71	glyma.Wm82.gnm2.ann1.Glyma.07G219900
-C2-72	C2 domain containing protein gene 72	glyma.Wm82.gnm2.ann1.Glyma.07G230700
-C2-73	C2 domain containing protein gene 73	glyma.Wm82.gnm2.ann1.Glyma.07G248600
-C2-74	C2 domain containing protein gene 74	glyma.Wm82.gnm2.ann1.Glyma.07G268400
-C2-75	C2 domain containing protein gene 75	glyma.Wm82.gnm2.ann1.Glyma.07G269000
-C2-76	C2 domain containing protein gene 76	glyma.Wm82.gnm2.ann1.Glyma.08G007500
-C2-77	C2 domain containing protein gene 77	glyma.Wm82.gnm2.ann1.Glyma.08G011900
-C2-78	C2 domain containing protein gene 78	glyma.Wm82.gnm2.ann1.Glyma.08G041800
-C2-79	C2 domain containing protein gene 79	glyma.Wm82.gnm2.ann1.Glyma.08G054500
-C2-8	C2 domain containing protein gene 8	glyma.Wm82.gnm2.ann1.Glyma.02G137700
-C2-80	C2 domain containing protein gene 80	glyma.Wm82.gnm2.ann1.Glyma.08G124000
-C2-81	C2 domain containing protein gene 81	glyma.Wm82.gnm2.ann1.Glyma.08G126700
-C2-82	C2 domain containing protein gene 82	glyma.Wm82.gnm2.ann1.Glyma.08G152000
-C2-83	C2 domain containing protein gene 83	glyma.Wm82.gnm2.ann1.Glyma.08G194100
-C2-84	C2 domain containing protein gene 84	glyma.Wm82.gnm2.ann1.Glyma.08G211700
-C2-85	C2 domain containing protein gene 85	glyma.Wm82.gnm2.ann1.Glyma.08G239300
-C2-86	C2 domain containing protein gene 86	glyma.Wm82.gnm2.ann1.Glyma.08G325300
-C2-87	C2 domain containing protein gene 87	glyma.Wm82.gnm2.ann1.Glyma.09G003400
-C2-88	C2 domain containing protein gene 88	glyma.Wm82.gnm2.ann1.Glyma.09G014700
-C2-89	C2 domain containing protein gene 89	glyma.Wm82.gnm2.ann1.Glyma.09G015700
-C2-9	C2 domain containing protein gene 9	glyma.Wm82.gnm2.ann1.Glyma.02G176700
-C2-90	C2 domain containing protein gene 90	glyma.Wm82.gnm2.ann1.Glyma.09G024400
-C2-91, COR2	cold-regulated protein	glyma.Wm82.gnm2.ann1.Glyma.09g045700
-C2-92	C2 domain containing protein gene 92	glyma.Wm82.gnm2.ann1.Glyma.09G117100
-C2-93	C2 domain containing protein gene 93	glyma.Wm82.gnm2.ann1.Glyma.09G134500
-C2-94	C2 domain containing protein gene 94	glyma.Wm82.gnm2.ann1.Glyma.09G176900
-C2-95	C2 domain containing protein gene 95	glyma.Wm82.gnm2.ann1.Glyma.09G182700
-C2-96	C2 domain containing protein gene 96	glyma.Wm82.gnm2.ann1.Glyma.09G187900
-C2-97	C2 domain containing protein gene 97	glyma.Wm82.gnm2.ann1.Glyma.09G261200
-C2-98	C2 domain containing protein gene 98	glyma.Wm82.gnm2.ann1.Glyma.09G266600
-C2-99	C2 domain containing protein gene 99	glyma.Wm82.gnm2.ann1.Glyma.10G091800
-C3H	C3H protein	glyma.Wm82.gnm2.ann1.Glyma.05g224400
-C4H	trans-cinnamate 4-monooxygenase	glyma.Wm82.gnm2.ann1.Glyma.02g236500
-C4H1	cinnamate 4-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.20g114200
-CA1	carbonic anhydrase	glyma.Wm82.gnm2.ann1.Glyma.06g182700
-CAB3	chlorophyll a/b-binding protein	glyma.Wm82.gnm2.ann1.Glyma.05g128000
-CAMK1	CaM-binding protein kinase CaMK1	glyma.Wm82.gnm2.ann1.Glyma.12g216000
-CAMS1	CAMELLIOL C SYNTHASE 1	glyma.Wm82.gnm1.ann1.Glyma15g07110
-CAMTA1	Calmodulin binding transcription activator 1	glyma.Wm82.gnm2.ann1.Glyma.05G178200
-CAMTA10	Calmodulin binding transcription activator 10	glyma.Wm82.gnm2.ann1.Glyma.05G148300
-CAMTA11	Calmodulin binding transcription activator 11	glyma.Wm82.gnm2.ann1.Glyma.18G005100
-CAMTA12	Calmodulin binding transcription activator 12	glyma.Wm82.gnm2.ann1.Glyma.17G031900
-CAMTA13	Calmodulin binding transcription activator 13	glyma.Wm82.gnm2.ann1.Glyma.07G242000
-CAMTA14	Calmodulin binding transcription activator 14	glyma.Wm82.gnm2.ann1.Glyma.11G251900
-CAMTA15	Calmodulin binding transcription activator 15	glyma.Wm82.gnm2.ann1.Glyma.08G105200
-CAMTA2	Calmodulin binding transcription activator 2	glyma.Wm82.gnm2.ann1.Glyma.08G135200
-CAMTA3	Calmodulin binding transcription activator 3	glyma.Wm82.gnm2.ann1.Glyma.15G053600
-CAMTA4	Calmodulin binding transcription activator 4	glyma.Wm82.gnm2.ann1.Glyma.08G072100
-CAMTA5	Calmodulin binding transcription activator 5	glyma.Wm82.gnm2.ann1.Glyma.05G117000
-CAMTA6	Calmodulin binding transcription activator 6	glyma.Wm82.gnm2.ann1.Glyma.08G178900
-CAMTA7	Calmodulin binding transcription activator 7	glyma.Wm82.gnm2.ann1.Glyma.17G038800
-CAMTA8	Calmodulin binding transcription activator 8	glyma.Wm82.gnm2.ann1.Glyma.15G143400
-CAMTA9	Calmodulin binding transcription activator 9	glyma.Wm82.gnm2.ann1.Glyma.09G038300
-CAS	calcium sensing receptor, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.17g084300
-CASP2	casparian strip membrane protein 2	glyma.Wm82.gnm2.ann1.Glyma.10g075400
-CAT3	catalase	glyma.Wm82.gnm2.ann1.Glyma.14g223500
-CAT4	catalase	glyma.Wm82.gnm2.ann1.Glyma.04g017500
-CAT5	catalase	glyma.Wm82.gnm2.ann1.Glyma.06g017900
-CB5-A2	cytochrome b5	glyma.Wm82.gnm2.ann1.Glyma.04g231800
-CBP	putative calmodulin-binding protein	glyma.Wm82.gnm2.ann1.Glyma.09g231200
-CCD7	carotenoid cleavage dioxygenase 7	glyma.Wm82.gnm2.ann1.Glyma.u016700
-CCD8	carotenoid cleavage dioxygenase	glyma.Wm82.gnm2.ann1.Glyma.06g085800
-CCDA	cytochrome c-type biogenesis ccda-like chloroplastic protein 2-like	glyma.Wm82.gnm2.ann1.Glyma.12g147300
-CCH	heavy-metal-associated domain-containing protein 	glyma.Wm82.gnm1.ann1.Glyma06g11190
-CCR	cinnamoyl-CoA reductase	glyma.Wm82.gnm2.ann1.Glyma.13g369800
-CCS	Cu/Zn-superoxide dismutase copper chaperone	glyma.Wm82.gnm2.ann1.Glyma.05g055000
-CCS52	WD-repeat cell cycle regulatory protein	glyma.Wm82.gnm2.ann1.Glyma.11g219600
-CCT-D	cytosolic chaperonin	glyma.Wm82.gnm2.ann1.Glyma.08g050100
-CDC48	plamsma membrane-associated AAA-ATPase	glyma.Wm82.gnm2.ann1.Glyma.13g323600
-CDF1	cation diffusion facilitator 1	glyma.Wm82.gnm2.ann1.Glyma.08g102000
-CDF2	Cycling Dof Factor 2	glyma.Wm82.gnm2.ann1.Glyma.18G260500
-CDF3a	Cycling Dof Factor 3 gene a	glyma.Wm82.gnm2.ann1.Glyma.06G194800
-CDF3b	Cycling Dof Factor 3 gene b	glyma.Wm82.gnm2.ann1.Glyma.02G108600
-CDF3c	Cycling Dof Factor 3 gene c	glyma.Wm82.gnm2.ann1.Glyma.05G025900
-CDF3d	Cycling Dof Factor 3 gene d	glyma.Wm82.gnm2.ann1.Glyma.17G101000
-CDPK	Calcium-dependent protein kinase SK5	glyma.Wm82.gnm2.ann1.Glyma.08g005600
-CDPK-BETA	calmodulin-like domain protein kinase isoenzyme beta	glyma.Wm82.gnm2.ann1.Glyma.20g175100
-CDPK-GAMMA	calmodulin-like domain protein kinase isoenzyme gamma	glyma.Wm82.gnm2.ann1.Glyma.08g316500
-CEL12	endo-1,4-beta-glucancase	glyma.Wm82.gnm2.ann1.Glyma.09g018500
-CEL7	alpha family endo-beta-1,4-glucanase	glyma.Wm82.gnm2.ann1.Glyma.02g016400
-CEL8	endo-1,4-beta-glucanase	glyma.Wm82.gnm2.ann1.Glyma.08g022300
-CEN1	protein SELF-PRUNING-like	glyma.Wm82.gnm2.ann1.Glyma.11g209500
-CEN2	CEN-like protein 2-like	glyma.Wm82.gnm2.ann1.Glyma.10g071400
-CEN3	CENTRORADIALIS-like protein 3	glyma.Wm82.gnm2.ann1.Glyma.12g184000
-CEN4	protein CENTRORADIALIS-like	glyma.Wm82.gnm2.ann1.Glyma.13g317100
-CENH3	Centromere specific histone 3	glyma.Wm82.gnm2.ann1.Glyma.07G057300
-CFIM-25	mRNA and protein family	glyma.Wm82.gnm1.ann1.Glyma09g07670
-CG-1, GM7S	beta-conglycinin alpha prime subunit 1	glyma.Wm82.gnm2.ann1.Glyma.10g246300
-CG-ALPHA-2, Cgy2	beta-conglycinin alpha prime subunit 2	glyma.Wm82.gnm2.ann1.Glyma.20g148400
-CG-BETA-1, Cgy4	beta-conglycinin beta-subunit 4	glyma.Wm82.gnm2.ann1.Glyma.20g146200
-CG-BETA-2	beta-conglycinin, beta chain-like	glyma.Wm82.gnm2.ann1.Glyma.20g148200
-CGS1	cystathionine gamma-synthase 1, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.18g261600
-CGS2	cystathionine-gamma-synthase	glyma.Wm82.gnm2.ann1.Glyma.09g235400
-CHI1, CHI1A	chalcone-flavonone isomerase 1A	glyma.Wm82.gnm2.ann1.Glyma.20g241500
-CHI1B1, CHI2	chalcone isomerase 2	glyma.Wm82.gnm2.ann1.Glyma.20g241600
-CHI1B2	chalcone isomerase 1B2	glyma.Wm82.gnm2.ann1.Glyma.10g292200
-CHI2-A	chalcone--flavonone isomerase 2-A	glyma.Wm82.gnm2.ann1.Glyma.20g241700
-CHI3A1	chalcone isomerase 3A1	glyma.Wm82.gnm2.ann1.Glyma.13g262500
-CHI3A2	chalcone isomerase 3A2	glyma.Wm82.gnm2.ann1.Glyma.15g242900
-CHI3B1	chlacone isomerase 3B1	glyma.Wm82.gnm2.ann1.Glyma.03g154600
-CHI3B2	chalcone isomerase 3B2	glyma.Wm82.gnm2.ann1.Glyma.19g156900
-CHI3C1	chalcone isomerase 3C1	glyma.Wm82.gnm2.ann1.Glyma.14g098100
-CHI3C2	chalcone isomerase 3C2	glyma.Wm82.gnm2.ann1.Glyma.17g226600
-CHI4, CHI4A	chalcone isomerase 4A	glyma.Wm82.gnm2.ann1.Glyma.06g143000
-CHI4B	chalcone isomerase 4B	glyma.Wm82.gnm2.ann1.Glyma.04g222400
-CHIA1	chitinase class I	glyma.Wm82.gnm2.ann1.Glyma.02g042500
-CHL	chloroplastic lipocalin	glyma.Wm82.gnm2.ann1.Glyma.02g289400
-CHLH	magnesium chelatase subunit	glyma.Wm82.gnm2.ann1.Glyma.03g137000
-CHLI	Mg-protoporphyrin IX chelatase subunit ChlI	glyma.Wm82.gnm2.ann1.Glyma.13g232500
-CHR1	chalcone reductase CHR1	glyma.Wm82.gnm2.ann1.Glyma.14g005700
-CHR2	chalcone reductase CHR2	glyma.Wm82.gnm2.ann1.Glyma.16g219500
-CHR3	chalcone reductase CHR3	glyma.Wm82.gnm2.ann1.Glyma.16g219400
-CHR4	chalcone reductase CHR4	glyma.Wm82.gnm2.ann1.Glyma.20g031100
-CHR5	chalcone reductase CHR5	glyma.Wm82.gnm2.ann1.Glyma.18g285800
-CHR6	chalcone reductase CHR6	glyma.Wm82.gnm2.ann1.Glyma.02g307300
-CHS	Chalcone synthase	glyma.Wm82.gnm1.ann1.Glyma08g11530
-CHS1	chalcone synthase 1	glyma.Wm82.gnm2.ann1.Glyma.08g109400
-CHS10, CHS6c	Chalcone and stilbene synthases, C-terminal domain; Chalcone and stilbene synthases, N-terminal domain 6 gene c	glyma.Wm82.gnm2.ann1.Glyma.02G130400
-CHS11, CHS6a	Chalcone and stilbene synthases, C-terminal domain; Chalcone and stilbene synthases, N-terminal domain 6 gene a	glyma.Wm82.gnm2.ann1.Glyma.01G091400
-CHS13	chalcone synthase 13	glyma.Wm82.gnm2.ann1.Glyma.19g105100
-CHS14	chalcone synthase	glyma.Wm82.gnm2.ann1.Glyma.06g118500
-CHS3, SOYCHS	chalcone synthase	glyma.Wm82.gnm2.ann1.Glyma.08g109300
-CHS3B	chalcone synthase 3	glyma.Wm82.gnm2.ann1.Glyma.08g110900
-CHS3C	chalcone synthase 3	glyma.Wm82.gnm2.ann1.Glyma.08g110300
-CHS4, CHS4A	chalcone synthase 4a	glyma.Wm82.gnm2.ann1.Glyma.08g110700
-CHS4B	chalcone synthase 4b	glyma.Wm82.gnm2.ann1.Glyma.08g110500
-CHS9	chalcone synthase 9	glyma.Wm82.gnm2.ann1.Glyma.08g109500
-CIF1	cell-wall inhibitor of beta-fructosidase	glyma.Wm82.gnm2.ann1.Glyma.17g036300
-CIM1	cytokinin induced message	glyma.Wm82.gnm2.ann1.Glyma.01g077000
-CKX1	cytokinin dehydrogenase 1-like	glyma.Wm82.gnm2.ann1.Glyma.03g133300
-CKX3	cytokinin dehydrogenase 3-like	glyma.Wm82.gnm2.ann1.Glyma.17g054500
-CLC-C	anion channel/ voltage-gated chloride channel  	glyma.Wm82.gnm1.ann1.Glyma09g28620
-CLC1	chloride channel	glyma.Wm82.gnm2.ann1.Glyma.05g077100
-CLV1A	receptor protein kinase-like protein	glyma.Wm82.gnm2.ann1.Glyma.11g114100
-COBL1	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.01G240200
-COBL10	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.07G243200
-COBL11	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.08G249700
-COBL12	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.08G249800
-COBL13	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.09G039900
-COBL14	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.11G003300
-COBL15	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.12G213400
-COBL16	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.13G053300
-COBL17	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.13G288300
-COBL18	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.17G030700
-COBL19	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.17G080600
-COBL2	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.02G196100
-COBL20	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.18G271900
-COBL21	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.18G272000
-COBL22	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.18G272100
-COBL23	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.19G033500
-COBL24	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.19G033600
-COBL3	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.04G006100
-COBL4	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.04G160000
-COBL5	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.04G160100
-COBL6	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.05G019100
-COBL7	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.06G005800
-COBL8	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.06G205400
-COBL9	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.06G205500
-COI1	coronatine-insensitive 1	glyma.Wm82.gnm2.ann1.Glyma.11g227300
-COL10	zinc finger protein CONSTANS-LIKE 5-like	glyma.Wm82.gnm2.ann1.Glyma.13g093800
-COL10a	Constans-like 10a	glyma.Wm82.gnm1.ann1.Glyma12g32221
-COL10b	Constans-like 10b	glyma.Wm82.gnm1.ann1.Glyma13g38251
-COL11a	Constans-like 11a	glyma.Wm82.gnm1.ann1.Glyma03g36810
-COL11b	Constans-like 11b	glyma.Wm82.gnm1.ann1.Glyma19g39460
-COL12	zinc finger protein CONSTANS-LIKE 12-like	glyma.Wm82.gnm2.ann1.Glyma.12g196100
-COL12a	Constans-like 12a	glyma.Wm82.gnm1.ann1.Glyma10g02621
-COL13	Constans-like 13	glyma.Wm82.gnm1.ann1.Glyma02g17181
-COL13a	Constans-like 13a	glyma.Wm82.gnm1.ann1.Glyma16g05540
-COL13b	Constans-like 13b	glyma.Wm82.gnm1.ann1.Glyma19g27240
-COL14a, COL7b	Constans-like 7b	glyma.Wm82.gnm1.ann1.Glyma20g24940
-COL15	zinc finger protein CONSTANS-LIKE 13-like	glyma.Wm82.gnm2.ann1.Glyma.03g209800
-COL16	zinc finger protein CONSTANS-LIKE 15	glyma.Wm82.gnm2.ann1.Glyma.16g050900
-COL17	zinc finger protein CONSTANS-LIKE 14-like	glyma.Wm82.gnm2.ann1.Glyma.19g099700
-COL21	CONSTANS-like zinc finger protein	glyma.Wm82.gnm2.ann1.Glyma.07g091400
-COL22	zinc finger protein CONSTANS-LIKE 16-like	glyma.Wm82.gnm2.ann1.Glyma.10g274300
-COL3a	Constans-like 3a	glyma.Wm82.gnm1.ann1.Glyma04g06240
-COL3b	Constans-like 3b	glyma.Wm82.gnm1.ann1.Glyma06g06300
-COL4a	Constans-like 4a	glyma.Wm82.gnm1.ann1.Glyma13g01290
-COL5a	Constans-like 5a	glyma.Wm82.gnm1.ann1.Glyma07g10161
-COL5b	Constans-like 5b	glyma.Wm82.gnm1.ann1.Glyma13g33420
-COL6a	Constans-like 6a	glyma.Wm82.gnm1.ann1.Glyma05g35151
-COL6b	Constans-like 6b	glyma.Wm82.gnm1.ann1.Glyma08g04570
-COL7a	Constans-like 7a	glyma.Wm82.gnm1.ann1.Glyma10g42090
-COL8	Constans-like 8	glyma.Wm82.gnm1.ann1.Glyma02g38870
-COL8b	Constans-like 8b	glyma.Wm82.gnm1.ann1.Glyma14g36930
-COL9	zinc finger protein CONSTANS-LIKE 13-like	glyma.Wm82.gnm2.ann1.Glyma.19g207100
-COL9a	Constans-like 9a	glyma.Wm82.gnm1.ann1.Glyma13g11592
-COL9b	Constans-like 9b	glyma.Wm82.gnm1.ann1.Glyma20g07051
-COP1	Ubiquitin Ligase	glyma.Wm82.gnm2.ann1.Glyma.14G049700
-COP10	constitutive photomorphogenesis protein 10	glyma.Wm82.gnm2.ann1.Glyma.08g113700
-COPE1	epsilon1-COP	glyma.Wm82.gnm2.ann1.Glyma.15g136100
-COPE2	epsilon2-COP	glyma.Wm82.gnm2.ann1.Glyma.09g030400
-COPZ1	nonclathrin coat protein zeta1-COP	glyma.Wm82.gnm2.ann1.Glyma.07g008000
-COPZ2	nonclathrin coat protein zeta2-COP	glyma.Wm82.gnm2.ann1.Glyma.15g125800
-COR1	cold-regulated protein	glyma.Wm82.gnm2.ann1.Glyma.12g047500
-CP3	cysteine proteinase	glyma.Wm82.gnm2.ann1.Glyma.10g207100
-CPIP	Soybean mosaic virus coat protein-interacting protein	glyma.Wm82.gnm2.ann1.Glyma.06g289000
-CPK2, CRK35	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g206300
-CPP1	cysteine-rich polycomb-like protein	glyma.Wm82.gnm2.ann1.Glyma.17g208500
-CPS2, TPS22	terpene synthase 22	glyma.Wm82.gnm2.ann1.Glyma.19g157000
-CPX	coproporphyrinogen oxidase	glyma.Wm82.gnm2.ann1.Glyma.14g003200
-CRK1	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.01g013500
-CRK11	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.08g284100
-CRK12	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.09g150500
-CRK13	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.09g151400
-CRK14	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.09g151700
-CRK15	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10g109200
-CRK16	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10g252700
-CRK17	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10g252800
-CRK18	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10g253000
-CRK19	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10g253100
-CRK2	cysteine-rich receptor-like protein kinase 2	glyma.Wm82.gnm2.ann1.Glyma.01g028100
-CRK20	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10g253200
-CRK21	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10g253300
-CRK23	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10g253900
-CRK24	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10g254300
-CRK25	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g002800
-CRK26	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g204500
-CRK27	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g204700
-CRK28	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g204800
-CRK29	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g204900
-CRK3	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.01g240800
-CRK30	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g205200
-CRK31	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g205300
-CRK32	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g205400
-CRK33	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g205600
-CRK34	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g206100
-CRK36	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g206400
-CRK37	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g206700
-CRK39	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g207000
-CRK4	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.01g240900
-CRK40	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g207300
-CRK41	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g207500
-CRK42	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13g188900
-CRK43	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13g189000
-CRK44	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.15g226500
-CRK45	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.15g226800
-CRK46	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.15g227000
-CRK47	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.16g202200
-CRK48	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.16g202400
-CRK49	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.17g088000
-CRK5	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.01g241000
-CRK50	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g046100
-CRK51	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g046200
-CRK53	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g046400
-CRK54	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g046600
-CRK55	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g141500
-CRK56	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g141700
-CRK57	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g219200
-CRK58	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g219300
-CRK59	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g219600
-CRK6	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.02g037100
-CRK60	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g219700
-CRK61	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g219800
-CRK62	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g237900
-CRK63	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.19g005700
-CRK64	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.19g062300
-CRK65	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g137200
-CRK67	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g137400
-CRK68	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g137500
-CRK69	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g137700
-CRK7	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.02g037200
-CRK70	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g137900
-CRK71	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g138100
-CRK72	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g138400
-CRK73	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g138500
-CRK74	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g138600
-CRK75	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g138800
-CRK76	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g138900
-CRK77	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g139000
-CRK78	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g139100
-CRK79	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g139200
-CRK8	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.04g127100
-CRK81	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g139400
-CRK82	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g139500
-CRK83	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g139600
-CRK84	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g139700
-CRK86	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g140100
-CRK87	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g140200
-CRK88	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g140400
-CRK89	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g140500
-CRK9	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.05g005100
-CRK90	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g140600
-CRK91	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g140700
-CRY1a	Cryptochrome 1a	glyma.Wm82.gnm2.ann1.Glyma.04g101500
-CRY1b1	Cryptochrome 1b1	glyma.Wm82.gnm2.ann1.Glyma.06g103200
-CRY1c1	Cryptochrome 1c1	glyma.Wm82.gnm2.ann1.Glyma.14g174200
-CRY2B	Cryptochrome 2-like	glyma.Wm82.gnm2.ann1.Glyma.02g005700
-CRY2a1	Cryptochrome 2a1	glyma.Wm82.gnm2.ann1.Glyma.10g180600
-CRY2c	Cryptochrome 2c	glyma.Wm82.gnm2.ann1.Glyma.20g209900
-CWINV	beta-fructofuranosidase	glyma.Wm82.gnm2.ann1.Glyma.07g008800
-CYCA1;1	mitotic cyclin a2-type	glyma.Wm82.gnm2.ann1.Glyma.04g246600
-CYCA2;1	mitotic cyclin a2-type	glyma.Wm82.gnm2.ann1.Glyma.04g071600
-CYCA3;1	mitotic cyclin a1-type	glyma.Wm82.gnm2.ann1.Glyma.04g043400
-CYCB1;1	G2/mitotic-specific cyclin S13-6	glyma.Wm82.gnm2.ann1.Glyma.03g123600
-CYCB1;2	G2/mitotic-specific cyclin S13-7	glyma.Wm82.gnm2.ann1.Glyma.19g127200
-CYCB1;3	mitotic cyclin b1-type	glyma.Wm82.gnm2.ann1.Glyma.14g037100
-CYN	Cyanate hydratase	glyma.Wm82.gnm2.ann1.Glyma.10g005200
-CYP, CYP2	peptidyl-prolyl cis-trans isomerase CYP2	glyma.Wm82.gnm2.ann1.Glyma.12g024700
-CYP1	peptidyl-prolyl cis-trans isomerase 1	glyma.Wm82.gnm2.ann1.Glyma.11g098700
-CYP10	peptidyl-prolyl cis-trans isomerase CYP10	glyma.Wm82.gnm2.ann1.Glyma.20g249300
-CYP11	peptidyl-prolyl cis-trans isomerase CYP11	glyma.Wm82.gnm2.ann1.Glyma.19g249000
-CYP12	peptidyl-prolyl cis-trans isomerase CYP12	glyma.Wm82.gnm2.ann1.Glyma.03g225600
-CYP13	peptidyl-prolyl cis-trans isomerase CYP13	glyma.Wm82.gnm2.ann1.Glyma.03g198200
-CYP14	peptidyl-prolyl cis-trans isomerase CYP14	glyma.Wm82.gnm2.ann1.Glyma.19g222600
-CYP15	peptidyl-prolyl cis-trans isomerase CYP15	glyma.Wm82.gnm2.ann1.Glyma.19g196100
-CYP16	peptidyl-prolyl cis-trans isomerase CYP16	glyma.Wm82.gnm2.ann1.Glyma.07g210200
-CYP17	peptidyl-prolyl cis-trans isomerase CYP17	glyma.Wm82.gnm2.ann1.Glyma.02g134800
-CYP18	peptidyl-prolyl cis-trans isomerase CYP18	glyma.Wm82.gnm2.ann1.Glyma.11g047800
-CYP19	peptidyl-prolyl cis-trans isomerase CYP19	glyma.Wm82.gnm2.ann1.Glyma.01g194100
-CYP20	peptidyl-prolyl cis-trans isomerase CYP20	glyma.Wm82.gnm2.ann1.Glyma.13g318300
-CYP21	peptidyl-prolyl cis-trans isomerase CYP21	glyma.Wm82.gnm2.ann1.Glyma.09g090900
-CYP23	peptidyl-prolyl cis-trans isomerase CYP23	glyma.Wm82.gnm2.ann1.Glyma.10g298200
-CYP24	peptidyl-prolyl cis-trans isomerase CYP24	glyma.Wm82.gnm2.ann1.Glyma.18g062900
-CYP25	peptidyl-prolyl cis-trans isomerase CYP25	glyma.Wm82.gnm2.ann1.Glyma.18g027400
-CYP26	peptidyl-prolyl cis-trans isomerase CYP26	glyma.Wm82.gnm2.ann1.Glyma.11g229800
-CYP27	peptidyl-prolyl cis-trans isomerase CYP27	glyma.Wm82.gnm2.ann1.Glyma.19g160200
-CYP28	peptidyl-prolyl cis-trans isomerase CYP28	glyma.Wm82.gnm2.ann1.Glyma.10g139500
-CYP29	peptidyl-prolyl cis-trans isomerase CYP29	glyma.Wm82.gnm2.ann1.Glyma.18g248100
-CYP3	peptidyl-prolyl cis-trans isomerase CYP3	glyma.Wm82.gnm2.ann1.Glyma.06g005100
-CYP30	peptidyl-prolyl cis-trans isomerase CYP30	glyma.Wm82.gnm2.ann1.Glyma.09g245200
-CYP31	peptidyl-prolyl cis-trans isomerase CYP31	glyma.Wm82.gnm2.ann1.Glyma.01g204300
-CYP32	peptidyl-prolyl cis-trans isomerase CYP32	glyma.Wm82.gnm2.ann1.Glyma.11g038700
-CYP33	peptidyl-prolyl cis-trans isomerase CYP33	glyma.Wm82.gnm2.ann1.Glyma.17g148700
-CYP34	peptidyl-prolyl cis-trans isomerase CYP34	glyma.Wm82.gnm2.ann1.Glyma.11g175200
-CYP35	peptidyl-prolyl cis-trans isomerase CYP35	glyma.Wm82.gnm2.ann1.Glyma.12g182700
-CYP36	peptidyl-prolyl cis-trans isomerase CYP36	glyma.Wm82.gnm2.ann1.Glyma.03g157900
-CYP37	peptidyl-prolyl cis-trans isomerase CYP37	glyma.Wm82.gnm2.ann1.Glyma.17g218800
-CYP39	peptidyl-prolyl cis-trans isomerase CYP39	glyma.Wm82.gnm2.ann1.Glyma.04g004300
-CYP4	peptidyl-prolyl cis-trans isomerase CYP4	glyma.Wm82.gnm2.ann1.Glyma.04g005300
-CYP40	peptidyl-prolyl cis-trans isomerase CYP40	glyma.Wm82.gnm2.ann1.Glyma.12g031500
-CYP41	peptidyl-prolyl cis-trans isomerase CYP41	glyma.Wm82.gnm2.ann1.Glyma.11g106400
-CYP42	peptidyl-prolyl cis-trans isomerase CYP42	glyma.Wm82.gnm2.ann1.Glyma.01g144800
-CYP43	peptidyl-prolyl cis-trans isomerase CYP43	glyma.Wm82.gnm2.ann1.Glyma.06g070300
-CYP45	peptidyl-prolyl cis-trans isomerase CYP45	glyma.Wm82.gnm2.ann1.Glyma.02g105500
-CYP46	peptidyl-prolyl cis-trans isomerase CYP46	glyma.Wm82.gnm2.ann1.Glyma.04g068700
-CYP47	peptidyl-prolyl cis-trans isomerase CYP47	glyma.Wm82.gnm2.ann1.Glyma.05g014300
-CYP48	peptidyl-prolyl cis-trans isomerase CYP48	glyma.Wm82.gnm2.ann1.Glyma.06g249300
-CYP49	peptidyl-prolyl cis-trans isomerase CYP49	glyma.Wm82.gnm2.ann1.Glyma.07g157800
-CYP50	peptidyl-prolyl cis-trans isomerase CYP50	glyma.Wm82.gnm2.ann1.Glyma.09g095400
-CYP51	peptidyl-prolyl cis-trans isomerase CYP51	glyma.Wm82.gnm2.ann1.Glyma.10g206100
-CYP52	peptidyl-prolyl cis-trans isomerase CYP52	glyma.Wm82.gnm2.ann1.Glyma.12g148600
-CYP53	peptidyl-prolyl cis-trans isomerase CYP53	glyma.Wm82.gnm2.ann1.Glyma.13g169500
-CYP54	peptidyl-prolyl cis-trans isomerase CYP54	glyma.Wm82.gnm2.ann1.Glyma.14g125200
-CYP55	peptidyl-prolyl cis-trans isomerase CYP55	glyma.Wm82.gnm2.ann1.Glyma.15g202300
-CYP56	peptidyl-prolyl cis-trans isomerase CYP56	glyma.Wm82.gnm2.ann1.Glyma.15g213200
-CYP57	peptidyl-prolyl cis-trans isomerase CYP57	glyma.Wm82.gnm2.ann1.Glyma.15g231800
-CYP58	peptidyl-prolyl cis-trans isomerase CYP58	glyma.Wm82.gnm2.ann1.Glyma.17g122500
-CYP59	peptidyl-prolyl cis-trans isomerase CYP59	glyma.Wm82.gnm2.ann1.Glyma.19g004200
-CYP6	peptidyl-prolyl cis-trans isomerase CYP6	glyma.Wm82.gnm2.ann1.Glyma.15g242500
-CYP60	peptidyl-prolyl cis-trans isomerase CYP60	glyma.Wm82.gnm2.ann1.Glyma.19g009700
-CYP61	peptidyl-prolyl cis-trans isomerase CYP61	glyma.Wm82.gnm2.ann1.Glyma.20g005600
-CYP62	peptidyl-prolyl cis-trans isomerase CYP62	glyma.Wm82.gnm2.ann1.Glyma.20g184400
-CYP7	peptidyl-prolyl cis-trans isomerase CYP7	glyma.Wm82.gnm2.ann1.Glyma.03g251600
-CYP701A16	ent-kaurene oxidase, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.13g371400
-CYP707A1A	abscisic acid 8'-hydroxylase 1	glyma.Wm82.gnm2.ann1.Glyma.09g218600
-CYP71A10	cytochrome P450 71A10	glyma.Wm82.gnm2.ann1.Glyma.06g176100
-CYP71A9	cytochrome P450 71A9-like	glyma.Wm82.gnm2.ann1.Glyma.05g042800
-CYP71D10	cytochrome P450 CYP71D10	glyma.Wm82.gnm2.ann1.Glyma.15g050300
-CYP72A67	cytochrome P450 72A15	glyma.Wm82.gnm2.ann1.Glyma.08g238100
-CYP72A69	11-oxo-beta-amyrin 30-oxidase	glyma.Wm82.gnm2.ann1.Glyma.15g243300
-CYP74A1	allene oxide synthase, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.07g162900
-CYP76O2	7-ethoxycoumarin O-deethylase-like	glyma.Wm82.gnm2.ann1.Glyma.10g200800
-CYP77A3	Cytochrome P450 77A3	glyma.Wm82.gnm2.ann1.Glyma.20g188000
-CYP78A10	cytochrome P450 family protein CYP78A10	glyma.Wm82.gnm2.ann1.Glyma.05g019200
-CYP8	peptidyl-prolyl cis-trans isomerase CYP8	glyma.Wm82.gnm2.ann1.Glyma.05g080800
-CYP81D3	oxygen binding 	glyma.Wm82.gnm1.ann1.Glyma09g05440
-CYP81D5	oxygen binding 	glyma.Wm82.gnm1.ann1.Glyma11g09880
-CYP82A2	cytochrome P450 82A2-like	glyma.Wm82.gnm2.ann1.Glyma.13g285300
-CYP82A3	cytochrome P450 82A3-like	glyma.Wm82.gnm2.ann1.Glyma.13g068800
-CYP82C1	cytochrome P450 CYP82C1	glyma.Wm82.gnm2.ann1.Glyma.11g060100
-CYP83D1	cytochrome P450 monooxygenase CYP83D1	glyma.Wm82.gnm2.ann1.Glyma.17g255900
-CYP83E8	cytochrome P450 83B1-like	glyma.Wm82.gnm2.ann1.Glyma.03g029900
-CYP9	peptidyl-prolyl cis-trans isomerase CYP9	glyma.Wm82.gnm2.ann1.Glyma.17g177600
-CYP90A15	cytochrome P450 90A1	glyma.Wm82.gnm2.ann1.Glyma.11g228900
-CYP93A1	3,9-dihydroxypterocarpan 6A-monooxygenase	glyma.Wm82.gnm2.ann1.Glyma.03g143700
-CYP93A2	Cytochrome P450 93A2	glyma.Wm82.gnm2.ann1.Glyma.19g144700
-CYP93A3	cytochrome P450 93A3	glyma.Wm82.gnm2.ann1.Glyma.03g142100
-CYP93E1	beta-amyrin and sophoradiol 24-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.08g350800
-CYP94D24	cytochrome P450 94A1	glyma.Wm82.gnm2.ann1.Glyma.03g122300
-CYP97B2	Cytochrome P450 97B2	glyma.Wm82.gnm2.ann1.Glyma.11g016200
-CYP97C10	protein LUTEIN DEFICIENT 5, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.18g239900
-CYP98A2	cytochrome P450 98A2	glyma.Wm82.gnm2.ann1.Glyma.19g126000
-CYSP1	cysteine proteinase	glyma.Wm82.gnm2.ann1.Glyma.04g190700
-CYSP2	cysteine proteinase	glyma.Wm82.gnm2.ann1.Glyma.06g174800
-CYSTATIN	cysteine proteinase inhibitor	glyma.Wm82.gnm2.ann1.Glyma.15g227500
-Cdk8-1	Cyclin-dependent kinase 8 gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g207900
-Cdk8-2	Cyclin-dependent kinase 8 gene 2	glyma.Wm82.gnm2.ann1.Glyma.05g145800
-Cdk8-3	Cyclin-dependent kinase 8 gene 3	glyma.Wm82.gnm2.ann1.Glyma.05g195300
-Cdk8-4	Cyclin-dependent kinase 8 gene 4	glyma.Wm82.gnm2.ann1.Glyma.08g002900
-Cdk8-5	Cyclin-dependent kinase 8 gene 6	glyma.Wm82.gnm2.ann1.Glyma.08g102600
-CrRI,k1l,08	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.09G024700
-CrRI,k1l,09	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.09G133000
-CrRLk1L01	CrRLK1-Like Kinase 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02G121900
-CrRLk1L02	CrRLK1-Like Kinase 1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.02G122000
-CrRLk1L03	CrRLK1-Like Kinase 1 gene 3	glyma.Wm82.gnm2.ann1.Glyma.03G247800
-CrRLk1L04	CrRLK1-Like Kinase 1 gene 4	glyma.Wm82.gnm2.ann1.Glyma.05G099900
-CrRLk1L05	CrRLK1-Like Kinase 1 gene 5	glyma.Wm82.gnm2.ann1.Glyma.08G248900
-CrRLk1L06	CrRLK1-Like Kinase 1 gene 6	glyma.Wm82.gnm2.ann1.Glyma.08G249200
-CrRLk1L07	CrRLK1-Like Kinase 1 gene 7	glyma.Wm82.gnm2.ann1.Glyma.08G249400
-CrRLk1L12	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10G231500
-CrRLk1L14	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.12G148200
-CrRLk1L15	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.12G220400
-CrRLk1L16	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.12G235900
-CrRLk1L25	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.16G179600
-CrRLk1L29	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G269900
-CrRLk1L31	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G270600
-CrRLkUGo	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G054200
-CrRRk1R1 1	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10G163200
-CrRRk1R1 3	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.12G074600
-CrRRk1R10	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.09G273300
-CycC-1	Cyclin C gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g347600
-CycC-2	Cyclin C gene 2	glyma.Wm82.gnm2.ann1.Glyma.18g159000
-D-II	Bowman-Birk proteinase isoinhibitor D-II	glyma.Wm82.gnm2.ann1.Glyma.16g208900
-D1	D1	glyma.Wm82.gnm1.ann1.Glyma01g42390
-D14	alpha/beta hydroxylase D14	glyma.Wm82.gnm2.ann1.Glyma.17g235300
-D2	D2	glyma.Wm82.gnm1.ann1.Glyma11g02980
-DAD1	dolichyl-diphosphooligosaccharide--protein glycosyltransferase subunit DAD1	glyma.Wm82.gnm2.ann1.Glyma.14g201900
-DAGL	Diacylglycerol lipase	glyma.Wm82.gnm1.ann1.Glyma09G34250
-DAO	copper amino oxidase	glyma.Wm82.gnm2.ann1.Glyma.17g019300
-DBB	DBB protein	glyma.Wm82.gnm2.ann1.Glyma.15g029500
-DCL2, DCL2B	endoribonuclease dicer-like 2b	glyma.Wm82.gnm2.ann1.Glyma.09g025300
-DCL2A	endoribonuclease dicer-like 2a	glyma.Wm82.gnm2.ann1.Glyma.09g025400
-DCL3A	endoribonuclease dicer-like 3a	glyma.Wm82.gnm2.ann1.Glyma.04g057400
-DD2/63	expansin	glyma.Wm82.gnm2.ann1.Glyma.06g143300
-DDKCS	3-ketoacyl-CoA synthase 4-like	glyma.Wm82.gnm2.ann1.Glyma.14g074300
-DEHYDRIN, MAT9	Maturation-associated protein 9 gene	glyma.Wm82.gnm2.ann1.Glyma.09g185500
-DEP1	dense and erect panicle 1	glyma.Wm82.gnm2.ann1.Glyma.17g048600
-DES1.1	sphingolipid delta(4)-desaturase DES1-like	glyma.Wm82.gnm2.ann1.Glyma.13g240700
-DES1.2	sphingolipid delta(4)-desaturase DES1-like	glyma.Wm82.gnm2.ann1.Glyma.15g072800
-DET2	Steroid reductase	glyma.Wm82.gnm2.ann1.Glyma.11G110300
-DFR	dihydroflavanol reductase	glyma.Wm82.gnm2.ann1.Glyma.17g173200
-DFR1, DHFR1, W3	White flower 3	glyma.Wm82.gnm2.ann1.Glyma.14g072700
-DFR2, DHFR2, W4	White flower 4	glyma.Wm82.gnm2.ann1.Glyma.17g252200
-DGAT1C	diacylglycerol acyltransferase 1 gene C	glyma.Wm82.gnm1.ann1.Glyma09g07520
-DGAT2A	diacylglycerol acyltransferase 2 gene A	glyma.Wm82.gnm1.ann1.Glyma09g32790
-DGAT2B	diacylglycerol acyltransferase 2 gene B	glyma.Wm82.gnm1.ann1.Glyma16g21960
-DGAT2C	diacylglycerol acyltransferase 2 gene C	glyma.Wm82.gnm1.ann1.Glyma16g21970
-DGAT2D	diacylglycerol acyltransferase 2 gene D	glyma.Wm82.gnm1.ann1.Glyma01g36010
-DGAT2E	diacylglycerol acyltransferase 2 gene E	glyma.Wm82.gnm1.ann1.Glyma11g09410
-DGAT3A	diacylglycerol acyltransferase 3 gene A	glyma.Wm82.gnm1.ann1.Glyma17g04650
-DGAT3B	diacylglycerol acyltransferase 3 gene B	glyma.Wm82.gnm1.ann1.Glyma13g17860
-DGD1	digalactosyldiacylglycerol synthase 1	glyma.Wm82.gnm2.ann1.Glyma.19g200000
-DGD2	digalactosyldiacylglycerol synthase 2	glyma.Wm82.gnm2.ann1.Glyma.18g228900
-DGK10	diacylglycerol kinase 10	glyma.Wm82.gnm2.ann1.Glyma.17g067400
-DGK11	diacylglycerol kinase 11	glyma.Wm82.gnm2.ann1.Glyma.17g077100
-DGK12	diacylglycerol kinase 12	glyma.Wm82.gnm2.ann1.Glyma.05g022500
-DGK3	diacylglycerol kinase 3	glyma.Wm82.gnm2.ann1.Glyma.12g200100
-DGK4	diacylglycerol kinase 4	glyma.Wm82.gnm2.ann1.Glyma.06g299200
-DGK5	diacylglycerol kinase 5	glyma.Wm82.gnm2.ann1.Glyma.06g223900
-DGK6	diacylglycerol kinase 6	glyma.Wm82.gnm2.ann1.Glyma.04g143000
-DGK7	diacylglycerol kinase 7	glyma.Wm82.gnm2.ann1.Glyma.13g093100
-DGK8	diacylglycerol kinase 8	glyma.Wm82.gnm2.ann1.Glyma.06g254900
-DGK9	diacylglycerol kinase 9	glyma.Wm82.gnm2.ann1.Glyma.12g146700
-DHAR-1a, DHAR1, MDHAR-1a	DEHYDROASCORBATE REDUCTASE 1 gene a	glyma.Wm82.gnm2.ann1.Glyma.10G291100
-DHAR-1b, DHAR4, MDHAR-1b	DEHYDROASCORBATE REDUCTASE 1 gene b	glyma.Wm82.gnm2.ann1.Glyma.20G240300
-DHAR-3a, DHAR3, MDHAR-3a	DEHYDROASCORBATE REDUCTASE 3 gene a	glyma.Wm82.gnm2.ann1.Glyma.18G040100
-DHAR-3b, DHAR2	DHAR class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.11g216400
-DHBK	putative 3,4-dihydroxy-2-butanone kinase	glyma.Wm82.gnm2.ann1.Glyma.07g107100
-DHFR-TS	bifunctional dihydrofolate reductase-thymidylate synthase	glyma.Wm82.gnm2.ann1.Glyma.06g010600
-DHPS1	dihydrodipicolinate synthase	glyma.Wm82.gnm2.ann1.Glyma.18g221700
-DIM1	DIM 1-like protein	glyma.Wm82.gnm2.ann1.Glyma.09g283300
-DIN1	asparagine	glyma.Wm82.gnm1.ann1.Glyma11g27480
-DIR22	dirigent protein 22	glyma.Wm82.gnm2.ann1.Glyma.01g127200
-DMT1	ferrous ion membrane transport protein DMT1	glyma.Wm82.gnm2.ann1.Glyma.17g165200
-DNAJ	chaperone protein DnaJ-like	glyma.Wm82.gnm2.ann1.Glyma.03g232700
-DOF10	dof zinc finger protein DOF1.5-like	glyma.Wm82.gnm2.ann1.Glyma.13g230200
-DPB3-1	dr1-associated corepressor	glyma.Wm82.gnm2.ann1.Glyma.11g250000
-DPB3-2	dr1-associated corepressor-like	glyma.Wm82.gnm2.ann1.Glyma.18g007100
-DR1	class 2 transcription repressor NC2 beta 2	glyma.Wm82.gnm2.ann1.Glyma.06g209000
-DRB2A	dsRNA-binding protein Drb2a	glyma.Wm82.gnm2.ann1.Glyma.12g075700
-DRB2B	dsRNA-binding protein Drb2b	glyma.Wm82.gnm2.ann1.Glyma.11g145900
-DREB	dehydration-responsive element-binding protein	glyma.Wm82.gnm2.ann1.Glyma.13g304300
-DREB1	dehydration responsive element binding protein	glyma.Wm82.gnm2.ann1.Glyma.14g084700
-DREB1-like	CRT binding factor 1	glyma.Wm82.gnm2.ann1.Glyma.09g147200
-DREB2	ethylene-responsive transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g137600
-DREB2A2	dehydration-responsive element-binding protein 2A2	glyma.Wm82.gnm2.ann1.Glyma.14g056200
-DREB3	dehydration responsive element-binding protein 3	glyma.Wm82.gnm2.ann1.Glyma.04g103900
-DREB5	dehydration-responsive element binding protein 5	glyma.Wm82.gnm2.ann1.Glyma.12g203100
-DREBA	DREBa transcription factor	glyma.Wm82.gnm2.ann1.Glyma.12g103100
-DRM1	DORMANCY-ASSOCIATED PROTEIN 1	glyma.Wm82.gnm1.ann1.Glyma15g08300
-DRR2	disease resitance-responsive 2protein	glyma.Wm82.gnm2.ann1.Glyma.11g150300
-DRR3	disease resitance-responsive 3 protein	glyma.Wm82.gnm2.ann1.Glyma.11g150700
-DXR1	1-deoxy-D-xylulose 5-phosphate reductoisomerase, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.05g037500
-DXR2	putative 1-deoxy-D-xylulose 5-phosphate reductoisomerase	glyma.Wm82.gnm2.ann1.Glyma.16g089000
-DXS1	1-deoxy-D-xylulose 5-phosphate synthase 1	glyma.Wm82.gnm2.ann1.Glyma.07g252600
-E1LA	B3 domain-containing protein E1La	glyma.Wm82.gnm2.ann1.Glyma.04g156400
-E1LB	B3 domain-containing protein E1Lb	glyma.Wm82.gnm2.ann1.Glyma.04g143300
-E9-1, FT2a (E9), FTL3	Flowering locus T-like gene 3	glyma.Wm82.gnm2.ann1.Glyma.16g150700
-EBP, ERF8	Ethylene-responsive factor gene 8	glyma.Wm82.gnm2.ann1.Glyma.02G016100
-EDR1	serine/threonine-protein kinase EDR1	glyma.Wm82.gnm2.ann1.Glyma.10g159200
-EDS1	Enhanced disease susceptibility 1	glyma.Wm82.gnm2.ann1.Glyma.06G187300
-EDS1a	Enhanced disease susceptibility 1 gene b	glyma.Wm82.gnm1.ann1.Glyma04g34800
-EDS1b	Enhanced disease susceptibility 1 gene a	glyma.Wm82.gnm1.ann1.Glyma06g19920
-EDS5	MATE efflux family protein 4, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.11g112100
-EF1BGAMMA1	elongation factor 1-gamma-like	glyma.Wm82.gnm2.ann1.Glyma.07g273500
-EF1BGAMMA2	elongation factor 1-gamma-like	glyma.Wm82.gnm2.ann1.Glyma.12g165500
-EF1BGAMMA3	EF1Bgamma class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.16g001900
-EF1BGAMMA4	elongation factor 1-gamma	glyma.Wm82.gnm2.ann1.Glyma.17g001400
-EF4	elongation factor 1-alpha	glyma.Wm82.gnm2.ann1.Glyma.05g114900
-EIF5A	eukaryotic translation initiation factor 5A	glyma.Wm82.gnm2.ann1.Glyma.02g112400
-EIN4	GAF/HisKA/CheY-like REC domain-containing protein	glyma.Wm82.gnm2.ann1.Glyma.10g167300
-EKN	EKN protein	glyma.Wm82.gnm2.ann1.Glyma.05g121700
-ELF3A	protein EARLY FLOWERING 3a	glyma.Wm82.gnm2.ann1.Glyma.04g050200
-ELF3B	protein EARLY FLOWERING 3b	glyma.Wm82.gnm2.ann1.Glyma.14g091900
-ELF4A	protein EARLY FLOWERING 4a	glyma.Wm82.gnm2.ann1.Glyma.11g229700
-ELF4B	protein EARLY FLOWERING 4b	glyma.Wm82.gnm2.ann1.Glyma.18g027500
-ELIP	early light-induced protein	glyma.Wm82.gnm2.ann1.Glyma.20g150600
-ELO	Catalytic histone acetyltransferase subunit of the RNA polymerase II elongator complex	glyma.Wm82.gnm1.ann1.Glyma06G18150
-EN1	endonuclease	glyma.Wm82.gnm2.ann1.Glyma.15g068600
-EN2	endonuclease	glyma.Wm82.gnm2.ann1.Glyma.07g050300
-ENOD55-2	early nodulin	glyma.Wm82.gnm2.ann1.Glyma.17g073400
-ENOD93	early nodulin-93	glyma.Wm82.gnm2.ann1.Glyma.06g216500
-ERA1A	farnesyltransferase	glyma.Wm82.gnm2.ann1.Glyma.06g185500
-ERA1B	farnesyltransferase ERA1B	glyma.Wm82.gnm2.ann1.Glyma.13g168600
-ERD15A	Responsive to Desication 15 gene A	glyma.Wm82.gnm1.ann1.Glyma04g28560
-ERD15C	Responsive to Desication 15 gene C	glyma.Wm82.gnm1.ann1.Glyma02g42860
-ERD15D	Responsive to Desication 15 gene D	glyma.Wm82.gnm1.ann1.Glyma14g05980
-EREB, ERF124	Ethylene-responsive factor gene 124	glyma.Wm82.gnm2.ann1.Glyma.16G012600
-EREBP1, ERF141	Ethylene-responsive factor gene 141	glyma.Wm82.gnm2.ann1.Glyma.18G252300
-ERF1	Ethylene-responsive factor gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G025400
-ERF10	Ethylene-responsive factor gene 10	glyma.Wm82.gnm2.ann1.Glyma.02G066200
-ERF100	Ethylene-responsive factor gene 100	glyma.Wm82.gnm2.ann1.Glyma.13G122800
-ERF101	Ethylene-responsive factor gene 101	glyma.Wm82.gnm2.ann1.Glyma.13G122900
-ERF102	Ethylene-responsive factor gene 102	glyma.Wm82.gnm2.ann1.Glyma.13G123000
-ERF103	Ethylene-responsive factor gene 103	glyma.Wm82.gnm2.ann1.Glyma.13G123100
-ERF105	Ethylene-responsive factor gene 105	glyma.Wm82.gnm2.ann1.Glyma.13G233800
-ERF106	Ethylene-responsive factor gene 106	glyma.Wm82.gnm2.ann1.Glyma.13G233900
-ERF107	Ethylene-responsive factor gene 107	glyma.Wm82.gnm2.ann1.Glyma.13G236500
-ERF108	Ethylene-responsive factor gene 108	glyma.Wm82.gnm2.ann1.Glyma.13G236600
-ERF109	Ethylene-responsive factor gene 109	glyma.Wm82.gnm2.ann1.Glyma.13G274100
-ERF11	Ethylene-responsive factor gene 11	glyma.Wm82.gnm2.ann1.Glyma.02G067600
-ERF110	Ethylene-responsive factor gene 110	glyma.Wm82.gnm2.ann1.Glyma.13G369400
-ERF111	Ethylene-responsive factor gene 111	glyma.Wm82.gnm2.ann1.Glyma.14G020100
-ERF112	Ethylene-responsive factor gene 112	glyma.Wm82.gnm2.ann1.Glyma.14G050100
-ERF113	Ethylene-responsive factor gene 113	glyma.Wm82.gnm2.ann1.Glyma.14G111600
-ERF114	Ethylene-responsive factor gene 114	glyma.Wm82.gnm2.ann1.Glyma.14G123900
-ERF116	Ethylene-responsive factor gene 116	glyma.Wm82.gnm2.ann1.Glyma.15G004200
-ERF117	Ethylene-responsive factor gene 117	glyma.Wm82.gnm2.ann1.Glyma.15G008600
-ERF118	Ethylene-responsive factor gene 118	glyma.Wm82.gnm2.ann1.Glyma.15G077000
-ERF119	Ethylene-responsive factor gene 119	glyma.Wm82.gnm2.ann1.Glyma.15G077100
-ERF12	Ethylene-responsive factor gene 12	glyma.Wm82.gnm2.ann1.Glyma.02G072800
-ERF120	Ethylene-responsive factor gene 120	glyma.Wm82.gnm2.ann1.Glyma.15G079100
-ERF121	Ethylene-responsive factor gene 121	glyma.Wm82.gnm2.ann1.Glyma.15G079200
-ERF122	Ethylene-responsive factor gene 122	glyma.Wm82.gnm2.ann1.Glyma.15G152000
-ERF123	Ethylene-responsive factor gene 123	glyma.Wm82.gnm2.ann1.Glyma.15G159200
-ERF125	Ethylene-responsive factor gene 125	glyma.Wm82.gnm2.ann1.Glyma.16G040000
-ERF126	Ethylene-responsive factor gene 126	glyma.Wm82.gnm2.ann1.Glyma.16G046300
-ERF127	Ethylene-responsive factor gene 127	glyma.Wm82.gnm2.ann1.Glyma.16G047600
-ERF128	Ethylene-responsive factor gene 128	glyma.Wm82.gnm2.ann1.Glyma.16G147500
-ERF129	Ethylene-responsive factor gene 129	glyma.Wm82.gnm2.ann1.Glyma.16G148700
-ERF13	Ethylene-responsive factor gene 13	glyma.Wm82.gnm2.ann1.Glyma.02G080200
-ERF130	Ethylene-responsive factor gene 130	glyma.Wm82.gnm2.ann1.Glyma.16G154100
-ERF131	Ethylene-responsive factor gene 131	glyma.Wm82.gnm2.ann1.Glyma.16G164800
-ERF132	Ethylene-responsive factor gene 132	glyma.Wm82.gnm2.ann1.Glyma.17G024300
-ERF133	Ethylene-responsive factor gene 133	glyma.Wm82.gnm2.ann1.Glyma.17G114500
-ERF134	Ethylene-responsive factor gene 134	glyma.Wm82.gnm2.ann1.Glyma.17G124100
-ERF135	Ethylene-responsive factor gene 135	glyma.Wm82.gnm2.ann1.Glyma.17G145300
-ERF136	Ethylene-responsive factor gene 136	glyma.Wm82.gnm2.ann1.Glyma.17G145400
-ERF137	Ethylene-responsive factor gene 137	glyma.Wm82.gnm2.ann1.Glyma.17G210500
-ERF138	Ethylene-responsive factor gene 138	glyma.Wm82.gnm2.ann1.Glyma.18G091600
-ERF139	Ethylene-responsive factor gene 139	glyma.Wm82.gnm2.ann1.Glyma.18G144700
-ERF14	Ethylene-responsive factor gene 14	glyma.Wm82.gnm2.ann1.Glyma.02G132500
-ERF140	Ethylene-responsive factor gene 140	glyma.Wm82.gnm2.ann1.Glyma.18G252200
-ERF142	Ethylene-responsive factor gene 142	glyma.Wm82.gnm2.ann1.Glyma.18G281400
-ERF143	Ethylene-responsive factor gene 143	glyma.Wm82.gnm2.ann1.Glyma.19G026000
-ERF144	Ethylene-responsive factor gene 144	glyma.Wm82.gnm2.ann1.Glyma.19G104200
-ERF145, ERN	ethylene-responsive transcription factor ERN1	glyma.Wm82.gnm2.ann1.Glyma.19g113100
-ERF146	Ethylene-responsive factor gene 146	glyma.Wm82.gnm2.ann1.Glyma.19G163700
-ERF147	Ethylene-responsive factor gene 147	glyma.Wm82.gnm2.ann1.Glyma.19G163900
-ERF148	Ethylene-responsive factor gene 148	glyma.Wm82.gnm2.ann1.Glyma.19G164100
-ERF149	Ethylene-responsive factor gene 149	glyma.Wm82.gnm2.ann1.Glyma.19G213100
-ERF15	Ethylene-responsive factor gene 15	glyma.Wm82.gnm2.ann1.Glyma.02G236800
-ERF150	Ethylene-responsive factor gene 150	glyma.Wm82.gnm2.ann1.Glyma.19G253100
-ERF151	Ethylene-responsive factor gene 151	glyma.Wm82.gnm2.ann1.Glyma.19G262700
-ERF152	Ethylene-responsive factor gene 152	glyma.Wm82.gnm2.ann1.Glyma.20G031000
-ERF153	Ethylene-responsive factor gene 153	glyma.Wm82.gnm2.ann1.Glyma.20G070000
-ERF154	Ethylene-responsive factor gene 154	glyma.Wm82.gnm2.ann1.Glyma.20G070100
-ERF155	Ethylene-responsive factor gene 155	glyma.Wm82.gnm2.ann1.Glyma.20G115300
-ERF156	Ethylene-responsive factor gene 156	glyma.Wm82.gnm2.ann1.Glyma.20G168500
-ERF157	Ethylene-responsive factor gene 157	glyma.Wm82.gnm2.ann1.Glyma.20G195900
-ERF158	Ethylene-responsive factor gene 158	glyma.Wm82.gnm2.ann1.Glyma.20G203500
-ERF159	Ethylene-responsive factor gene 159	glyma.Wm82.gnm2.ann1.Glyma.20G203600
-ERF16	Ethylene-responsive factor gene 16	glyma.Wm82.gnm2.ann1.Glyma.02G267400
-ERF160	Ethylene-responsive factor gene 160	glyma.Wm82.gnm2.ann1.Glyma.20G203700
-ERF17	Ethylene-responsive factor gene 17	glyma.Wm82.gnm2.ann1.Glyma.02G294100
-ERF18	Ethylene-responsive factor gene 18	glyma.Wm82.gnm2.ann1.Glyma.03G094700
-ERF19	Ethylene-responsive factor gene 19	glyma.Wm82.gnm2.ann1.Glyma.03G111700
-ERF2	Ethylene-responsive factor gene  2	glyma.Wm82.gnm2.ann1.Glyma.01G081100
-ERF20	Ethylene-responsive factor gene 20	glyma.Wm82.gnm2.ann1.Glyma.03G112000
-ERF21	Ethylene-responsive factor gene 21	glyma.Wm82.gnm2.ann1.Glyma.03G112400
-ERF22	Ethylene-responsive factor gene 22	glyma.Wm82.gnm2.ann1.Glyma.03G112700
-ERF23	Ethylene-responsive factor gene 23	glyma.Wm82.gnm2.ann1.Glyma.03G112800
-ERF24	Ethylene-responsive factor gene 24	glyma.Wm82.gnm2.ann1.Glyma.03G162500
-ERF25	Ethylene-responsive factor gene 25	glyma.Wm82.gnm2.ann1.Glyma.03G162600
-ERF26	Ethylene-responsive factor gene 26	glyma.Wm82.gnm2.ann1.Glyma.03G255500
-ERF27	Ethylene-responsive factor gene 27	glyma.Wm82.gnm2.ann1.Glyma.03G263700
-ERF28	Ethylene-responsive factor gene 28	glyma.Wm82.gnm2.ann1.Glyma.04G062900
-ERF29	Ethylene-responsive factor gene 29	glyma.Wm82.gnm2.ann1.Glyma.04G067200
-ERF30	Ethylene-responsive factor gene 30	glyma.Wm82.gnm2.ann1.Glyma.04G147500
-ERF31	Ethylene-responsive factor gene 31	glyma.Wm82.gnm2.ann1.Glyma.04G151100
-ERF32	Ethylene-responsive factor gene 32	glyma.Wm82.gnm2.ann1.Glyma.04G201700
-ERF33	Ethylene-responsive factor gene 33	glyma.Wm82.gnm2.ann1.Glyma.04G201900
-ERF34	Ethylene-responsive factor gene 34	glyma.Wm82.gnm2.ann1.Glyma.04G217400
-ERF35	Ethylene-responsive factor gene 35	glyma.Wm82.gnm2.ann1.Glyma.04G238700
-ERF36	Ethylene-responsive factor gene 36	glyma.Wm82.gnm2.ann1.Glyma.05G063500
-ERF37	Ethylene-responsive factor gene 37	glyma.Wm82.gnm2.ann1.Glyma.05G063600
-ERF38	Ethylene-responsive factor gene 38	glyma.Wm82.gnm2.ann1.Glyma.05G157400
-ERF39	Ethylene-responsive factor gene 39	glyma.Wm82.gnm2.ann1.Glyma.05G186700
-ERF4	Ethylene-responsive factor gene 4	glyma.Wm82.gnm2.ann1.Glyma.01G206700
-ERF40	Ethylene-responsive factor gene 40	glyma.Wm82.gnm2.ann1.Glyma.05G200100
-ERF41	Ethylene-responsive factor gene 41	glyma.Wm82.gnm2.ann1.Glyma.05G214400
-ERF42	Ethylene-responsive factor gene 42	glyma.Wm82.gnm2.ann1.Glyma.06G064000
-ERF43	Ethylene-responsive factor gene 43	glyma.Wm82.gnm2.ann1.Glyma.06G068800
-ERF45	Ethylene-responsive factor gene 45	glyma.Wm82.gnm2.ann1.Glyma.06G125100
-ERF46	Ethylene-responsive factor gene 46	glyma.Wm82.gnm2.ann1.Glyma.06G148400
-ERF47	Ethylene-responsive factor gene 47	glyma.Wm82.gnm2.ann1.Glyma.06G163700
-ERF48	Ethylene-responsive factor gene 48	glyma.Wm82.gnm2.ann1.Glyma.06G221800
-ERF49	Ethylene-responsive factor gene 49	glyma.Wm82.gnm2.ann1.Glyma.06G236400
-ERF50	Ethylene-responsive factor gene 50	glyma.Wm82.gnm2.ann1.Glyma.06G290000
-ERF51	Ethylene-responsive factor gene 51	glyma.Wm82.gnm2.ann1.Glyma.07G031200
-ERF52	Ethylene-responsive factor gene 52	glyma.Wm82.gnm2.ann1.Glyma.07G044300
-ERF53	Ethylene-responsive factor gene 53	glyma.Wm82.gnm2.ann1.Glyma.07G113800
-ERF54	Ethylene-responsive factor gene 54	glyma.Wm82.gnm2.ann1.Glyma.07G114000
-ERF55	Ethylene-responsive factor gene 55	glyma.Wm82.gnm2.ann1.Glyma.07G114300
-ERF56	Ethylene-responsive factor gene 56	glyma.Wm82.gnm2.ann1.Glyma.07G212400
-ERF57	Ethylene-responsive factor gene 57	glyma.Wm82.gnm2.ann1.Glyma.07G250100
-ERF58	Ethylene-responsive factor gene 58	glyma.Wm82.gnm2.ann1.Glyma.08G020900
-ERF59	Ethylene-responsive factor gene 59	glyma.Wm82.gnm2.ann1.Glyma.08G040900
-ERF60	Ethylene-responsive factor gene 60	glyma.Wm82.gnm2.ann1.Glyma.08G145300
-ERF61	Ethylene-responsive factor gene 61	glyma.Wm82.gnm2.ann1.Glyma.08G211600
-ERF62	Ethylene-responsive factor gene 62	glyma.Wm82.gnm2.ann1.Glyma.08G216600
-ERF63	Ethylene-responsive factor gene 63	glyma.Wm82.gnm2.ann1.Glyma.08G257300
-ERF64	Ethylene-responsive factor gene 64	glyma.Wm82.gnm2.ann1.Glyma.08G261500
-ERF65	Ethylene-responsive factor gene 65	glyma.Wm82.gnm2.ann1.Glyma.08G278800
-ERF66, LF1	putative AP2 domain-containing protein Lf1	glyma.Wm82.gnm2.ann1.Glyma.08g281900
-ERF67	Ethylene-responsive factor gene 67	glyma.Wm82.gnm2.ann1.Glyma.08G320700
-ERF68	Ethylene-responsive factor gene 68	glyma.Wm82.gnm2.ann1.Glyma.09G041500
-ERF69	Ethylene-responsive factor gene 69	glyma.Wm82.gnm2.ann1.Glyma.09G052800
-ERF70	Ethylene-responsive factor gene 70	glyma.Wm82.gnm2.ann1.Glyma.09G052900
-ERF71	Ethylene-responsive factor gene 71	glyma.Wm82.gnm2.ann1.Glyma.09G053000
-ERF72	Ethylene-responsive factor gene 72	glyma.Wm82.gnm2.ann1.Glyma.09G242600
-ERF73	Ethylene-responsive factor gene 73	glyma.Wm82.gnm2.ann1.Glyma.10G007000
-ERF74	Ethylene-responsive factor gene 74	glyma.Wm82.gnm2.ann1.Glyma.10G007100
-ERF75	Ethylene-responsive factor gene 75	glyma.Wm82.gnm2.ann1.Glyma.10G016500
-ERF76	Ethylene-responsive factor gene 76	glyma.Wm82.gnm2.ann1.Glyma.10G036200
-ERF77	Ethylene-responsive factor gene 77	glyma.Wm82.gnm2.ann1.Glyma.10G036300
-ERF78	Ethylene-responsive factor gene 78	glyma.Wm82.gnm2.ann1.Glyma.10G036600
-ERF79	Ethylene-responsive factor gene 79	glyma.Wm82.gnm2.ann1.Glyma.10G036700
-ERF80	Ethylene-responsive factor gene 80	glyma.Wm82.gnm2.ann1.Glyma.10G061400
-ERF81	Ethylene-responsive factor gene 81	glyma.Wm82.gnm2.ann1.Glyma.10G118900
-ERF82	Ethylene-responsive factor gene 82	glyma.Wm82.gnm2.ann1.Glyma.10G186800
-ERF83	Ethylene-responsive factor gene 83	glyma.Wm82.gnm2.ann1.Glyma.10G186900
-ERF84	Ethylene-responsive factor gene 84	glyma.Wm82.gnm2.ann1.Glyma.10G187000
-ERF85	Ethylene-responsive factor gene 85	glyma.Wm82.gnm2.ann1.Glyma.10G194200
-ERF86	Ethylene-responsive factor gene 86	glyma.Wm82.gnm2.ann1.Glyma.10G223200
-ERF87	Ethylene-responsive factor gene 87	glyma.Wm82.gnm2.ann1.Glyma.10G274600
-ERF88	Ethylene-responsive factor gene 88	glyma.Wm82.gnm2.ann1.Glyma.11G019000
-ERF89	Ethylene-responsive factor gene 89	glyma.Wm82.gnm2.ann1.Glyma.11G036400
-ERF9, ESR1	ethylene-responsive transcription factor ESR1	glyma.Wm82.gnm2.ann1.Glyma.02g039300
-ERF90	Ethylene-responsive factor gene 90	glyma.Wm82.gnm2.ann1.Glyma.11G036500
-ERF91	Ethylene-responsive factor gene 91	glyma.Wm82.gnm2.ann1.Glyma.12G117000
-ERF92	Ethylene-responsive factor gene 92	glyma.Wm82.gnm2.ann1.Glyma.12G162700
-ERF93	Ethylene-responsive factor gene 93	glyma.Wm82.gnm2.ann1.Glyma.12G226600
-ERF94	Ethylene-responsive factor gene 94	glyma.Wm82.gnm2.ann1.Glyma.13G040400
-ERF95	Ethylene-responsive factor gene 95	glyma.Wm82.gnm2.ann1.Glyma.13G060600
-ERF97	Ethylene-responsive factor gene 97	glyma.Wm82.gnm2.ann1.Glyma.13G122500
-ERF98	Ethylene-responsive factor gene 98	glyma.Wm82.gnm2.ann1.Glyma.13G122600
-ERF99	Ethylene-responsive factor gene 99	glyma.Wm82.gnm2.ann1.Glyma.13G122700
-ERS1	Ubiquitous, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma19g40090
-ERS2	root preferential, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma03g37470
-ETR1	Ubiquitous, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma09g00490
-EU3	Ni-binding urease accessory protein UreG	glyma.Wm82.gnm2.ann1.Glyma.08g084800
-EU4	urease	glyma.Wm82.gnm2.ann1.Glyma.05g146000
-EU5	urease SBU-III	glyma.Wm82.gnm2.ann1.Glyma.08g103000
-EXB1	Expansin B1 like protein	glyma.Wm82.gnm2.ann1.Glyma.17G147500
-EXLA1	expansin-like A gene 1	glyma.Wm82.gnm1.ann1.Glyma11g10240
-EXLA2	expansin-like A gene 2	glyma.Wm82.gnm1.ann1.Glyma12g02550
-EXLB1	expansin-like B gene 1	glyma.Wm82.gnm1.ann1.Glyma01g35070
-EXLB10	expansin-like B gene 10	glyma.Wm82.gnm1.ann1.Glyma17g15640
-EXLB11	expansin-like B gene 11	glyma.Wm82.gnm1.ann1.Glyma17g15670
-EXLB12	expansin-like B gene 12	glyma.Wm82.gnm1.ann1.Glyma17g15680
-EXLB13	expansin-like B gene 13	glyma.Wm82.gnm1.ann1.Glyma17g15690
-EXLB14	expansin-like B gene 14	glyma.Wm82.gnm1.ann1.Glyma17g15710
-EXLB15	expansin-like B gene 15	glyma.Wm82.gnm1.ann1.Glyma17g16210
-EXLB2	expansin-like B gene 2	glyma.Wm82.gnm1.ann1.Glyma01g41050
-EXLB3	expansin-like B gene 3	glyma.Wm82.gnm1.ann1.Glyma01g41330
-EXLB4	expansin-like B gene 4	glyma.Wm82.gnm1.ann1.Glyma05g05390
-EXLB5	expansin-like B gene 5	glyma.Wm82.gnm1.ann1.Glyma05g05420
-EXLB6	expansin-like B gene 6	glyma.Wm82.gnm1.ann1.Glyma05g05430
-EXLB7	expansin-like B gene 7	glyma.Wm82.gnm1.ann1.Glyma05g05880
-EXLB8	expansin-like B gene 8	glyma.Wm82.gnm1.ann1.Glyma11g04080
-EXLB9	expansin-like B gene 9	glyma.Wm82.gnm1.ann1.Glyma11g04370
-EXP1	expansin 1	glyma.Wm82.gnm2.ann1.Glyma.17g260400
-EXP2	expansin	glyma.Wm82.gnm2.ann1.Glyma.07g132600
-EXP4	expansin 4	glyma.Wm82.gnm2.ann1.Glyma.02g109100
-EXP5A	expansin-A4-like	glyma.Wm82.gnm2.ann1.Glyma.12g062700
+VQ1	VQ motif containing protein gene 1	glyma.Wm82.gnm1.ann1.Glyma01g02280
 EXPA1	alpha-expansin gene 1	glyma.Wm82.gnm1.ann1.Glyma01g06030
+EXPA2	alpha-expansin gene 2	glyma.Wm82.gnm1.ann1.Glyma01g06031
+EXPA3	alpha-expansin gene 3	glyma.Wm82.gnm1.ann1.Glyma01g06032
+EXPA4	alpha-expansin gene 4	glyma.Wm82.gnm1.ann1.Glyma01g06033
+EXPA5	alpha-expansin gene 5	glyma.Wm82.gnm1.ann1.Glyma01g06034
+EXPA6	alpha-expansin gene 6	glyma.Wm82.gnm1.ann1.Glyma01g06035
+EXPA7	alpha-expansin gene 7	glyma.Wm82.gnm1.ann1.Glyma01g06036
+EXPA8	alpha-expansin gene 8	glyma.Wm82.gnm1.ann1.Glyma01g06037
+EXPA9	alpha-expansin gene 9	glyma.Wm82.gnm1.ann1.Glyma01g06038
 EXPA10	alpha-expansin gene 10	glyma.Wm82.gnm1.ann1.Glyma01g06039
 EXPA11	alpha-expansin gene 11	glyma.Wm82.gnm1.ann1.Glyma01g06040
 EXPA12	alpha-expansin gene 12	glyma.Wm82.gnm1.ann1.Glyma01g06041
@@ -1152,7 +19,6 @@ EXPA16	alpha-expansin gene 16	glyma.Wm82.gnm1.ann1.Glyma01g06045
 EXPA17	alpha-expansin gene 17	glyma.Wm82.gnm1.ann1.Glyma01g06046
 EXPA18	alpha-expansin gene 18	glyma.Wm82.gnm1.ann1.Glyma01g06047
 EXPA19	alpha-expansin gene 19	glyma.Wm82.gnm1.ann1.Glyma01g06048
-EXPA2	alpha-expansin gene 2	glyma.Wm82.gnm1.ann1.Glyma01g06031
 EXPA20	alpha-expansin gene 20	glyma.Wm82.gnm1.ann1.Glyma01g06049
 EXPA21	alpha-expansin gene 21	glyma.Wm82.gnm1.ann1.Glyma01g06050
 EXPA22	alpha-expansin gene 22	glyma.Wm82.gnm1.ann1.Glyma01g06051
@@ -1163,7 +29,6 @@ EXPA26	alpha-expansin gene 26	glyma.Wm82.gnm1.ann1.Glyma01g06055
 EXPA27	alpha-expansin gene 27	glyma.Wm82.gnm1.ann1.Glyma01g06056
 EXPA28	alpha-expansin gene 28	glyma.Wm82.gnm1.ann1.Glyma01g06057
 EXPA29	alpha-expansin gene 29	glyma.Wm82.gnm1.ann1.Glyma01g06058
-EXPA3	alpha-expansin gene 3	glyma.Wm82.gnm1.ann1.Glyma01g06032
 EXPA30	alpha-expansin gene 30	glyma.Wm82.gnm1.ann1.Glyma01g06059
 EXPA31	alpha-expansin gene 31	glyma.Wm82.gnm1.ann1.Glyma01g06060
 EXPA32	alpha-expansin gene 32	glyma.Wm82.gnm1.ann1.Glyma01g06061
@@ -1174,7 +39,6 @@ EXPA36	alpha-expansin gene 36	glyma.Wm82.gnm1.ann1.Glyma01g06065
 EXPA37	alpha-expansin gene 37	glyma.Wm82.gnm1.ann1.Glyma01g06066
 EXPA38	alpha-expansin gene 38	glyma.Wm82.gnm1.ann1.Glyma01g06067
 EXPA39	alpha-expansin gene 39	glyma.Wm82.gnm1.ann1.Glyma01g06068
-EXPA4	alpha-expansin gene 4	glyma.Wm82.gnm1.ann1.Glyma01g06033
 EXPA40	alpha-expansin gene 40	glyma.Wm82.gnm1.ann1.Glyma01g06069
 EXPA41	alpha-expansin gene 41	glyma.Wm82.gnm1.ann1.Glyma01g06070
 EXPA42	alpha-expansin gene 42	glyma.Wm82.gnm1.ann1.Glyma01g06071
@@ -1185,2661 +49,4192 @@ EXPA46	alpha-expansin gene 46	glyma.Wm82.gnm1.ann1.Glyma01g06075
 EXPA47	alpha-expansin gene 47	glyma.Wm82.gnm1.ann1.Glyma01g06076
 EXPA48	alpha-expansin gene 48	glyma.Wm82.gnm1.ann1.Glyma01g06077
 EXPA49	alpha-expansin gene 49	glyma.Wm82.gnm1.ann1.Glyma01g06078
-EXPA5	alpha-expansin gene 5	glyma.Wm82.gnm1.ann1.Glyma01g06034
-EXPA5C	expansin A5c	glyma.Wm82.gnm2.ann1.Glyma.11g139100
-EXPA6	alpha-expansin gene 6	glyma.Wm82.gnm1.ann1.Glyma01g06035
-EXPA7	alpha-expansin gene 7	glyma.Wm82.gnm1.ann1.Glyma01g06036
-EXPA8	alpha-expansin gene 8	glyma.Wm82.gnm1.ann1.Glyma01g06037
-EXPA9	alpha-expansin gene 9	glyma.Wm82.gnm1.ann1.Glyma01g06038
+VQ2	VQ motif containing protein gene 2	glyma.Wm82.gnm1.ann1.Glyma01g12940
 EXPB1	beta-expansin gene 1	glyma.Wm82.gnm1.ann1.Glyma01g16140
-Ep, PRX1, SPOD4.1	Ep, peroxidase	glyma.Wm82.gnm2.ann1.Glyma.09g022300
-F-box protein2	F-box protein 2	glyma.Wm82.gnm2.ann1.Glyma.02G273700
-F3'5'H	flavonoid 3', 5'-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.13g072100
-F3G2Gt 1, F3G2Gt-a, F3G2Gt-b, UGT79B30, UGT79B30-1	anthocyanidin 3-O-glucoside 2''-O-glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.06g285700
-F3G6''Gt	anthocyanidin 3-O-glucosyltransferase-like	glyma.Wm82.gnm2.ann1.Glyma.20g196000
-F3G6''Rt, Fg2, UGT79A6, UGT79A6-1	flavonol 3-O-glucoside (1->6) rhamnosyltransferase gene 1	glyma.Wm82.gnm2.ann1.Glyma.10g194000
-F3H	flavanone 3-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.02g048400
-F6'H1	feruloyl CoA ortho-hydroxylase 1	glyma.Wm82.gnm2.ann1.Glyma.18g111000
-F6H1	flavonoid 6-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.18g080400
-F6H2	flavonoid 6-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.18g080200
-F6H3	flavonoid 6-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.08g326900
-FAD2-1A	fatty acid desaturase	glyma.Wm82.gnm2.ann1.Glyma.10g278000
-FAD2-2A	fatty acid desaturase-2	glyma.Wm82.gnm2.ann1.Glyma.19g147300
-FAD2-2B	fatty acid desaturase-2	glyma.Wm82.gnm2.ann1.Glyma.19g147400
-FAD2-2D	fatty acid desaturase-2	glyma.Wm82.gnm2.ann1.Glyma.09g111900
-FAD3, FAD3-2b, FAD3d	omega-3-fatty acid desaturase 3 gene 4	glyma.Wm82.gnm2.ann1.Glyma.11g174100
-FAD5.1	delta-7 desaturase	glyma.Wm82.gnm2.ann1.Glyma.07g030000
-FAD5.2	delta-7 desaturase	glyma.Wm82.gnm2.ann1.Glyma.08g212900
-FAD6.1	omega-6 fatty acid desaturase, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.02g203300
-FAD6.2	delta-12 desaturase, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.17g074400
+P5CS1	DELTA1-PYRROLINE-5-CARBOXYLATE SYNTHASE 1	glyma.Wm82.gnm1.ann1.Glyma01g24530
 FAD8	Fatty acid desaturase 8	glyma.Wm82.gnm1.ann1.Glyma01G29630
-FAD8.2	omega-3 fatty acid desaturase, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.03g056700
-FAN		glyma.Wm82.gnm1.ann1.Glyma14g37350
-FANX		glyma.Wm82.gnm1.ann1.Glyma02g39230
-FAT1	acyl-ACP thioesterase	glyma.Wm82.gnm2.ann1.Glyma.05g012300
-FATB1A	16:0-acyl carrier protein (ACP) thioesterase enzyme	glyma.Wm82.gnm1.ann1.Glyma05g08060
-FATB1B	myristoyl-acyl carrier protein thioesterase	glyma.Wm82.gnm2.ann1.Glyma.17g120400
-FBA	fructose-bisphosphate aldolase	glyma.Wm82.gnm2.ann1.Glyma.02g303000
-FBP	fructose-1,6-bisphosphatase	glyma.Wm82.gnm2.ann1.Glyma.07g142700
-FCL1	homeobox protein knotted-1-like 1	glyma.Wm82.gnm2.ann1.Glyma.07g104800
-FCL2	homeobox protein knotted-1-like	glyma.Wm82.gnm2.ann1.Glyma.09g172800
+EXLB1	expansin-like B gene 1	glyma.Wm82.gnm1.ann1.Glyma01g35070
+DGAT2D	diacylglycerol acyltransferase 2 gene D	glyma.Wm82.gnm1.ann1.Glyma01g36010
+HK07	Ubiquitous, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma01g36950
+N:IFR	Isoflavone Reductase	glyma.Wm82.gnm1.ann1.Glyma01g37810
+VQ3	VQ motif containing protein gene 3	glyma.Wm82.gnm1.ann1.Glyma01g40320
+PRR48	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma01g40900
+EXLB2	expansin-like B gene 2	glyma.Wm82.gnm1.ann1.Glyma01g41050
+EXLB3	expansin-like B gene 3	glyma.Wm82.gnm1.ann1.Glyma01g41330
+D1	D1	glyma.Wm82.gnm1.ann1.Glyma01g42390
+PLD-gamma	Phospholipase D gamma	glyma.Wm82.gnm1.ann1.Glyma01g42420
+RR01	Ubiquitous, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma02g03140
 FDL02	Flowering Locus D-like gene 2	glyma.Wm82.gnm1.ann1.Glyma02g05100
-FDL0513	Flowering Locus D-like gene 513	glyma.Wm82.gnm1.ann1.Glyma05g13890
-FDL0525	Flowering Locus D-like gene 525	glyma.Wm82.gnm1.ann1.Glyma05g25200
-FDL06	Flowering Locus D-like gene 6	glyma.Wm82.gnm1.ann1.Glyma06g04350
-FDL0602	Flowering Locus D-like gene 602	glyma.Wm82.gnm1.ann1.Glyma06g02470
-FDL0647	Flowering Locus D-like gene 647	glyma.Wm82.gnm1.ann1.Glyma06g47220
-FDL07	Flowering Locus D-like gene 7	glyma.Wm82.gnm1.ann1.Glyma07g33600
-FDL08	Flowering Locus D-like gene 8	glyma.Wm82.gnm1.ann1.Glyma08g24340
-FDL0808	Flowering Locus D-like gene 808	glyma.Wm82.gnm1.ann1.Glyma08g08220
-FDL10	Flowering Locus D-like gene 10	glyma.Wm82.gnm1.ann1.Glyma10g08370
-FDL12	Flowering Locus D-like gene 12	glyma.Wm82.gnm1.ann1.Glyma12g30980
-FDL13	Flowering Locus D-like gene 13	glyma.Wm82.gnm1.ann1.Glyma13g03880
-FDL1339	Flowering Locus D-like gene 1339	glyma.Wm82.gnm1.ann1.Glyma13g39340
-FDL15	Flowering Locus D-like gene 15	glyma.Wm82.gnm1.ann1.Glyma15g35080
-FDL1920	Flowering Locus D-like gene 1920	glyma.Wm82.gnm1.ann1.Glyma19g20090
-FDL20	Flowering Locus D-like gene 20	glyma.Wm82.gnm1.ann1.Glyma20g10060
-FDa1	Flowering Locus D	glyma.Wm82.gnm2.ann1.Glyma.01G163500
-FDa2	Flowering Locus D	glyma.Wm82.gnm2.ann1.Glyma.11G080000
-FDb1	Flowering Locus D	glyma.Wm82.gnm2.ann1.Glyma.02G045500
-FDc1, FDL04	Flowering Locus D-like gene 4	glyma.Wm82.gnm2.ann1.Glyma.04G022100
-FDc2	Flowering Locus D	glyma.Wm82.gnm2.ann1.Glyma.06G022300
-FER2-1	ferritin	glyma.Wm82.gnm2.ann1.Glyma.02g262500
-FILA	YABBY protein FILa	glyma.Wm82.gnm2.ann1.Glyma.17g138200
-FKF1	Flavin-binding Kelch Repeat F-Box 1 gene	glyma.Wm82.gnm1.ann1.Glyma05g34530
-FLD	Flowering locus D	glyma.Wm82.gnm2.ann1.Glyma.02g159100
-FLS1	Flavonol synthase 1	glyma.Wm82.gnm2.ann1.Glyma.13g082300
-FLS2a	flavanol synthase	glyma.Wm82.gnm2.ann1.Glyma.08g083300
-FLS2b	flavanol synthase	glyma.Wm82.gnm2.ann1.Glyma.05g128200
-FNSII-1	flavone synthase II	glyma.Wm82.gnm2.ann1.Glyma.12g067000
-FNSII-2	flavone synthase II	glyma.Wm82.gnm2.ann1.Glyma.12g067100
-FRD3a	ferric reductase defective 3a	glyma.Wm82.gnm2.ann1.Glyma.15g274600
-FRD3b	ferric reductase defective 3b	glyma.Wm82.gnm2.ann1.Glyma.09g102800
+HK09	Ubiquitous, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma02g05220
 FT	FLOWERING LOCUS T  	glyma.Wm82.gnm1.ann1.Glyma02g07650
-FT2C, FT2c-N	Flowering Locus T gene 2c	glyma.Wm82.gnm2.ann1.Glyma.02G069200
-FT4 (E10)	Flowering Locus T gene 4	glyma.Wm82.gnm2.ann1.Glyma.08G363100
-FTL1	Flowering locus T-like gene 1	glyma.Wm82.gnm2.ann1.Glyma.16g044200
-FTL2	Flowering locus T-like gene 2	glyma.Wm82.gnm2.ann1.Glyma.19g108100
-FTL4	Flowering locus T-like gene 4	glyma.Wm82.gnm2.ann1.Glyma.16g044100
-FTL5	Flowering locus T-like gene 5	glyma.Wm82.gnm2.ann1.Glyma.16g151000
-FTL6	Flowering locus T-like gene 6	glyma.Wm82.gnm2.ann1.Glyma.19g108200
-FTL7	Flowering locus T-like gene 7	glyma.Wm82.gnm2.ann1.Glyma.08g363200
-FTL9	flowering locus T-like protein 9	glyma.Wm82.gnm2.ann1.Glyma.08g256000
-FTRC	ferredoxin thioredoxin reductase precursor	glyma.Wm82.gnm2.ann1.Glyma.13g069100
-FTSH9	ATP-dependent zinc metalloprotease FTSH 8, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.15g158900
-FULb	Fruitfull gene b	glyma.Wm82.gnm2.ann1.Glyma.04g159300
-FUSA1	elongation factor G-1	glyma.Wm82.gnm2.ann1.Glyma.17g137600
-FUSA2	elongation factor G-2	glyma.Wm82.gnm2.ann1.Glyma.05g055500
-FVE	WD-40 repeat-containing protein MSI4-like	glyma.Wm82.gnm2.ann1.Glyma.15g169800
-FWL3	protein FW2.2-like 3	glyma.Wm82.gnm2.ann1.Glyma.08g043500
-FWL6	protein FW2.2-like 6	glyma.Wm82.gnm2.ann1.Glyma.07g185200
-FWL7	protein FW2.2-like 7	glyma.Wm82.gnm2.ann1.Glyma.01g084000
-FWL8	protein FW2.2-like 8	glyma.Wm82.gnm2.ann1.Glyma.15g016800
-FabD	malonyl-CoA:ACP malonyltransferase	glyma.Wm82.gnm2.ann1.Glyma.11g164500
-FabF	3-ketoacyl-ACP-synthase II	glyma.Wm82.gnm2.ann1.Glyma.13g112700
-FabG	3-ketoacyl-ACP reductase	glyma.Wm82.gnm2.ann1.Glyma.08g102100
-FabZ	3-hydroxyacyl-ACP dehydrase	glyma.Wm82.gnm2.ann1.Glyma.15g052500
-G2DT	glycinol 2-dimethylallyltransferase	glyma.Wm82.gnm2.ann1.Glyma.20g245100
+NAC006	NAC Transcription Factor gene 6	glyma.Wm82.gnm1.ann1.Glyma02g07700
+2A6		glyma.Wm82.gnm1.ann1.Glyma02g09290
+HK15	root preferential, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma02g09550
+SWEET1	sucrose effluxer gene 1	glyma.Wm82.gnm1.ann1.Glyma02g09710
+Actin11	Actin 11	glyma.Wm82.gnm1.ann1.Glyma02g10170
+PAP1	Purple acid phosphatase gene 1	glyma.Wm82.gnm1.ann1.Glyma02g13070
+SACPD-B	stearoyl-acyl carrier protein desaturase	glyma.Wm82.gnm1.ann1.Glyma02g15600
+HTA8	HISTONE H2A 8	glyma.Wm82.gnm1.ann1.Glyma02g16150
+HP09	Ubiquitous, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma02g16980
+COL13	Constans-like 13	glyma.Wm82.gnm1.ann1.Glyma02g17181
+LSD1	Lys-Specific Demethylase 1	glyma.Wm82.gnm1.ann1.Glyma02g18610
+NAC011, NAC193	NAC Transcription Factor gene 193	glyma.Wm82.gnm1.ann1.Glyma02g26480
+VQ4	VQ motif containing protein gene 4	glyma.Wm82.gnm1.ann1.Glyma02g29281
+ATG18b	yeast autophagy 18 gene b	glyma.Wm82.gnm1.ann1.Glyma02g36960
+VQ5	VQ motif containing protein gene 5	glyma.Wm82.gnm1.ann1.Glyma02g37135
 G3pdh	Glycerol-3-phosphate dehydrogenase	glyma.Wm82.gnm1.ann1.Glyma02g38310
-G4DT	Glycinol 4-dimethylallyltransferase	glyma.Wm82.gnm2.ann1.Glyma.10g295300
-G6PD, G6PDH4	Glucose-6-phosphate dehydrogenase gene 4	glyma.Wm82.gnm2.ann1.Glyma.16G063200
-G6PDH, G6PDH2	Glucose-6-phosphate dehydrogenase gene 2	glyma.Wm82.gnm2.ann1.Glyma.19G082300
-G6PDH1	Glucose-6-phosphate dehydrogenase gene 1	glyma.Wm82.gnm2.ann1.Glyma.03G229400
-G6PDH3	Glucose-6-phosphate dehydrogenase gene 3	glyma.Wm82.gnm2.ann1.Glyma.08G199000
-G6PDH5	Glucose-6-phosphate dehydrogenase gene 5	glyma.Wm82.gnm2.ann1.Glyma.02G096800
-G6PDH6	Glucose-6-phosphate dehydrogenase gene 6	glyma.Wm82.gnm2.ann1.Glyma.19G077300
-G6PDH7	Glucose-6-phosphate dehydrogenase gene 7	glyma.Wm82.gnm2.ann1.Glyma.18G284600
-G6PDH8	Glucose-6-phosphate dehydrogenase gene 8	glyma.Wm82.gnm2.ann1.Glyma.07G013800
-G6PDH9	Glucose-6-phosphate dehydrogenase gene 9	glyma.Wm82.gnm2.ann1.Glyma.19G226700
-G93	PH/RCC1/FYVE zinc finger domain-containing protein G93	glyma.Wm82.gnm2.ann1.Glyma.18g044000
-GA1, GA20OX3	gibberellin 20-oxidase	glyma.Wm82.gnm2.ann1.Glyma.09g149200
-GA2, GA20OX8	gibberellin 20 oxidase 8	glyma.Wm82.gnm2.ann1.Glyma.20g153400
+COL8	Constans-like 8	glyma.Wm82.gnm1.ann1.Glyma02g38870
+FANX		glyma.Wm82.gnm1.ann1.Glyma02g39230
+HSP15.7-CI	15.7 kDa class I-related small heat shock protein-like	glyma.Wm82.gnm1.ann1.Glyma02g41150
+BIK1-2	BOTRYTIS INDUCED KINASE1 gene 2	glyma.Wm82.gnm1.ann1.Glyma02g41490
+ERD15C	Responsive to Desication 15 gene C	glyma.Wm82.gnm1.ann1.Glyma02g42860
+PAP2	Purple acid phosphatase gene 2	glyma.Wm82.gnm1.ann1.Glyma02g45950
+NFYA	Nuclear Factor Y subunit A	glyma.Wm82.gnm1.ann1.Glyma02g47380
+HK10	root preferential, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma02g47610
+PAL1	phenylalanine ammonia-lyase 1	glyma.Wm82.gnm1.ann1.Glyma02g47940
+MYB091	MYB transcription factor 91	glyma.Wm82.gnm1.ann1.Glyma03g19030
+VQ6	VQ motif containing protein gene 6	glyma.Wm82.gnm1.ann1.Glyma03g27560
+VQ7	VQ motif containing protein gene 7	glyma.Wm82.gnm1.ann1.Glyma03g28360
+RR09	Root Preferential, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma03g28570
+RS1	Raffinose Synthase 1	glyma.Wm82.gnm1.ann1.Glyma03g29440
+PBS3	avrPphB susceptible 3	glyma.Wm82.gnm1.ann1.Glyma03g30590
+Gy1	Glycinin gene 1	glyma.Wm82.gnm1.ann1.Glyma03g32030
+RR34	Root Specific, Response Regulator Type-C	glyma.Wm82.gnm1.ann1.Glyma03g32720
+SALT3	K+/H+ antiporter gene 1	glyma.Wm82.gnm1.ann1.Glyma03g32900
+PAP3	Purple acid phosphatase gene 3	glyma.Wm82.gnm1.ann1.Glyma03g35190
+PAP4	Purple acid phosphatase gene 4	glyma.Wm82.gnm1.ann1.Glyma03g35200
+VQ8	VQ motif containing protein gene 8	glyma.Wm82.gnm1.ann1.Glyma03g36330
+COL11a	Constans-like 11a	glyma.Wm82.gnm1.ann1.Glyma03g36810
+ERS2	root preferential, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma03g37470
+HK01	Ubiquitous, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma03g37760
+PHYA4	Phytochrome A gene 4	glyma.Wm82.gnm1.ann1.Glyma03g38620
+SWEET3	sucrose effluxer gene 3	glyma.Wm82.gnm1.ann1.Glyma03g39430
+VQ9	VQ motif containing protein gene 9	glyma.Wm82.gnm1.ann1.Glyma03g40941
+HK02	Root Exclusive, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma04g06190
+COL3a	Constans-like 3a	glyma.Wm82.gnm1.ann1.Glyma04g06240
+RR26	Ubiquitous, Response Regiulator Type-B	glyma.Wm82.gnm1.ann1.Glyma04g06650
+ATS9	NON-ATPASE SUBUNIT 9	glyma.Wm82.gnm1.ann1.Glyma04g08280
+VQ10	VQ motif containing protein gene 10	glyma.Wm82.gnm1.ann1.Glyma04g10780
+VQ11	VQ motif containing protein gene 11	glyma.Wm82.gnm1.ann1.Glyma04g11211
+AOX1A	alternative oxidase 1A  	glyma.Wm82.gnm1.ann1.Glyma04g14800
+VQ12	VQ motif containing protein gene 12	glyma.Wm82.gnm1.ann1.Glyma04g16880
+ERD15A	Responsive to Desication 15 gene A	glyma.Wm82.gnm1.ann1.Glyma04g28560
+RR12	Root Preferential, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma04g29250
+PRR37	Root Preferential, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma04g33110
+NAC017	NAC Transcription Factor gene 17	glyma.Wm82.gnm1.ann1.Glyma04g33270
+EDS1a	Enhanced disease susceptibility 1 gene b	glyma.Wm82.gnm1.ann1.Glyma04g34800
+RR15	Root specific, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma04g34820
+PAP5	Purple acid phosphatase 5 gene	glyma.Wm82.gnm1.ann1.Glyma04g37180
+SWEET4	sucrose effluxer gene 4	glyma.Wm82.gnm1.ann1.Glyma04g37510
+SWEET5	sucrose effluxer gene 5	glyma.Wm82.gnm1.ann1.Glyma04g37520
+SWEET6	sucrose effluxer gene 6	glyma.Wm82.gnm1.ann1.Glyma04g37530
+NAC038	NAC Transcription Factor gene 38	glyma.Wm82.gnm1.ann1.Glyma04g38990
+VQ13	VQ motif containing protein gene 13	glyma.Wm82.gnm1.ann1.Glyma04g39270
+RR17	Shoot preferential, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma04g40100
+PRR43, PRR5	Pseudo-response regulator gene 5	glyma.Wm82.gnm1.ann1.Glyma04g40640
+VQ14	VQ motif containing protein gene 14	glyma.Wm82.gnm1.ann1.Glyma04g41820
+SWEET8	sucrose effluxer gene 8	glyma.Wm82.gnm1.ann1.Glyma04g42040
+RR07	Ubiquitous, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma04g42680
+PRR38	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma05g00880
+RR03	Ubiquitous, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma05g01730
+PAP6	Purple acid phosphatase 6 gene	glyma.Wm82.gnm1.ann1.Glyma05g03320
+EXLB4	expansin-like B gene 4	glyma.Wm82.gnm1.ann1.Glyma05g05390
+EXLB5	expansin-like B gene 5	glyma.Wm82.gnm1.ann1.Glyma05g05420
+EXLB6	expansin-like B gene 6	glyma.Wm82.gnm1.ann1.Glyma05g05430
+EXLB7	expansin-like B gene 7	glyma.Wm82.gnm1.ann1.Glyma05g05880
+PRR46	Shoot preferential, Pseudo Response Regulator	glyma.Wm82.gnm1.ann1.Glyma05g06070
+FATB1A	16:0-acyl carrier protein (ACP) thioesterase enzyme	glyma.Wm82.gnm1.ann1.Glyma05g08060
+FDL0513	Flowering Locus D-like gene 513	glyma.Wm82.gnm1.ann1.Glyma05g13890
+VQ15	VQ motif containing protein gene 15	glyma.Wm82.gnm1.ann1.Glyma05g22760
+NAC027	NAC Transcription Factor gene 27	glyma.Wm82.gnm1.ann1.Glyma05g24910
+SWEET10	sucrose effluxer gene 10	glyma.Wm82.gnm1.ann1.Glyma05g25180
+FDL0525	Flowering Locus D-like gene 525	glyma.Wm82.gnm1.ann1.Glyma05g25200
+VQ16	VQ motif containing protein gene 16	glyma.Wm82.gnm1.ann1.Glyma05g26340
+PAP7	Purple acid phosphatase gene 7	glyma.Wm82.gnm1.ann1.Glyma05g26920
+PAP8	Purple acid phosphatase gene 8	glyma.Wm82.gnm1.ann1.Glyma05g26930
+VQ17	VQ motif containing protein gene 17	glyma.Wm82.gnm1.ann1.Glyma05g27220
+RR24	Root Preferential, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma05g27670
+HK13	Root Specific, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma05g28070
+VQ18	VQ motif containing protein gene 18	glyma.Wm82.gnm1.ann1.Glyma05g31341
+VQ19	VQ motif containing protein gene 19	glyma.Wm82.gnm1.ann1.Glyma05g32350
+UVR8	UVB-RESISTANCE 8  	glyma.Wm82.gnm1.ann1.Glyma05g32790
+VQ20	VQ motif containing protein gene 20	glyma.Wm82.gnm1.ann1.Glyma05g33250
+PAP9	Purple acid phosphatase 9 gene	glyma.Wm82.gnm1.ann1.Glyma05g33630
+PAP10	Purple acid phosphatase gene 10	glyma.Wm82.gnm1.ann1.Glyma05g33640
+PEAMT1	Phosphoethanolamine methyltransferase 1	glyma.Wm82.gnm1.ann1.Glyma05g33790
+HK16	Root Specific, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma05g34310
+FKF1	Flavin-binding Kelch Repeat F-Box 1 gene	glyma.Wm82.gnm1.ann1.Glyma05g34530
+COL6a	Constans-like 6a	glyma.Wm82.gnm1.ann1.Glyma05g35151
+AOMT	Anthocyanin O-methyltransferase	glyma.Wm82.gnm1.ann1.Glyma05g36210
+SR1	Serine racemase-1 involved in D-Serine biosynthetic process	glyma.Wm82.gnm1.ann1.Glyma05G37930
+SWEET11	sucrose effluxer gene 11	glyma.Wm82.gnm1.ann1.Glyma05g38340
+SWEET12	sucrose effluxer gene 12	glyma.Wm82.gnm1.ann1.Glyma05g38350
+FDL0602	Flowering Locus D-like gene 602	glyma.Wm82.gnm1.ann1.Glyma06g02470
+PAP11	Purple acid phosphatase 11 gene	glyma.Wm82.gnm1.ann1.Glyma06g03100
+FDL06	Flowering Locus D-like gene 6	glyma.Wm82.gnm1.ann1.Glyma06g04350
+HK06	root preferential, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma06g06180
+HK05	Root Specific, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma06g06240
+COL3b	Constans-like 3b	glyma.Wm82.gnm1.ann1.Glyma06g06300
+RR31	Root Preferential, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma06g06730
+VQ21	VQ motif containing protein gene 21	glyma.Wm82.gnm1.ann1.Glyma06g10630
+VQ22	VQ motif containing protein gene 22	glyma.Wm82.gnm1.ann1.Glyma06g10951
+VQ23	VQ motif containing protein gene 23	glyma.Wm82.gnm1.ann1.Glyma06g10960
+CCH	heavy-metal-associated domain-containing protein 	glyma.Wm82.gnm1.ann1.Glyma06g11190
+RR08	Ubiquitous, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma06g12100
+SWEET13	sucrose effluxer gene 13	glyma.Wm82.gnm1.ann1.Glyma06g12740
+VQ24	VQ motif containing protein gene 24	glyma.Wm82.gnm1.ann1.Glyma06g12960
+SWEET14	sucrose effluxer gene 14	glyma.Wm82.gnm1.ann1.Glyma06g13110
+PRR39	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma06g14150
+RR16	Ubiquitous, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma06g14750
+VQ25	VQ motif containing protein gene 25	glyma.Wm82.gnm1.ann1.Glyma06g15650
+SWEET16	sucrose effluxer gene 16	glyma.Wm82.gnm1.ann1.Glyma06g17530
+SWEET17	sucrose effluxer gene 17	glyma.Wm82.gnm1.ann1.Glyma06g17540
+ELO	Catalytic histone acetyltransferase subunit of the RNA polymerase II elongator complex	glyma.Wm82.gnm1.ann1.Glyma06G18150
+RR14	Root Preferential, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma06g19870
+EDS1b	Enhanced disease susceptibility 1 gene a	glyma.Wm82.gnm1.ann1.Glyma06g19920
+SWEET18	sucrose effluxer gene 18	glyma.Wm82.gnm1.ann1.Glyma06g21570
+SWEET19	sucrose effluxer gene 19	glyma.Wm82.gnm1.ann1.Glyma06g21640
+VQ26	VQ motif containing protein gene 26	glyma.Wm82.gnm1.ann1.Glyma06g36640
+NAC043	NAC Transcription Factor gene 43	glyma.Wm82.gnm1.ann1.Glyma06g38410
+NAC044	NAC Transcription Factor gene 44	glyma.Wm82.gnm1.ann1.Glyma06g38440
+LDL2-1	LSD2-like2 gene 1	glyma.Wm82.gnm1.ann1.Glyma06g38600
+ZF351	tandem CCCH zinc finger protein 351	glyma.Wm82.gnm1.ann1.Glyma06g44440
+FDL0647	Flowering Locus D-like gene 647	glyma.Wm82.gnm1.ann1.Glyma06g47220
+HP07	Shoot preferential, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma07g01840
+VQ27	VQ motif containing protein gene 27	glyma.Wm82.gnm1.ann1.Glyma07g03240
+PHP1	Ubiquitous, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma07g03390
+O-MT	O-methyltransferase	glyma.Wm82.gnm1.ann1.Glyma07g05480
+PRR45	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma07g05530
+SDR	short-chain dehydrogenase/reductase (SDR) family protein 	glyma.Wm82.gnm1.ann1.Glyma07g08090
 GA20OX	gibberellin oxidase gene 20	glyma.Wm82.gnm1.ann1.Glyma07g08950
-GA20OX1	gibberellin 20 oxidase 1	glyma.Wm82.gnm2.ann1.Glyma.03g019800
-GA20OX2	gibberellin 20 oxidase 2	glyma.Wm82.gnm2.ann1.Glyma.07g081700
-GA20OX5	gibberellin 20 oxidase 5	glyma.Wm82.gnm2.ann1.Glyma.13g035600
-GA20OX6	gibberellin 20 oxidase 6	glyma.Wm82.gnm2.ann1.Glyma.14g157400
-GA20OX7	gibberellin 20-oxidase 7	glyma.Wm82.gnm2.ann1.Glyma.16g200800
-GA2OX1	gibberellin 2-beta-dioxygenase 1	glyma.Wm82.gnm2.ann1.Glyma.02g010100
-GA2OX10	gibberellin 2-beta-dioxygenase 10	glyma.Wm82.gnm2.ann1.Glyma.15g252100
-GA2OX2	gibberellin 2-beta-dioxygenase 2	glyma.Wm82.gnm2.ann1.Glyma.10g010700
-GA2OX3	gibberellin 2-beta-dioxygenase 3	glyma.Wm82.gnm2.ann1.Glyma.10g123000
-GA2OX4	gibberellin 2-beta-dioxygenase 4	glyma.Wm82.gnm2.ann1.Glyma.11g003200
-GA2OX5	gibberellin 2-beta-dioxygenase 5	glyma.Wm82.gnm2.ann1.Glyma.13g218200
-GA2OX6	gibberellin 2-beta-dioxygenase 6	glyma.Wm82.gnm2.ann1.Glyma.13g259400
-GA2OX7	gibberellin 2-beta-dioxygenase 7	glyma.Wm82.gnm2.ann1.Glyma.13g259500
-GA2OX8	gibberellin 2-beta-dioxygenase 8	glyma.Wm82.gnm2.ann1.Glyma.15g093900
-GA2OX9	gibberellin 2-beta-dioxygenase 9	glyma.Wm82.gnm2.ann1.Glyma.15g248400
-GA2ox8A	giberellin 2-oxidase 8 gene A	glyma.Wm82.gnm2.ann1.Glyma.13G287600
-GA2ox8B	giberellin 2-oxidase 8 gene B	glyma.Wm82.gnm2.ann1.Glyma.13G288000
-GA3OX1	gibberellin 3-beta-dioxygenase 1	glyma.Wm82.gnm2.ann1.Glyma.04g071000
-GA3OX2	gibberellin 3-beta-dioxygenase 2	glyma.Wm82.gnm2.ann1.Glyma.06g072600
-GA3OX3	gibberellin 3-beta-dioxygenase 3	glyma.Wm82.gnm2.ann1.Glyma.13g361700
-GA3OX4	gibberellin 3-beta-dioxygenase 4	glyma.Wm82.gnm2.ann1.Glyma.14g128400
-GA3OX5	gibberellin 3-beta-dioxygenase 5	glyma.Wm82.gnm2.ann1.Glyma.15g012100
-GA3OX6	gibberellin 3-beta-dioxygenase 6	glyma.Wm82.gnm2.ann1.Glyma.17g205300
-GAD	GAD protein	glyma.Wm82.gnm2.ann1.Glyma.18g043600
-GAI1	DELLA protein GAI 1	glyma.Wm82.gnm2.ann1.Glyma.05g140400
-GAI2, GR8	giberellic acid responsive gene 8	glyma.Wm82.gnm2.ann1.Glyma.11G216500
-GAMMA-TMT	gamma-tocopherol methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.09g222800
-GAPC1	glyceraldehyde-3-phosphate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.06g172600
-GAPDH	glyceraldehyde 3-phosphate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.04g193500
-GASA1	gibberellin-regulated protein 1	glyma.Wm82.gnm2.ann1.Glyma.02g245600
-GASA10	gibberellin-regulated protein 10	glyma.Wm82.gnm2.ann1.Glyma.06g185300
-GASA11	gibberellin-regulated protein 11	glyma.Wm82.gnm2.ann1.Glyma.06g193800
-GASA12	gibberellin-regulated protein 12	glyma.Wm82.gnm2.ann1.Glyma.08g291900
-GASA13	gibberellin-regulated protein 13	glyma.Wm82.gnm2.ann1.Glyma.09g095200
-GASA14	gibberellin-regulated protein 14	glyma.Wm82.gnm2.ann1.Glyma.09g238300
-GASA15	gibberellin-regulated protein 15	glyma.Wm82.gnm2.ann1.Glyma.10g216000
-GASA16	gibberellin-regulated protein 16	glyma.Wm82.gnm2.ann1.Glyma.10g216100
-GASA17	gibberellin-regulated protein 17	glyma.Wm82.gnm2.ann1.Glyma.10g259800
-GASA18	gibberellin-regulated protein 18	glyma.Wm82.gnm2.ann1.Glyma.13g039300
-GASA19	gibberellin-regulated protein 19	glyma.Wm82.gnm2.ann1.Glyma.13g039600
-GASA21	gibberellin-regulated protein 21	glyma.Wm82.gnm2.ann1.Glyma.13g069900
-GASA22	gibberellin-regulated protein 22	glyma.Wm82.gnm2.ann1.Glyma.14g087200
-GASA23	gibberellin-regulated protein 23	glyma.Wm82.gnm2.ann1.Glyma.14g215600
-GASA24	gibberellin-regulated protein 24	glyma.Wm82.gnm2.ann1.Glyma.14g219100
-GASA26	gibberellin-regulated protein 26	glyma.Wm82.gnm2.ann1.Glyma.17g092800
-GASA27	gibberellin-regulated protein 27	glyma.Wm82.gnm2.ann1.Glyma.17g237100
-GASA28	gibberellin-regulated protein 28	glyma.Wm82.gnm2.ann1.Glyma.17g258100
-GASA29	gibberellin-regulated protein 29	glyma.Wm82.gnm2.ann1.Glyma.17g258200
-GASA3	gibberellin-regulated protein 3	glyma.Wm82.gnm2.ann1.Glyma.03g131700
-GASA31	gibberellin-regulated protein 31	glyma.Wm82.gnm2.ann1.Glyma.18g132100
-GASA32	gibberellin-regulated protein 32	glyma.Wm82.gnm2.ann1.Glyma.18g259400
-GASA33	gibberellin-regulated protein 33	glyma.Wm82.gnm2.ann1.Glyma.19g013000
-GASA34	gibberellin-regulated protein 34	glyma.Wm82.gnm2.ann1.Glyma.19g022500
-GASA35	gibberellin-regulated protein 35	glyma.Wm82.gnm2.ann1.Glyma.19g133600
-GASA36	gibberellin-regulated protein 36	glyma.Wm82.gnm2.ann1.Glyma.20g131100
-GASA37	gibberellin-regulated protein 37	glyma.Wm82.gnm2.ann1.Glyma.20g175800
-GASA4	gibberellin-regulated protein 4	glyma.Wm82.gnm2.ann1.Glyma.04g024400
-GASA5	gibberellin-regulated protein 5	glyma.Wm82.gnm2.ann1.Glyma.04g169600
-GASA6	gibberellin-regulated protein 6	glyma.Wm82.gnm2.ann1.Glyma.04g179500
-GASA7	gibberellin-regulated protein 7	glyma.Wm82.gnm2.ann1.Glyma.05g034500
-GASA8	gibberellin-regulated protein 8	glyma.Wm82.gnm2.ann1.Glyma.06g024500
-GASA9	gibberellin-regulated protein 9	glyma.Wm82.gnm2.ann1.Glyma.06g044400
-GBF2	G-box binding factor	glyma.Wm82.gnm2.ann1.Glyma.16g029000
-GBP	GAGA-binding protein	glyma.Wm82.gnm2.ann1.Glyma.09g170400
-GBSSIa	granule bound starch synthase Ia	glyma.Wm82.gnm2.ann1.Glyma.10g172200
-GDH1	glutamate dehydrogenase 1	glyma.Wm82.gnm2.ann1.Glyma.16g041200
-GDH2	glutamate dehydrogenase 2	glyma.Wm82.gnm2.ann1.Glyma.17g148000
-GER10	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.15g176900
-GER11	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.20g220800
-GER12	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.20g220900
-GER13	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.19g086100
-GER14	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.19g086200
-GER15	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.15g222500
-GER16	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.10g139700
-GER17	germin-like protein 17	glyma.Wm82.gnm2.ann1.Glyma.10g139800
-GER19	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.20g090200
-GER2	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.16g060800
-GER20	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.19g058900
-GER3	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.16g060900
-GER4	germin-like protein 4	glyma.Wm82.gnm2.ann1.Glyma.16g061400
+LDL1-1	LSD1-like1 gene 1	glyma.Wm82.gnm1.ann1.Glyma07g09980
+COL5a	Constans-like 5a	glyma.Wm82.gnm1.ann1.Glyma07g10161
+VQ28	VQ motif containing protein gene 28	glyma.Wm82.gnm1.ann1.Glyma07g10290
+PEAMT2	Phosphoethanolamine methyltransferase 2	glyma.Wm82.gnm1.ann1.Glyma07g11580
+RR33	Ubiquitous, Response Regiulator Type-B	glyma.Wm82.gnm1.ann1.Glyma07g26890
+HK14	Ubiquitous, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma07g27540
+VQ29	VQ motif containing protein gene 29	glyma.Wm82.gnm1.ann1.Glyma07g31781
+SACPD-A	stearoyl-acyl carrier protein desaturase	glyma.Wm82.gnm1.ann1.Glyma07g32850
+FDL07	Flowering Locus D-like gene 7	glyma.Wm82.gnm1.ann1.Glyma07g33600
+NAC052	NAC Transcription Factor gene 52	glyma.Wm82.gnm1.ann1.Glyma07g35630
+RR21	Root Specific, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma07g37220
+HP03	Root Specific, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma07g38310
+VQ30	VQ motif containing protein gene 30	glyma.Wm82.gnm1.ann1.Glyma08g00850
+SR2	Serine racemase-2	glyma.Wm82.gnm1.ann1.Glyma08G01670
+RPS10C	40S ribosomal protein S10	glyma.Wm82.gnm1.ann1.Glyma08g02070
+SWEET22	sucrose transporter gene 22	glyma.Wm82.gnm1.ann1.Glyma08g02890
+COL6b	Constans-like 6b	glyma.Wm82.gnm1.ann1.Glyma08g04570
+VQ31	VQ motif containing protein gene 31	glyma.Wm82.gnm1.ann1.Glyma08g04651
+HK17	root preferential, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma08g05370
+PAP13	Purple acid phosphatase 13 gene	glyma.Wm82.gnm1.ann1.Glyma08g06090
+ANR1	Anthocyanidin reductase 1	glyma.Wm82.gnm1.ann1.Glyma08g06630
+ANR2	Anthocyanidin reductase 2	glyma.Wm82.gnm1.ann1.Glyma08g06640
+PIP1:6	Plasma membrane intrinsic protein 1 gene 6	glyma.Wm82.gnm1.ann1.Glyma08g08160
+SWEET23	sucrose transporter gene 23	glyma.Wm82.gnm1.ann1.Glyma08g08200
+FDL0808	Flowering Locus D-like gene 808	glyma.Wm82.gnm1.ann1.Glyma08g08220
+VQ32	VQ motif containing protein gene 32	glyma.Wm82.gnm1.ann1.Glyma08g09250
+PAP14	Purple acid phosphatase gene 13	glyma.Wm82.gnm1.ann1.Glyma08g09880
+PAP15	Purple acid phosphatase gene 15	glyma.Wm82.gnm1.ann1.Glyma08g09900
+PAP16	Purple acid phosphatase 16 gene	glyma.Wm82.gnm1.ann1.Glyma08g09910
+VQ33	VQ motif containing protein gene 33	glyma.Wm82.gnm1.ann1.Glyma08g10166
+RR25	Root Specific, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma08g10650
+KAR	3-oxoacyl-[acyl-carrier-protein] reductase	glyma.Wm82.gnm1.ann1.Glyma08G10760
+HK12	Root Specific, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma08g11060
+CHS	Chalcone synthase	glyma.Wm82.gnm1.ann1.Glyma08g11530
+VQ34	VQ motif containing protein gene 34	glyma.Wm82.gnm1.ann1.Glyma08g14581
+VQ35	VQ motif containing protein gene 35	glyma.Wm82.gnm1.ann1.Glyma08g15620
+VQ36	VQ motif containing protein gene 36	glyma.Wm82.gnm1.ann1.Glyma08g16790
+LEM3	ligand-effect modulator 3	glyma.Wm82.gnm1.ann1.Glyma08g17460
+VQ37	VQ motif containing protein gene 37	glyma.Wm82.gnm1.ann1.Glyma08g18820
+MAGL	Monoacylglycerol lipase	glyma.Wm82.gnm1.ann1.Glyma08G19060
+NAC062	NAC Transcription Factor gene 62	glyma.Wm82.gnm1.ann1.Glyma08g19300
+HP08	Ubiquitous, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma08g21510
+PHP2	Root Preferential, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma08g22720
+VQ38	VQ motif containing protein gene 38	glyma.Wm82.gnm1.ann1.Glyma08g22860
+FDL08	Flowering Locus D-like gene 8	glyma.Wm82.gnm1.ann1.Glyma08g24340
+VQ39	VQ motif containing protein gene 39	glyma.Wm82.gnm1.ann1.Glyma08g36730
+VQ40	VQ motif containing protein gene 40	glyma.Wm82.gnm1.ann1.Glyma08g36740
+VQ41	VQ motif containing protein gene 41	glyma.Wm82.gnm1.ann1.Glyma08g36750
+PAP17	Purple acid phosphatase gene 17	glyma.Wm82.gnm1.ann1.Glyma08g40210
+RR04	Shoot preferential, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma08g40330
+VQ42	VQ motif containing protein gene 42	glyma.Wm82.gnm1.ann1.Glyma08g42125
+PAP18	Purple acid phosphatase 18 gene	glyma.Wm82.gnm1.ann1.Glyma08g42670
+PAP19	Purple acid phosphatase 19 gene	glyma.Wm82.gnm1.ann1.Glyma08g46550
+SWEET26	sucrose effluxer gene 26	glyma.Wm82.gnm1.ann1.Glyma08g47560
+FT4	Flowering Locus T 4	glyma.Wm82.gnm1.ann1.Glyma08g47810
+FT6	Flowering Locus T 6	glyma.Wm82.gnm1.ann1.Glyma08g47820
+SWEET27	sucrose effluxer gene 27	glyma.Wm82.gnm1.ann1.Glyma08g48280
+ETR1	Ubiquitous, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma09g00490
+NPR1-2	nonexpressor of PR1	glyma.Wm82.gnm1.ann1.Glyma09g02430
+RR20	Root Preferential, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma09g04470
+SWEET28	sucrose effluxer gene 28	glyma.Wm82.gnm1.ann1.Glyma09g04840
+CYP81D3	oxygen binding 	glyma.Wm82.gnm1.ann1.Glyma09g05440
+VQ43	VQ motif containing protein gene 43	glyma.Wm82.gnm1.ann1.Glyma09g05700
+GI2	gigantea protein gene 2	glyma.Wm82.gnm1.ann1.Glyma09g07240
+DGAT1C	diacylglycerol acyltransferase 1 gene C	glyma.Wm82.gnm1.ann1.Glyma09g07520
+MKK1b	Mitogen-activated protein kinase kinase 1 gene b	glyma.Wm82.gnm1.ann1.Glyma09g07660
+CFIM-25	mRNA and protein family	glyma.Wm82.gnm1.ann1.Glyma09g07670
+RR30	Root Preferential, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma09g14650
+VQ44	VQ motif containing protein gene 44	glyma.Wm82.gnm1.ann1.Glyma09g17151
+CLC-C	anion channel/ voltage-gated chloride channel  	glyma.Wm82.gnm1.ann1.Glyma09g28620
+VQ45	VQ motif containing protein gene 45	glyma.Wm82.gnm1.ann1.Glyma09g31600
+LDL1-2	LSD1-like1 gene 2	glyma.Wm82.gnm1.ann1.Glyma09g31770
+DGAT2A	diacylglycerol acyltransferase 2 gene A	glyma.Wm82.gnm1.ann1.Glyma09g32790
+AMF5	ammonium-facilitator 5	glyma.Wm82.gnm1.ann1.Glyma09g33680
+DAGL	Diacylglycerol lipase	glyma.Wm82.gnm1.ann1.Glyma09G34250
+PAP20	Purple acid phosphatase gene 20	glyma.Wm82.gnm1.ann1.Glyma09g36360
+MPK4c	Mitogen-activated protein kinase kinase 4 gene c	glyma.Wm82.gnm1.ann1.Glyma09g39190
+BEN1	Brassinosteriod Insensitive 1 Enhanced 1 gene	glyma.Wm82.gnm1.ann1.Glyma09g40590
+COL12a	Constans-like 12a	glyma.Wm82.gnm1.ann1.Glyma10g02621
+HP10	Ubiquitous, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma10g02820
+NAC071	NAC Transcription Factor gene 71	glyma.Wm82.gnm1.ann1.Glyma10g04350
+PAP21	Purple acid phosphatase 21 gene	glyma.Wm82.gnm1.ann1.Glyma10g08300
+FDL10	Flowering Locus D-like gene 10	glyma.Wm82.gnm1.ann1.Glyma10g08370
+Le5	Lectin gene 5	glyma.Wm82.gnm1.ann1.Glyma10g15480
+UO1	Urate Oxidase 1 gene	glyma.Wm82.gnm1.ann1.Glyma10g23790
+HP04	Root Specific, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma10g29890
+VQ46	VQ motif containing protein gene 46	glyma.Wm82.gnm1.ann1.Glyma10g41970
+COL7a	Constans-like 7a	glyma.Wm82.gnm1.ann1.Glyma10g42090
+D2	D2	glyma.Wm82.gnm1.ann1.Glyma11g02980
+KEU	protein transporter  	glyma.Wm82.gnm1.ann1.Glyma11g03230
+EXLB8	expansin-like B gene 8	glyma.Wm82.gnm1.ann1.Glyma11g04080
+EXLB9	expansin-like B gene 9	glyma.Wm82.gnm1.ann1.Glyma11g04370
+PRR49	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma11g04440
+VQ47	VQ motif containing protein gene 47	glyma.Wm82.gnm1.ann1.Glyma11g04970
+HK08	Root preferential, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma11g08310
+DGAT2E	diacylglycerol acyltransferase 2 gene E	glyma.Wm82.gnm1.ann1.Glyma11g09410
+CYP81D5	oxygen binding 	glyma.Wm82.gnm1.ann1.Glyma11g09880
+EXLA1	expansin-like A gene 1	glyma.Wm82.gnm1.ann1.Glyma11g10240
+LPAT	Lysophosphatidyl acyltransferase	glyma.Wm82.gnm1.ann1.Glyma11G12830
+MYB59	DNA binding / transcription factor  	glyma.Wm82.gnm1.ann1.Glyma11g15180
+RR11	Root Preferential, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma11g21650
+DIN1	asparagine	glyma.Wm82.gnm1.ann1.Glyma11g27480
+PAP22	Purple acid phosphatase gene 22	glyma.Wm82.gnm1.ann1.Glyma11g36510
+RR23	Root Preferential, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma11g37480
+VQ48	VQ motif containing protein gene 48	glyma.Wm82.gnm1.ann1.Glyma11g38180
+PAP23	Purple acid phosphatase gene 23	glyma.Wm82.gnm1.ann1.Glyma12g01000
+TMT2a	gamma-Tocopherol methyltranserase 2 gene a	glyma.Wm82.gnm1.ann1.Glyma12g01690
+EXLA2	expansin-like A gene 2	glyma.Wm82.gnm1.ann1.Glyma12g02550
+jmjC	transcription factor; jumonji (jmjC) domain-containing protein	glyma.Wm82.gnm1.ann1.Glyma12g05890
+ADT2	AROGENATE DEHYDRATASE 2	glyma.Wm82.gnm1.ann1.Glyma12g07720
+PRR42, PRR7	Pseudo-response regulator gene 7	glyma.Wm82.gnm1.ann1.Glyma12g07860
+PRR3B	Psudo-Response Regulator 3 gene B	glyma.Wm82.gnm1.ann1.Glyma12g07861
+NAC083	NAC Transcription Factor gene 83	glyma.Wm82.gnm1.ann1.Glyma12g13710
+PLA1-IId	Phospholipase A1-Iid	glyma.Wm82.gnm1.ann1.Glyma12G15430
+HGO	HOMOGENTISATE 1,2-DIOXYGENASE	glyma.Wm82.gnm1.ann1.Glyma12g20220
+NAC084	NAC Transcription Factor gene 84	glyma.Wm82.gnm1.ann1.Glyma12g22790
+NAC085	NAC Transcription Factor gene 85	glyma.Wm82.gnm1.ann1.Glyma12g22880
+VQ49	VQ motif containing protein gene 49	glyma.Wm82.gnm1.ann1.Glyma12g24250
+FDL12	Flowering Locus D-like gene 12	glyma.Wm82.gnm1.ann1.Glyma12g30980
+COL10a	Constans-like 10a	glyma.Wm82.gnm1.ann1.Glyma12g32221
+PAP24	Purple acid phosphatase 24 gene	glyma.Wm82.gnm1.ann1.Glyma12g34960
+NAC092	NAC Transcription Factor gene 92	glyma.Wm82.gnm1.ann1.Glyma12g35000
+VQ50	VQ motif containing protein gene 50	glyma.Wm82.gnm1.ann1.Glyma12g35380
+SWEET29	sucrose effluxer gene 29	glyma.Wm82.gnm1.ann1.Glyma12g36300
+COL4a	Constans-like 4a	glyma.Wm82.gnm1.ann1.Glyma13g01290
+RR13	Root Preferential, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma13g03560
+FDL13	Flowering Locus D-like gene 13	glyma.Wm82.gnm1.ann1.Glyma13g03880
+NAC095	NAC Transcription Factor gene 95	glyma.Wm82.gnm1.ann1.Glyma13g05540
+VQ51	VQ motif containing protein gene 51	glyma.Wm82.gnm1.ann1.Glyma13g08831
+VQ52	VQ motif containing protein gene 52	glyma.Wm82.gnm1.ann1.Glyma13g10840
+COL9a	Constans-like 9a	glyma.Wm82.gnm1.ann1.Glyma13g11592
+MKK2b	Mitogen-activated protein kinase kinase 2 gene b	glyma.Wm82.gnm1.ann1.Glyma13g16650
+KASII-B, KASIIb	3-ketoacyl-ACP synthase II	glyma.Wm82.gnm1.ann1.Glyma13g17290
+DGAT3B	diacylglycerol acyltransferase 3 gene B	glyma.Wm82.gnm1.ann1.Glyma13g17860
+PRR41	Root Preferential, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma13g19870
+RR32	Root Specific, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma13g22320
+PAP25	Purple acid phosphatase 25 gene	glyma.Wm82.gnm1.ann1.Glyma13g23090
+VQ53	VQ motif containing protein gene 53	glyma.Wm82.gnm1.ann1.Glyma13g24700
+VQ54	VQ motif containing protein gene 54	glyma.Wm82.gnm1.ann1.Glyma13g26290
+RR18	Root specific, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma13g26770
+HP02	Ubiquitous, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma13g28390
+VQ55	VQ motif containing protein gene 55	glyma.Wm82.gnm1.ann1.Glyma13g29005
+VQ56	VQ motif containing protein gene 56	glyma.Wm82.gnm1.ann1.Glyma13g31180
+NAC099	NAC Transcription Factor gene 99	glyma.Wm82.gnm1.ann1.Glyma13g31660
+PB1	octicosapeptide/Phox/Bem1p (PB1) domain-containing protein  	glyma.Wm82.gnm1.ann1.Glyma13g32730
+COL5b	Constans-like 5b	glyma.Wm82.gnm1.ann1.Glyma13g33420
+SWEET34	sucrose effluxer gene 34	glyma.Wm82.gnm1.ann1.Glyma13g33950
+VQ57	VQ motif containing protein gene 57	glyma.Wm82.gnm1.ann1.Glyma13g35130
+NAC101	NAC Transcription Factor gene 101	glyma.Wm82.gnm1.ann1.Glyma13g35550
+NAC102	NAC Transcription Factor gene 102	glyma.Wm82.gnm1.ann1.Glyma13g35560
+PAP26	Purple acid phosphatase 26 gene	glyma.Wm82.gnm1.ann1.Glyma13g35610
+RIC1	CLE-related protein RIC1	glyma.Wm82.gnm1.ann1.Glyma13g36830
+COL10b	Constans-like 10b	glyma.Wm82.gnm1.ann1.Glyma13g38251
+FDL1339	Flowering Locus D-like gene 1339	glyma.Wm82.gnm1.ann1.Glyma13g39340
+AR791	actin binding	glyma.Wm82.gnm1.ann1.Glyma13g42970
+VQ58	VQ motif containing protein gene 58	glyma.Wm82.gnm1.ann1.Glyma14g00570
+HK11	Ubiquitous, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma14g01040
+PAP27	Purple acid phosphatase gene 27	glyma.Wm82.gnm1.ann1.Glyma14g02790
+ERD15D	Responsive to Desication 15 gene D	glyma.Wm82.gnm1.ann1.Glyma14g05980
+SYP38	syntaxin	glyma.Wm82.gnm1.ann1.Glyma14g06610
+BIK1-6	BOTRYTIS INDUCED KINASE1 gene 6	glyma.Wm82.gnm1.ann1.Glyma14g07460
+HK03	Root Specific, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma14g12330
+RR28	Ubiquitous, Response Regiulator Type-B	glyma.Wm82.gnm1.ann1.Glyma14g13320
+SWEET35	sucrose effluxer gene 35	glyma.Wm82.gnm1.ann1.Glyma14g17810
+NAC109	NAC Transcription Factor gene 109	glyma.Wm82.gnm1.ann1.Glyma14g24220
+SKP2A	protein binding  	glyma.Wm82.gnm1.ann1.Glyma14g26660
+VQ59	VQ motif containing protein gene 59	glyma.Wm82.gnm1.ann1.Glyma14g29580
+SWEET38	sucrose effluxer gene 38	glyma.Wm82.gnm1.ann1.Glyma14g30940
+PP2C	protein phosphatase 2C	glyma.Wm82.gnm1.ann1.Glyma14g32430
+VQ60	VQ motif containing protein gene 60	glyma.Wm82.gnm1.ann1.Glyma14g34681
+COL8b	Constans-like 8b	glyma.Wm82.gnm1.ann1.Glyma14g36930
+FAN		glyma.Wm82.gnm1.ann1.Glyma14g37350
+PHP3	Root Specific, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma15g01010
+AMF3	ammonium-facilitator 3	glyma.Wm82.gnm1.ann1.Glyma15g06660
+CAMS1	CAMELLIOL C SYNTHASE 1	glyma.Wm82.gnm1.ann1.Glyma15g07110
+NAC091, NAC113	NAC Transcription Factor gene 113	glyma.Wm82.gnm1.ann1.Glyma15g07620
+VQ61	VQ motif containing protein gene 61	glyma.Wm82.gnm1.ann1.Glyma15g08160
+DRM1	DORMANCY-ASSOCIATED PROTEIN 1	glyma.Wm82.gnm1.ann1.Glyma15g08300
+HP01	Root Preferential, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma15g10660
+RR22	Root Preferential, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma15g15520
+SWEET40	sucrose effluxer gene 40	glyma.Wm82.gnm1.ann1.Glyma15g16030
+VQ62	VQ motif containing protein gene 62	glyma.Wm82.gnm1.ann1.Glyma15g16990
+MKK1a	Mitogen-activated protein kinase kinase 1 gene a	glyma.Wm82.gnm1.ann1.Glyma15g18860
+RR29	Root Preferential, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma15g24770
+WRI1	WRINKLED1	glyma.Wm82.gnm1.ann1.Glyma15g34770
+FDL15	Flowering Locus D-like gene 15	glyma.Wm82.gnm1.ann1.Glyma15g35080
+VQ63	VQ motif containing protein gene 63	glyma.Wm82.gnm1.ann1.Glyma15g37230
+RR06	Root specific, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma15g37770
+VQ64	VQ motif containing protein gene 64	glyma.Wm82.gnm1.ann1.Glyma15g40000
+NCED3	NINE-CIS-EPOXYCAROTENOID DIOXYGENASE3	glyma.Wm82.gnm1.ann1.Glyma15g40070
+VQ65	VQ motif containing protein gene 65	glyma.Wm82.gnm1.ann1.Glyma15g42280
+PRR44	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma16g02050
+FT5a	Flowering Locus T 5 gene a	glyma.Wm82.gnm1.ann1.Glyma16g04830
+FT3a	Flowering Locus T 3 gene a	glyma.Wm82.gnm1.ann1.Glyma16g04840
+COL13a	Constans-like 13a	glyma.Wm82.gnm1.ann1.Glyma16g05540
+DGAT2B	diacylglycerol acyltransferase 2 gene B	glyma.Wm82.gnm1.ann1.Glyma16g21960
+DGAT2C	diacylglycerol acyltransferase 2 gene C	glyma.Wm82.gnm1.ann1.Glyma16g21970
+TBP2	TATA BINDING PROTEIN 2	glyma.Wm82.gnm1.ann1.Glyma16g25450
+FT2a	Flowering Locus T 2 gene a	glyma.Wm82.gnm1.ann1.Glyma16g26660
+FT2b	Flowering Locus T  2 gene b	glyma.Wm82.gnm1.ann1.Glyma16g26690
+Rj2	Host Resistance Protein	glyma.Wm82.gnm1.ann1.Glyma16g33780
+RR19	Root Preferential, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma17g03380
+C/VIF1	pectinesterase inhibitor 	glyma.Wm82.gnm1.ann1.Glyma17g04050
+MTO3	METHIONINE OVER-ACCUMULATOR 3	glyma.Wm82.gnm1.ann1.Glyma17g04340
+DGAT3A	diacylglycerol acyltransferase 3 gene A	glyma.Wm82.gnm1.ann1.Glyma17g04650
+KASIIa	3-ketoacyl-ACP synthase II	glyma.Wm82.gnm1.ann1.Glyma17g05200
+MKK2a	Mitogen-activated protein kinase kinase 2 gene a	glyma.Wm82.gnm1.ann1.Glyma17g06020
+UC2	Uncharacterized protein 2	glyma.Wm82.gnm1.ann1.Glyma17G07200
+XTH43f	xyloglucan endotransglycosylase/hydrolase	glyma.Wm82.gnm1.ann1.Glyma17g07250
+RR02	Ubiquitous, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma17g10170
+PAP28	Purple acid phosphatase 28 gene	glyma.Wm82.gnm1.ann1.Glyma17g11790
+EXLB10	expansin-like B gene 10	glyma.Wm82.gnm1.ann1.Glyma17g15640
+EXLB11	expansin-like B gene 11	glyma.Wm82.gnm1.ann1.Glyma17g15670
+EXLB12	expansin-like B gene 12	glyma.Wm82.gnm1.ann1.Glyma17g15680
+EXLB13	expansin-like B gene 13	glyma.Wm82.gnm1.ann1.Glyma17g15690
+EXLB14	expansin-like B gene 14	glyma.Wm82.gnm1.ann1.Glyma17g15710
+EXLB15	expansin-like B gene 15	glyma.Wm82.gnm1.ann1.Glyma17g16210
+PRR47	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma17g16360
+VQ66	VQ motif containing protein gene 66	glyma.Wm82.gnm1.ann1.Glyma17g17210
+POT	proton-dependent oligopeptide transport  family protein  	glyma.Wm82.gnm1.ann1.Glyma17g25390
+RR27	Root Specific, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma17g33230
+HK04	Root Specific, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma17g33670
+PAP29	Purple acid phosphatase 29 gene	glyma.Wm82.gnm1.ann1.Glyma18g00410
+VQ67	VQ motif containing protein gene 67	glyma.Wm82.gnm1.ann1.Glyma18g02140
+HSP21	HEAT SHOCK PROTEIN 21	glyma.Wm82.gnm1.ann1.Glyma18g10760
+VQ68	VQ motif containing protein gene 68	glyma.Wm82.gnm1.ann1.Glyma18g13001
+RR05	Ubiquitous, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma18g17330
+PAP30	Purple acid phosphatase 30 gene	glyma.Wm82.gnm1.ann1.Glyma18g17580
+NAB	Nucleic Acids Binding protein	glyma.Wm82.gnm1.ann1.Glyma18G40360
+MPK4d	Mitogen-activated protein kinase kinase 4 gene d	glyma.Wm82.gnm1.ann1.Glyma18g47140
+FT1a	Flowering Locus T 1 gene a	glyma.Wm82.gnm1.ann1.Glyma18g53680
+FT1b	Flowering Locus T 1 gene b	glyma.Wm82.gnm1.ann1.Glyma18g53690
+SWEET45	sucrose effluxer gene 45	glyma.Wm82.gnm1.ann1.Glyma18g53930
+SWEET46	sucrose effluxer gene 46	glyma.Wm82.gnm1.ann1.Glyma18g53940
+SWEET48	sucrose effluxer gene 48	glyma.Wm82.gnm1.ann1.Glyma19g01280
+PAP31	Purple acid phosphatase 31 gene	glyma.Wm82.gnm1.ann1.Glyma19g03220
+BCCP2	Biotin carboxyl carrier protein 2	glyma.Wm82.gnm1.ann1.Glyma19g03530
+FDL1920	Flowering Locus D-like gene 1920	glyma.Wm82.gnm1.ann1.Glyma19g20090
+COL13b	Constans-like 13b	glyma.Wm82.gnm1.ann1.Glyma19g27240
+FT3b	Flowering Locus T 3 gene b	glyma.Wm82.gnm1.ann1.Glyma19g28390
+FT5b	Flowering Locus T 5 gene b	glyma.Wm82.gnm1.ann1.Glyma19g28400
+VQ69	VQ motif containing protein gene 69	glyma.Wm82.gnm1.ann1.Glyma19g30531
+VQ70	VQ motif containing protein gene 70	glyma.Wm82.gnm1.ann1.Glyma19g31080
+RR10	Ubiquitous, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma19g31320
+HP06	Root Preferential, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma19g33420
+RR35	Root Preferential, Response Regulator Type-C	glyma.Wm82.gnm1.ann1.Glyma19g35470
+RR36	Root Specific, Response Regulator Type-C	glyma.Wm82.gnm1.ann1.Glyma19g35480
+PHA1	plasma membrane H+-ATPase gene 1	glyma.Wm82.gnm1.ann1.Glyma19g35930
+PAP32	Purple acid phosphatase 32 gene	glyma.Wm82.gnm1.ann1.Glyma19g37850
+PAP33	Purple acid phosphatase 33 gene	glyma.Wm82.gnm1.ann1.Glyma19g37860
+VQ71	VQ motif containing protein gene 71	glyma.Wm82.gnm1.ann1.Glyma19g38980
+COL11b	Constans-like 11b	glyma.Wm82.gnm1.ann1.Glyma19g39460
+ERS1	Ubiquitous, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma19g40090
+NIP30	NEFA interacting protein 30	glyma.Wm82.gnm1.ann1.Glyma19G40910
+E3	Phytochrome A2	glyma.Wm82.gnm1.ann1.Glyma19g41210
+VQ72	VQ motif containing protein gene 72	glyma.Wm82.gnm1.ann1.Glyma19g43590
+PRR40	Root Preferential, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma19g44970
+PAP34	Purple acid phosphatase 34 gene	glyma.Wm82.gnm1.ann1.Glyma20g01470
+PAP35	Purple acid phosphatase 35 gene	glyma.Wm82.gnm1.ann1.Glyma20g03260
+NAC148	NAC Transcription Factor gene 148	glyma.Wm82.gnm1.ann1.Glyma20g04400
+COL9b	Constans-like 9b	glyma.Wm82.gnm1.ann1.Glyma20g07051
+FDL20	Flowering Locus D-like gene 20	glyma.Wm82.gnm1.ann1.Glyma20g10060
+VQ73	VQ motif containing protein gene 73	glyma.Wm82.gnm1.ann1.Glyma20g15230
+HMGB6	Transcription factor	glyma.Wm82.gnm1.ann1.Glyma20g23370
+COL14a, COL7b	Constans-like 7b	glyma.Wm82.gnm1.ann1.Glyma20g24940
+VQ74	VQ motif containing protein gene 74	glyma.Wm82.gnm1.ann1.Glyma20g25070
+GI1	gigantea protein gene 1	glyma.Wm82.gnm1.ann1.Glyma20g30980
+UC1	Uncharacterized protein 1, but possessing aMyb-DNA binding domain	glyma.Wm82.gnm1.ann1.Glyma20G32540
+Lbc2A	Leghemoglobin C2 gene A	glyma.Wm82.gnm1.ann1.Glyma20g33290
+HP05	Ubiquitous, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma20g37450
+PLDZ1	PHOSPHOLIPASE D ZETA1	glyma.Wm82.gnm1.ann1.Glyma20g38200
+MYB128	MYB transcription factor MYB128	glyma.Wm82.gnm2.ann1.Glyma.01g003000
+PPR1	Psudo-Response Regulator gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G003400
+PPR2	Psudo-Response Regulator gene 2	glyma.Wm82.gnm2.ann1.Glyma.01G004400
+NAC001	NAC Transcription Factor gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G005500
+ARGS	arginyl-tRNA synthetase	glyma.Wm82.gnm2.ann1.Glyma.01g006400
+IQD1	protein IQ-DOMAIN 1	glyma.Wm82.gnm2.ann1.Glyma.01g007000
+RDR3	RNA-dependent RNA polymerase	glyma.Wm82.gnm2.ann1.Glyma.01g008700
+PHR1	MYB-CC domain-containing transcription factor PHR1	glyma.Wm82.gnm2.ann1.Glyma.01g009600
+SLTI248	DEAD-box RNA helicase	glyma.Wm82.gnm2.ann1.Glyma.01g010400
+PPR3	Psudo-Response Regulator gene 3	glyma.Wm82.gnm2.ann1.Glyma.01G011300
+PPR4	Psudo-Response Regulator gene 4	glyma.Wm82.gnm2.ann1.Glyma.01G011700
+CRK1	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.01g013500
+HSF-02	heat stress transcription factor 2	glyma.Wm82.gnm2.ann1.Glyma.01g015900
+GH1, IAA1	Indole-3-Acetic Acid Responsive Gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G019400
+SYMRK-ALPHA	symbiosis receptor kinase SymRK-alpha	glyma.Wm82.gnm2.ann1.Glyma.01g020100
+ERF1	Ethylene-responsive factor gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G025400
+ALAAT2	alanine aminotransferase 2	glyma.Wm82.gnm2.ann1.Glyma.01g026700
+CRK2	cysteine-rich receptor-like protein kinase 2	glyma.Wm82.gnm2.ann1.Glyma.01g028100
+N-36A	early nodulin-36A	glyma.Wm82.gnm2.ann1.Glyma.01g028500
+ALDH2B1	aldehyde dehydrogenase family 2 member B1	glyma.Wm82.gnm2.ann1.Glyma.01g031500
+MMP2	Matrix metalloproteinase 2 gene	glyma.Wm82.gnm2.ann1.Glyma.01g036900
 GER5	germin-like protein 5	glyma.Wm82.gnm2.ann1.Glyma.01g037800
-GER6	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.10g168900
-GER7	germin-like protein 7	glyma.Wm82.gnm2.ann1.Glyma.08g226800
-GER8	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.07g038500
-GER9	germin-like protein 9	glyma.Wm82.gnm2.ann1.Glyma.07g039100
+MYB158	transcription factor MYB1R1	glyma.Wm82.gnm2.ann1.Glyma.01g0386002
+IAA2	Indole-3-Acetic Acid Responsive Gene 2	glyma.Wm82.gnm2.ann1.Glyma.01G039300
+GSTU1	tau class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.01g040000
+PLP2	proteolipid protein 2 (colonic epithelium-enriched)	glyma.Wm82.gnm2.ann1.Glyma.01g042300
+IQD2	protein IQ-DOMAIN 2	glyma.Wm82.gnm2.ann1.Glyma.01g043800
+TCP1	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G045500
+SLD1.1	delta8-sphingolipid desaturase 1	glyma.Wm82.gnm2.ann1.Glyma.01g046000
+SG-4, UGT73P10	Plant uridine 5' -diphosphate glycosyltransferase 73P10	glyma.Wm82.gnm2.ann1.Glyma.01g046300
+NAC002	NAC Transcription Factor gene 2	glyma.Wm82.gnm2.ann1.Glyma.01G046800
+PPR5	Psudo-Response Regulator gene 5	glyma.Wm82.gnm2.ann1.Glyma.01G048100
+PHR2	MYB-CC domain-containing transcription factor PHR2	glyma.Wm82.gnm2.ann1.Glyma.01g049100
+NAC003, NAC1	NAC domain protein NAC1	glyma.Wm82.gnm2.ann1.Glyma.01g051300
+WRKY3	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.01G056800
+SGF14e	14-3-3 protein SGF14e	glyma.Wm82.gnm2.ann1.Glyma.01g058000
+PPR6	Psudo-Response Regulator gene 6	glyma.Wm82.gnm2.ann1.Glyma.01G060400
+SABATH1	salicylic acid methyl transferase-like protein	glyma.Wm82.gnm2.ann1.Glyma.01g063100
+AP1b	Apetella 1 gene b	glyma.Wm82.gnm2.ann1.Glyma.01g064200
+bZIP2	Basic leucine zipper transcription factor-like protein gene 2	glyma.Wm82.gnm2.ann1.Glyma.01G069300
+CIM1	cytokinin induced message	glyma.Wm82.gnm2.ann1.Glyma.01g077000
+MKS2	methylketone synthase 2	glyma.Wm82.gnm2.ann1.Glyma.01g080400
+ERF2	Ethylene-responsive factor gene  2	glyma.Wm82.gnm2.ann1.Glyma.01G081100
+MED14-3	Mediator Complex 14 gene 3	glyma.Wm82.gnm2.ann1.Glyma.01G083100
+ALMT1	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.01g083700
+FWL7	protein FW2.2-like 7	glyma.Wm82.gnm2.ann1.Glyma.01g084000
+TGA01	bZIP transcription factor 1	glyma.Wm82.gnm2.ann1.Glyma.01g084200
+MED25-2	Mediator Complex 25 gene 2	glyma.Wm82.gnm2.ann1.Glyma.01G086600
+AOC1	allene oxide cyclase 4, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.01g086900
+RAV1	AP2/ERF transcription factor family protein RAV1	glyma.Wm82.gnm2.ann1.Glyma.01g087500
+NAC004	NAC Transcription Factor gene 4	glyma.Wm82.gnm2.ann1.Glyma.01G088200
+PEPC1	Phosphoenolpyruvate carboxylase gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G091000
+CHS11, CHS6a	Chalcone and stilbene synthases, C-terminal domain; Chalcone and stilbene synthases, N-terminal domain 6 gene a	glyma.Wm82.gnm2.ann1.Glyma.01G091400
+PHO1-H12	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.01g091800
+KTi1	Kunitz-type trypsin inhibitor	glyma.Wm82.gnm2.ann1.Glyma.01g095000
+IAA3	Indole-3-Acetic Acid Responsive Gene 3	glyma.Wm82.gnm2.ann1.Glyma.01G098000
+ALDH18B1	delta-1-pyrroline-5-carboxylate synthase	glyma.Wm82.gnm2.ann1.Glyma.01g099800
+GSTU4	tau class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.01g106000
+Lac1	Laccase 1	glyma.Wm82.gnm2.ann1.Glyma.01G108200
+Lac2	Laccase 2	glyma.Wm82.gnm2.ann1.Glyma.01G112600
+PIP1-9	aquaporin PIP1-9	glyma.Wm82.gnm2.ann1.Glyma.01g113400
+LAX1	auxin transporter-like protein 1	glyma.Wm82.gnm2.ann1.Glyma.01g114000
+Sle3	Group-1 late embryogenesis abundant protein 3 gene	glyma.Wm82.gnm2.ann1.Glyma.01g119600
+FAD8-1	fatty acid desaturase 8	glyma.Wm82.gnm2.ann1.Glyma.01g120400
+AMT2.3	ammonium transporter AMT2.3	glyma.Wm82.gnm2.ann1.Glyma.01g123400
+SFERH-2	ferritin	glyma.Wm82.gnm2.ann1.Glyma.01g124500
+DIR22	dirigent protein 22	glyma.Wm82.gnm2.ann1.Glyma.01g127200
+PIB1	bHLH transcription factor PIB1	glyma.Wm82.gnm2.ann1.Glyma.01g129700
+LBD1	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.01g131000
+PT01	glycinol 2-dimethylallyl transferase	glyma.Wm82.gnm2.ann1.Glyma.01g134600
+SPX1	SPX domain-containing protein 1	glyma.Wm82.gnm2.ann1.Glyma.01g135500
+GOS12	SNARE GOS12	glyma.Wm82.gnm2.ann1.Glyma.01g137300
+GSTZ1	glutathione S-transferase zeta class	glyma.Wm82.gnm2.ann1.Glyma.01g142800
+HSF-05	heat stress transcription factor 5	glyma.Wm82.gnm2.ann1.Glyma.01g143500
+LBD3	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.01g143900
+CYP42	peptidyl-prolyl cis-trans isomerase CYP42	glyma.Wm82.gnm2.ann1.Glyma.01g144800
+GLYI-1	Glyoxylase 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.01g146300
+GRF1	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.01g148600
+ANK4	ankyrin repeats-containing protein	glyma.Wm82.gnm2.ann1.Glyma.01g150400
+LEA2-1	late embryogenesis abundant 2 gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G152600
+GPRP4	glycine-rich protein A3-like	glyma.Wm82.gnm2.ann1.Glyma.01g154000
+C2-1	C2 domain containing protein gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G162100
+NRPB1-1	DNA-directed RNA polymerase II subunit 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.01g162200
+LUXA	transcription factor LUXa	glyma.Wm82.gnm2.ann1.Glyma.01g162600
+FDa1	Flowering Locus D	glyma.Wm82.gnm2.ann1.Glyma.01G163500
+APX-5a1	Ascorbate peroxidase 5 gene a1	glyma.Wm82.gnm2.ann1.Glyma.01G164700
+NAC005	NAC Transcription Factor gene 5	glyma.Wm82.gnm2.ann1.Glyma.01G167900
+GLYI-2	Glyoxylase 1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.01g168400
+AP3a	Apetala 3 gene a	glyma.Wm82.gnm2.ann1.Glyma.01G169600
+Lac3	Laccase 3	glyma.Wm82.gnm2.ann1.Glyma.01G173500
+Lac4	Laccase 4	glyma.Wm82.gnm2.ann1.Glyma.01G173600
+bZIP6	Basic leucine zipper transcription factor-like protein gene 6	glyma.Wm82.gnm2.ann1.Glyma.01G177400
+BEHL1	BES1/BZR1 family protein	glyma.Wm82.gnm2.ann1.Glyma.01g178000
+LYK4	lysM domain receptor-like kinase 4	glyma.Wm82.gnm2.ann1.Glyma.01g179000
+NFR5B	Nod-factor receptor 5B	glyma.Wm82.gnm2.ann1.Glyma.01g179100
+Lac5	Laccase 5	glyma.Wm82.gnm2.ann1.Glyma.01G183100
+LBD4	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.01g183900
+HSF-01	heat stress transcription factor 1	glyma.Wm82.gnm2.ann1.Glyma.01g185800
+WRKY5	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.01G189100
+MYB112	MYB transcription factor MYB112	glyma.Wm82.gnm2.ann1.Glyma.01g190100
+NRAMP1A	divalent metal ion transporter NRAMP1a	glyma.Wm82.gnm2.ann1.Glyma.01g190700
+LBD5	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.01g192600
+SCA1	plasma membrane Ca2+-ATPase	glyma.Wm82.gnm2.ann1.Glyma.01g193600
+CYP19	peptidyl-prolyl cis-trans isomerase CYP19	glyma.Wm82.gnm2.ann1.Glyma.01g194100
+bZIP7	Basic leucine zipper transcription factor-like protein gene 7	glyma.Wm82.gnm2.ann1.Glyma.01G195800
+RLK3	receptor-like protein kinase 3	glyma.Wm82.gnm2.ann1.Glyma.01g197800
+ALMT2	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.01g199400
+C2-2	C2 domain containing protein gene 2	glyma.Wm82.gnm2.ann1.Glyma.01G202200
+BMY3-2	Beta-amylase 3 gene 2	glyma.Wm82.gnm2.ann1.Glyma.01g203400
+SPK-1	protein kinase	glyma.Wm82.gnm2.ann1.Glyma.01g204200
+CYP31	peptidyl-prolyl cis-trans isomerase CYP31	glyma.Wm82.gnm2.ann1.Glyma.01g204300
+ERF4	Ethylene-responsive factor gene 4	glyma.Wm82.gnm2.ann1.Glyma.01G206700
+INV	alkaline/neutral invertase	glyma.Wm82.gnm2.ann1.Glyma.01G211000
+ACS10a	ACC Synthase 10 gene a	glyma.Wm82.gnm2.ann1.Glyma.01G213700
+ANS2	Anthocyanidin synthase 2	glyma.Wm82.gnm2.ann1.Glyma.01g214200
+SGR2	Stay-green gene 2	glyma.Wm82.gnm2.ann1.Glyma.01g214600
+C2-3	C2 domain containing protein gene 3	glyma.Wm82.gnm2.ann1.Glyma.01G215100
+IQD3	protein IQ-DOMAIN 3	glyma.Wm82.gnm2.ann1.Glyma.01g217200
+HSF-03	heat stress transcription factor 3	glyma.Wm82.gnm2.ann1.Glyma.01g217400
+OLPb	PR-5b protein	glyma.Wm82.gnm2.ann1.Glyma.01g217700
+C2-4	C2 domain containing protein gene 4	glyma.Wm82.gnm2.ann1.Glyma.01G219200
+PIP1-3	aquaporin PIP1-3	glyma.Wm82.gnm2.ann1.Glyma.01g220600
+MPK4	mitogen-activated protein kinase 4	glyma.Wm82.gnm2.ann1.Glyma.01G222000
+SGT1-1	Suppressor of the G2 allele of SKP1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.01g222400
+LEA2-2	late embryogenesis abundant 2 gene 2	glyma.Wm82.gnm2.ann1.Glyma.01G222800
+ALMT3	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.01g223300
+LEA2-3	late embryogenesis abundant 2 gene 3	glyma.Wm82.gnm2.ann1.Glyma.01G226100
+CHS7	chalcone synthase 7	glyma.Wm82.gnm2.ann1.Glyma.01g228700
+PPR7	Psudo-Response Regulator gene 7	glyma.Wm82.gnm2.ann1.Glyma.01G230500
+4CL4	4-coumarate:coenzyme A ligase gene 4	glyma.Wm82.gnm2.ann1.Glyma.01g232400
+HSF-04	heat stress transcription factor 4	glyma.Wm82.gnm2.ann1.Glyma.01g233000
+PPR8	Psudo-Response Regulator gene 8	glyma.Wm82.gnm2.ann1.Glyma.01G234100
+GRF2	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.01g234400
+PPR9	Psudo-Response Regulator gene 9	glyma.Wm82.gnm2.ann1.Glyma.01G236000
+PPR10	Psudo-Response Regulator gene 10	glyma.Wm82.gnm2.ann1.Glyma.01G237100
+HIDH	2-hydroxyisoflavanone dehydratase	glyma.Wm82.gnm2.ann1.Glyma.01g239600
+KAPP2	kinase-associated protein phosphatase 2	glyma.Wm82.gnm2.ann1.Glyma.01g239700
+COBL1	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.01G240200
+LEA2-4	late embryogenesis abundant 2 gene 4	glyma.Wm82.gnm2.ann1.Glyma.01G240600
+CRK3	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.01g240800
+CRK4	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.01g240900
+CRK5	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.01g241000
+C2-5	C2 domain containing protein gene 5	glyma.Wm82.gnm2.ann1.Glyma.01G244500
+HDA1	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.01g245100
+IAA4	Indole-3-Acetic Acid Responsive Gene 4	glyma.Wm82.gnm2.ann1.Glyma.02G000500
+SEOA	sieve element occlusion a	glyma.Wm82.gnm2.ann1.Glyma.02g000700
+SCAM-5	calmodulin	glyma.Wm82.gnm2.ann1.Glyma.02g002100
+PHO1-H1	phosphate transporter PHO1-like	glyma.Wm82.gnm2.ann1.Glyma.02g003700
+IQD4	protein IQ-DOMAIN 4	glyma.Wm82.gnm2.ann1.Glyma.02g004600
+CRY2B	Cryptochrome 2-like	glyma.Wm82.gnm2.ann1.Glyma.02g005700
+PHT1-14	inorganic phosphate transporter 1-14	glyma.Wm82.gnm2.ann1.Glyma.02g005800
+TOPP1	TOPP-type protein phosphatase gene 1	glyma.Wm82.gnm2.ann1.Glyma.02G006000
+IAA5	Indole-3-Acetic Acid Responsive Gene 5	glyma.Wm82.gnm2.ann1.Glyma.02G007300
+ATG8i	autophagy-related protein 8i	glyma.Wm82.gnm2.ann1.Glyma.02g008800
+MYB76	MYB transcription factor MYB76	glyma.Wm82.gnm2.ann1.Glyma.02g009800
+GA2OX1	gibberellin 2-beta-dioxygenase 1	glyma.Wm82.gnm2.ann1.Glyma.02g010100
+WRKY9	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.02G010900
+LE1, Le1-1	Lectin 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02g012600
+EBP, ERF8	Ethylene-responsive factor gene 8	glyma.Wm82.gnm2.ann1.Glyma.02G016100
+CEL7	alpha family endo-beta-1,4-glucanase	glyma.Wm82.gnm2.ann1.Glyma.02g016400
+HIUHase	hydroxyisourate hydrolase	glyma.Wm82.gnm2.ann1.Glyma.02g018700
+IQD5	protein IQ-DOMAIN 5	glyma.Wm82.gnm2.ann1.Glyma.02g019700
+PLP1	PAS/LOV protein 1	glyma.Wm82.gnm2.ann1.Glyma.02g022000
+HDL57	homeodomain-leucine zipper protein 57	glyma.Wm82.gnm2.ann1.Glyma.02g022300
+GSTIR	TIR-NBS-LRR type disease resistance protein	glyma.Wm82.gnm2.ann1.Glyma.02g023800
+GSTU8	glutathione S-transferase U17-like	glyma.Wm82.gnm2.ann1.Glyma.02g024800
+MYB138	MYB transcription factor MYB138	glyma.Wm82.gnm2.ann1.Glyma.02g026300
+SLTI114	matrix metalloproteinase	glyma.Wm82.gnm2.ann1.Glyma.02g028100
+ANK6	ankyrin repeats-containing protein	glyma.Wm82.gnm2.ann1.Glyma.02g033700
+ALDH2B2	aldehyde dehydrogenase family 2 member B2	glyma.Wm82.gnm2.ann1.Glyma.02g034000
+CRK6	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.02g037100
+CRK7	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.02g037200
+ERF9, ESR1	ethylene-responsive transcription factor ESR1	glyma.Wm82.gnm2.ann1.Glyma.02g039300
+SVPL	MADS-box protein SVP-like	glyma.Wm82.gnm2.ann1.Glyma.02g041500
+CHIA1	chitinase class I	glyma.Wm82.gnm2.ann1.Glyma.02g042500
+AMT4.4	ammonium transporter AMT4.4	glyma.Wm82.gnm2.ann1.Glyma.02g043700
+FDb1	Flowering Locus D	glyma.Wm82.gnm2.ann1.Glyma.02G045500
+F3H	flavanone 3-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.02g048400
+RPL2	ribosomal protein L2	glyma.Wm82.gnm2.ann1.Glyma.02g049300
+NAC153	NAC domain-containing protein 153	glyma.Wm82.gnm2.ann1.Glyma.02g050100
+ALDH3F1	aldehyde dehydrogenase family 3 member F1	glyma.Wm82.gnm2.ann1.Glyma.02g051500
+SABATH2, SAMT1.02	salicylic acid methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.02G054200
+ERF10	Ethylene-responsive factor gene 10	glyma.Wm82.gnm2.ann1.Glyma.02G066200
+ERF11	Ethylene-responsive factor gene 11	glyma.Wm82.gnm2.ann1.Glyma.02G067600
+FT2C, FT2c-N	Flowering Locus T gene 2c	glyma.Wm82.gnm2.ann1.Glyma.02G069200
+SIP1-1	aquaporin SIP1-1	glyma.Wm82.gnm2.ann1.Glyma.02g069800
+NAC007	NAC Transcription Factor gene 7	glyma.Wm82.gnm2.ann1.Glyma.02G070600.
+PHR3	MYB-CC domain-containing transcription factor PHR3	glyma.Wm82.gnm2.ann1.Glyma.02g070900
+PPR11	Psudo-Response Regulator gene 11	glyma.Wm82.gnm2.ann1.Glyma.02G071600
+ERF12	Ethylene-responsive factor gene 12	glyma.Wm82.gnm2.ann1.Glyma.02G072800
+PIP2-9	aquaporin PIP2-9	glyma.Wm82.gnm2.ann1.Glyma.02g073600
+PIP2-12	aquaporin PIP2-12	glyma.Wm82.gnm2.ann1.Glyma.02g073700
+GR-1b	Cytosolic glutathione reductase 1 gene b	glyma.Wm82.gnm2.ann1.Glyma.02G074200
+PM31	seed maturation protein PM31	glyma.Wm82.gnm2.ann1.Glyma.02g076600
+RSP13	ribosomal protein S13	glyma.Wm82.gnm2.ann1.Glyma.02g078000
+ERF13	Ethylene-responsive factor gene 13	glyma.Wm82.gnm2.ann1.Glyma.02G080200
+SWEET1	sugar efflux transporter SWEET1	glyma.Wm82.gnm2.ann1.Glyma.02g088400
+MED37-1	Mediator Complex 37 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02g093200
+C2-6	C2 domain containing protein gene 6	glyma.Wm82.gnm2.ann1.Glyma.02G093500
+G6PDH5	Glucose-6-phosphate dehydrogenase gene 5	glyma.Wm82.gnm2.ann1.Glyma.02G096800
+ALMT4	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.02g097700
+bZIP12, TGA02	bZIP transcription factor 2	glyma.Wm82.gnm2.ann1.Glyma.02g097900
+MED25-1	Mediator Complex 25 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02g098300
+MED25-3	Mediator Complex 25 gene 3	glyma.Wm82.gnm2.ann1.Glyma.02G098500
+NAC008	NAC Transcription Factor gene 8	glyma.Wm82.gnm2.ann1.Glyma.02G100200
+SIK1	stress-induced receptor-like kinase	glyma.Wm82.gnm2.ann1.Glyma.02g100300
+BHLH30	Basic helix-loop-helix transcription factor 30	glyma.Wm82.gnm2.ann1.Glyma.02G100700
+PPR12	Psudo-Response Regulator gene 12	glyma.Wm82.gnm2.ann1.Glyma.02G102000
+ZOU-2	bHLH transcription factor ZOU-2	glyma.Wm82.gnm2.ann1.Glyma.02g103100
+ZOU-1	bHLH transcription factor ZOU-1	glyma.Wm82.gnm2.ann1.Glyma.02g103200
+CYP45	peptidyl-prolyl cis-trans isomerase CYP45	glyma.Wm82.gnm2.ann1.Glyma.02g105500
+TCP2	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 2	glyma.Wm82.gnm2.ann1.Glyma.02G105900
+SLD1.2, SLD2-1	delta(8)-fatty-acid desaturase 2 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02g106300
+NAC009	NAC Transcription Factor gene 9	glyma.Wm82.gnm2.ann1.Glyma.02G107000
+PHR4	MYB-CC domain-containing transcription factor PHR4	glyma.Wm82.gnm2.ann1.Glyma.02g108500
+CDF3b	Cycling Dof Factor 3 gene b	glyma.Wm82.gnm2.ann1.Glyma.02G108600
+EXP4	expansin 4	glyma.Wm82.gnm2.ann1.Glyma.02g109100
+NAC010, NAC26, NAC29	NAC domain-containing protein	glyma.Wm82.gnm2.ann1.Glyma.02G109800
+PHO1-H13	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.02g110600
+WRKY11	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.02G112100
+EIF5A	eukaryotic translation initiation factor 5A	glyma.Wm82.gnm2.ann1.Glyma.02g112400
+WRKY12	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.02G115200
+SGF14f	14-3-3 protein SGF14f	glyma.Wm82.gnm2.ann1.Glyma.02g115900
+PPR13	Psudo-Response Regulator gene 13	glyma.Wm82.gnm2.ann1.Glyma.02G118600
+CrRLk1L01	CrRLK1-Like Kinase 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02G121900
+CrRLk1L02	CrRLK1-Like Kinase 1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.02G122000
+GH3.1	auxin synthesis-related gene	glyma.Wm82.gnm2.ann1.Glyma.02G125600
+bZIP13	Basic leucine zipper transcription factor-like protein gene 13	glyma.Wm82.gnm2.ann1.Glyma.02G126100
+PSK-GAMMA1	phytosulfokine-gamma1	glyma.Wm82.gnm2.ann1.Glyma.02g126200
+SAMDC	S-adenosylmethionine decarboxylase	glyma.Wm82.gnm2.ann1.Glyma.02g128000
+PHO1-H14	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.02g130200
+CHS10, CHS6c	Chalcone and stilbene synthases, C-terminal domain; Chalcone and stilbene synthases, N-terminal domain 6 gene c	glyma.Wm82.gnm2.ann1.Glyma.02G130400
+PEPC2	Phosphoenolpyruvate carboxylase gene 2	glyma.Wm82.gnm2.ann1.Glyma.02G130700
+ABF1, BZIP1, bZIP14	Basic leucine zipper transcription factor-like protein gene 14	glyma.Wm82.gnm2.ann1.Glyma.02G131700
+NIR, NIR1-1	nitrate reductase 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02g132100
+ERF14	Ethylene-responsive factor gene 14	glyma.Wm82.gnm2.ann1.Glyma.02G132500
+PPR14	Psudo-Response Regulator gene 14	glyma.Wm82.gnm2.ann1.Glyma.02G133100
+CYP17	peptidyl-prolyl cis-trans isomerase CYP17	glyma.Wm82.gnm2.ann1.Glyma.02g134800
+C2-7	C2 domain containing protein gene 7	glyma.Wm82.gnm2.ann1.Glyma.02G137500
+C2-8	C2 domain containing protein gene 8	glyma.Wm82.gnm2.ann1.Glyma.02G137700
+IQD6	protein IQ-DOMAIN 6	glyma.Wm82.gnm2.ann1.Glyma.02g138000
+ACPD, ACPD-1, FAB2, SACPD, SAD1	stearoyl-acyl carrier protein desaturase	glyma.Wm82.gnm2.ann1.Glyma.02g138100
+MAPK2	mitogen-activated protein kinase 2	glyma.Wm82.gnm2.ann1.Glyma.02g138800
+NIP7-1	aquaporin NIP7-1	glyma.Wm82.gnm2.ann1.Glyma.02g140500
+GR, GR-2b	Chloroplastic glutathione reductase 2 gene b	glyma.Wm82.gnm2.ann1.Glyma.02G141800
+GSH1	gamma glutamylcysteine synthestase	glyma.Wm82.gnm2.ann1.Glyma.02G142000
+IAA6	Indole-3-Acetic Acid Responsive Gene 6	glyma.Wm82.gnm2.ann1.Glyma.02G142400
+IAA7	Indole-3-Acetic Acid Responsive Gene 7	glyma.Wm82.gnm2.ann1.Glyma.02G142500
+IAA8	Indole-3-Acetic Acid Responsive Gene 8	glyma.Wm82.gnm2.ann1.Glyma.02G142600
+AMT4.5	ammonium transporter AMT4.5	glyma.Wm82.gnm2.ann1.Glyma.02g143500
+PPR15	Psudo-Response Regulator gene 15	glyma.Wm82.gnm2.ann1.Glyma.02G144100
+MCCA	3-methylcrotonyl-CoA carboxylase 1	glyma.Wm82.gnm2.ann1.Glyma.02g145300
+SBP2	sucrose-binding protein 2	glyma.Wm82.gnm2.ann1.Glyma.02g145700
+ALMT5	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.02g147900
+TIR1A	protein TRANSPORT INHIBITOR RESPONSE 1A	glyma.Wm82.gnm2.ann1.Glyma.02g152800
+GSTF1	glutathione S-transferase F1	glyma.Wm82.gnm2.ann1.Glyma.02g154300
+GSTF2	glutathione S-transferase F2	glyma.Wm82.gnm2.ann1.Glyma.02g154400
+NTF2B-5, NTF2B-6	nucleus transporter 2B gene 6	glyma.Wm82.gnm2.ann1.Glyma.02g156200
+FLD	Flowering locus D	glyma.Wm82.gnm2.ann1.Glyma.02g159100
+PPR16	Psudo-Response Regulator gene 16	glyma.Wm82.gnm2.ann1.Glyma.02G160400
+bZIP15	Basic leucine zipper transcription factor-like protein gene 15	glyma.Wm82.gnm2.ann1.Glyma.02G161100
+PPR17	Psudo-Response Regulator gene 17	glyma.Wm82.gnm2.ann1.Glyma.02G164800
+SDP6	glycerol-3-phosphate dehydrogenase SDP6, mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.02g165500
+LBD6	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g166400
+VTE2-2	homogentisate phytyltransferase VTE2-2	glyma.Wm82.gnm2.ann1.Glyma.02g168000
+POD	peroxidase	glyma.Wm82.gnm2.ann1.Glyma.02g171600
+PPR18	Psudo-Response Regulator gene 18	glyma.Wm82.gnm2.ann1.Glyma.02G174500
+C2-9	C2 domain containing protein gene 9	glyma.Wm82.gnm2.ann1.Glyma.02G176700
+TGA03	bZIP transcription factor 3	glyma.Wm82.gnm2.ann1.Glyma.02g176800
+SPL9A	squamosa promoter-binding-like protein 9a	glyma.Wm82.gnm2.ann1.Glyma.02g177500
+PHR5	MYB-CC domain-containing transcription factor PHR5	glyma.Wm82.gnm2.ann1.Glyma.02g177800
+PHR6	MYB-CC domain-containing transcription factor PHR6	glyma.Wm82.gnm2.ann1.Glyma.02g178100
+MATE13	citrate-proton symporter	glyma.Wm82.gnm2.ann1.Glyma.02g181800
+GSTU9	glutathione S-transferase GST 19	glyma.Wm82.gnm2.ann1.Glyma.02g187200
+SDP1-1	triacylglycerol lipase SDP1	glyma.Wm82.gnm2.ann1.Glyma.02g190000
+NF-YA01	nuclear transcription factor Y subunit A-1	glyma.Wm82.gnm2.ann1.Glyma.02g195000
+PUB8	E3 ubiquitin-protein ligase PUB8	glyma.Wm82.gnm2.ann1.Glyma.02g195900
+COBL2	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.02G196100
+LEA2-5	late embryogenesis abundant 2 gene 5	glyma.Wm82.gnm2.ann1.Glyma.02G197600
+LEA2-6	late embryogenesis abundant 2 gene 6	glyma.Wm82.gnm2.ann1.Glyma.02G197800
+SPY1	probable UDP-N-acetylglucosamine--peptide N-acetylglucosaminyltransferase SPINDLY-like	glyma.Wm82.gnm2.ann1.Glyma.02g201300
+PPR19	Psudo-Response Regulator gene 19	glyma.Wm82.gnm2.ann1.Glyma.02G201800
+ALDH11A1	aldehyde dehydrogenase 11A1	glyma.Wm82.gnm2.ann1.Glyma.02g202500
+FAD6.1	omega-6 fatty acid desaturase, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.02g203300
+PPR20	Psudo-Response Regulator gene 20	glyma.Wm82.gnm2.ann1.Glyma.02G205900
+SGF14G	14-3-3 protein SGF14g	glyma.Wm82.gnm2.ann1.Glyma.02g208700
+APX-4a	Ascorbate peroxidase 4 gene a	glyma.Wm82.gnm2.ann1.Glyma.02G209000
+Raf6-4	Raf6 proto-oncogene serine/threonine protein kinase gene 4	glyma.Wm82.gnm2.ann1.Glyma.02G215300
+SMEP1	metalloproteinase	glyma.Wm82.gnm2.ann1.Glyma.02g215700
+PPR21	Psudo-Response Regulator gene 21	glyma.Wm82.gnm2.ann1.Glyma.02G217200
+IAA9	Indole-3-Acetic Acid Responsive Gene 9	glyma.Wm82.gnm2.ann1.Glyma.02G218100
+GTR1	glutamyl-tRNA reductase 1	glyma.Wm82.gnm2.ann1.Glyma.02g218300
+GLYII-1	hydroxyacylglutathione hydrolase cytoplasmic-like	glyma.Wm82.gnm2.ann1.Glyma.02g220100
+C2-10	C2 domain containing protein gene 10	glyma.Wm82.gnm2.ann1.Glyma.02G220300
+NAC012, NAC22	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.02g222300
+Lac6	Laccase 6	glyma.Wm82.gnm2.ann1.Glyma.02G224800
+C2-11	C2 domain containing protein gene 11	glyma.Wm82.gnm2.ann1.Glyma.02G226800
+FAD3b	omega-3-fatty acid desaturase 3 gene 2	glyma.Wm82.gnm2.ann1.Glyma.02g227200
+PPR22	Psudo-Response Regulator gene 22	glyma.Wm82.gnm2.ann1.Glyma.02G227300
+Lac7	Laccase 7	glyma.Wm82.gnm2.ann1.Glyma.02G231600
+LBD7.2	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g234600
+WNK12	with no lysine kinase 12	glyma.Wm82.gnm2.ann1.Glyma.02g235700
+bZIP17	Basic leucine zipper transcription factor-like protein gene 17	glyma.Wm82.gnm2.ann1.Glyma.02G236200
+C4H	trans-cinnamate 4-monooxygenase	glyma.Wm82.gnm2.ann1.Glyma.02g236500
+ERF15	Ethylene-responsive factor gene 15	glyma.Wm82.gnm2.ann1.Glyma.02G236800
+LEA2-7	late embryogenesis abundant 2 gene 7	glyma.Wm82.gnm2.ann1.Glyma.02G239100
+ARF8A	auxin response factor 8a	glyma.Wm82.gnm2.ann1.Glyma.02g239600
+NAC013	NAC Transcription Factor gene 13	glyma.Wm82.gnm2.ann1.Glyma.02G240500
+GS, GS-gamma2-a, GS1GAMMA2	glutamine synthetase cytosolic isozyme 2	glyma.Wm82.gnm2.ann1.Glyma.02g244000
+GASA1	gibberellin-regulated protein 1	glyma.Wm82.gnm2.ann1.Glyma.02g245600
+NIP4-1	aquaporin NIP4-1	glyma.Wm82.gnm2.ann1.Glyma.02g246700
+C2-12	C2 domain containing protein gene 12	glyma.Wm82.gnm2.ann1.Glyma.02G247900
+C2-13	C2 domain containing protein gene 13	glyma.Wm82.gnm2.ann1.Glyma.02G248000
+C2-14	C2 domain containing protein gene 14	glyma.Wm82.gnm2.ann1.Glyma.02G248100
+RCAALPHA	ribulose bisphosphate carboxylase/oxygenase activase 1, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.02g249600
+LBD8	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g249700
+ALDH18B2	delta-1-pyrroline-5-carboxylate synthase	glyma.Wm82.gnm2.ann1.Glyma.02g251100
+TOPP2	TOPP-type protein phosphatase gene 2	glyma.Wm82.gnm2.ann1.Glyma.02G251600
+MYB83	MYB transcription factor MYB83	glyma.Wm82.gnm2.ann1.Glyma.02g254200
+PIP1-10	aquaporin PIP1-10	glyma.Wm82.gnm2.ann1.Glyma.02g255000
+HS1pro1	nematode resistance HS1pro1 protein	glyma.Wm82.gnm2.ann1.Glyma.02g255400
+LAX2	auxin transporter-like protein 2	glyma.Wm82.gnm2.ann1.Glyma.02g255800
+C2-15	C2 domain containing protein gene 15	glyma.Wm82.gnm2.ann1.Glyma.02G257000
+C2-16	C2 domain containing protein gene 16	glyma.Wm82.gnm2.ann1.Glyma.02G257100
+C2-17	C2 domain containing protein gene 17	glyma.Wm82.gnm2.ann1.Glyma.02G257200
+SNAP02	soluble NSF attachment protein SNAP02	glyma.Wm82.gnm2.ann1.Glyma.02g260400
+Lac8	Laccase 8	glyma.Wm82.gnm2.ann1.Glyma.02G261600
+AP2-8	dehydration-responsive element-binding protein 2C-like	glyma.Wm82.gnm2.ann1.Glyma.02g261700
+LBD9	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g262400
+FER2-1	ferritin	glyma.Wm82.gnm2.ann1.Glyma.02g262500
+LBD10	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g264500
+SGR	AP2-domain transcription factor SGR	glyma.Wm82.gnm2.ann1.Glyma.02g264700
+NGM-16	nodulin-16	glyma.Wm82.gnm2.ann1.Glyma.02g265200
+ERF16	Ethylene-responsive factor gene 16	glyma.Wm82.gnm2.ann1.Glyma.02G267400
+HS1	calcineurin-like metallophosphoesterase transmembrane protein	glyma.Wm82.gnm2.ann1.Glyma.02g269500
+RJ1	LysM-type receptor kinase NFR1alpha	glyma.Wm82.gnm2.ann1.Glyma.02g270800
+F-box protein2	F-box protein 2	glyma.Wm82.gnm2.ann1.Glyma.02G273700
+LEA2-8	late embryogenesis abundant 2 gene 8	glyma.Wm82.gnm2.ann1.Glyma.02G274400
+AGO4	Argonaut 4 ranscription factor	glyma.Wm82.gnm2.ann1.Glyma.02G274900
+ELF1B	elongation factor 1-beta	glyma.Wm82.gnm2.ann1.Glyma.02g276600
+LEA2-9	late embryogenesis abundant 2 gene 9	glyma.Wm82.gnm2.ann1.Glyma.02G277300
+C2-18	C2 domain containing protein gene 18	glyma.Wm82.gnm2.ann1.Glyma.02G279900
+NAC154, NAC42-1	transcription factor JUNGBRUNNEN 1	glyma.Wm82.gnm2.ann1.Glyma.02g284300
+CHL	chloroplastic lipocalin	glyma.Wm82.gnm2.ann1.Glyma.02g289400
+ERF17	Ethylene-responsive factor gene 17	glyma.Wm82.gnm2.ann1.Glyma.02G294100
+C2-19	C2 domain containing protein gene 19	glyma.Wm82.gnm2.ann1.Glyma.02G296900
+WRKY18	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.02G297400
+FBA	fructose-bisphosphate aldolase	glyma.Wm82.gnm2.ann1.Glyma.02g303000
+LEA2-10	late embryogenesis abundant 2 gene 10	glyma.Wm82.gnm2.ann1.Glyma.02G303100
+NF-YA02	nuclear transcription factor Y subunit A-2	glyma.Wm82.gnm2.ann1.Glyma.02g303800
+CHR6	chalcone reductase CHR6	glyma.Wm82.gnm2.ann1.Glyma.02g307300
+PAL3.1	phenylalanine ammonia-lyase 3.1	glyma.Wm82.gnm2.ann1.Glyma.02g309300
+LEA2-11	late embryogenesis abundant 2 gene 11	glyma.Wm82.gnm2.ann1.Glyma.03G000800
+B15-3-5	syringolide-induced protein B15-3-5	glyma.Wm82.gnm2.ann1.Glyma.03g001500
+WRKY20	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.03G002300
+bZIP18	Basic leucine zipper transcription factor-like protein gene 18	glyma.Wm82.gnm2.ann1.Glyma.03G003400
+PHR7	MYB-CC domain-containing transcription factor PHR7	glyma.Wm82.gnm2.ann1.Glyma.03g003500
+SCAM-1	calmodulin	glyma.Wm82.gnm2.ann1.Glyma.03g004100
+MED12-1	Mediator Complex 12 gene 1	glyma.Wm82.gnm2.ann1.Glyma.03g009200
+C2-20	C2 domain containing protein gene 20	glyma.Wm82.gnm2.ann1.Glyma.03G012600
+C2-21	C2 domain containing protein gene 21	glyma.Wm82.gnm2.ann1.Glyma.03G015400
+C2-22	C2 domain containing protein gene 22	glyma.Wm82.gnm2.ann1.Glyma.03G015800
+C2-23	C2 domain containing protein gene 23	glyma.Wm82.gnm2.ann1.Glyma.03G016000
+C2-24	C2 domain containing protein gene 24	glyma.Wm82.gnm2.ann1.Glyma.03G016100
+C2-25	C2 domain containing protein gene 25	glyma.Wm82.gnm2.ann1.Glyma.03G016200
+C2-26	C2 domain containing protein gene 26	glyma.Wm82.gnm2.ann1.Glyma.03G016300
+C2-27	C2 domain containing protein gene 27	glyma.Wm82.gnm2.ann1.Glyma.03G016400
+TCP3	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 3	glyma.Wm82.gnm2.ann1.Glyma.03G018800
+GA20OX1	gibberellin 20 oxidase 1	glyma.Wm82.gnm2.ann1.Glyma.03g019800
+C2-28	C2 domain containing protein gene 28	glyma.Wm82.gnm2.ann1.Glyma.03G020800
+ZPR1C	protein LITTLE ZIPPER 2-like	glyma.Wm82.gnm2.ann1.Glyma.03g022200
+LBD12	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.03g023000
+LBD13	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.03g023100
+AG1	arginase	glyma.Wm82.gnm2.ann1.Glyma.03g0280001
+CYP83E8	cytochrome P450 83B1-like	glyma.Wm82.gnm2.ann1.Glyma.03g029900
+PT03	prenyltransferase family protein PT03	glyma.Wm82.gnm2.ann1.Glyma.03g0331001
+EXPB3	putative expansin-B2-like	glyma.Wm82.gnm2.ann1.Glyma.03g033800
+WNK5	with no lysine kinase 5	glyma.Wm82.gnm2.ann1.Glyma.03g036500
+RPSHC18-NBL1	NB-LRR type disease resistance protein	glyma.Wm82.gnm2.ann1.Glyma.03g037100
+RPSHC18-NBL2	NB-LRR type disease resistance protein	glyma.Wm82.gnm2.ann1.Glyma.03g037300
+APX, POD1	Peroxidase 1	glyma.Wm82.gnm2.ann1.Glyma.03G038700
+PGM1	phosphoglucomutase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.03g042000
+Sle2	Group-1 late embryogenesis abundant protein 2 gene 	glyma.Wm82.gnm2.ann1.Glyma.03g056000
+FAD8-2, FAD8.2	omega-3 fatty acid desaturase, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.03g056700
+LAX3	auxin transporter-like protein 3	glyma.Wm82.gnm2.ann1.Glyma.03g063600
+LAX4	auxin transporter-like protein 4	glyma.Wm82.gnm2.ann1.Glyma.03g063900
+Bic-c2	Bicaudal- C gene 2	glyma.Wm82.gnm2.ann1.Glyma.03G064800
+SWEET50	sugar efflux transporter SWEET50	glyma.Wm82.gnm2.ann1.Glyma.03g065500
+RCA03	ribulose bisphosphate carboxylase/oxygenase activase 1, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.03g068100
+ALDH18B3	delta-1-pyrroline-5-carboxylate synthase	glyma.Wm82.gnm2.ann1.Glyma.03g069400
+ICS1	isochorismate synthase, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.03g070600
+TUBB2	tubulin beta-2	glyma.Wm82.gnm2.ann1.Glyma.03g074400
+Lac9	Laccase 9	glyma.Wm82.gnm2.ann1.Glyma.03G077900
+MYB51	MYB transcription factor MYB51	glyma.Wm82.gnm2.ann1.Glyma.03g078000
+PIP1-1	aquaporin PIP1-1	glyma.Wm82.gnm2.ann1.Glyma.03g078700
+bZIP20	Basic leucine zipper transcription factor-like protein gene 20	glyma.Wm82.gnm2.ann1.Glyma.03G081700
+PHANb	phantastica transcription factor b	glyma.Wm82.gnm2.ann1.Glyma.03g081900
+RIN4a	RIN4a protein	glyma.Wm82.gnm2.ann1.Glyma.03g084000
+AIR12	plasma membrane ascorbate-reducible b-type cytochrome family protein	glyma.Wm82.gnm2.ann1.Glyma.03g088900
+PPR23	Psudo-Response Regulator gene 23	glyma.Wm82.gnm2.ann1.Glyma.03G093000
+LHP1-2	chromo domain-containing protein LHP1-2	glyma.Wm82.gnm2.ann1.Glyma.03g094200
+ERF18	Ethylene-responsive factor gene 18	glyma.Wm82.gnm2.ann1.Glyma.03G094700
+PPR24	Psudo-Response Regulator gene 24	glyma.Wm82.gnm2.ann1.Glyma.03G108500
+WRKY22	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.03G109100
+ERF19	Ethylene-responsive factor gene 19	glyma.Wm82.gnm2.ann1.Glyma.03G111700
+ERF20	Ethylene-responsive factor gene 20	glyma.Wm82.gnm2.ann1.Glyma.03G112000
+ERF21	Ethylene-responsive factor gene 21	glyma.Wm82.gnm2.ann1.Glyma.03G112400
+ERF22	Ethylene-responsive factor gene 22	glyma.Wm82.gnm2.ann1.Glyma.03G112700
+ERF23	Ethylene-responsive factor gene 23	glyma.Wm82.gnm2.ann1.Glyma.03G112800
+RPSQ	LRR receptor kinase-like protein	glyma.Wm82.gnm2.ann1.Glyma.03g117600
+SIP2-1	aquaporin SIP2-1	glyma.Wm82.gnm2.ann1.Glyma.03g119300
+CYP94D24	cytochrome P450 94A1	glyma.Wm82.gnm2.ann1.Glyma.03g122300
+CYCB1;1	G2/mitotic-specific cyclin S13-6	glyma.Wm82.gnm2.ann1.Glyma.03g123600
+TUBB3	beta-tubulin	glyma.Wm82.gnm2.ann1.Glyma.03g124400
+PIN1d	PIN-formed 1 gene d	glyma.Wm82.gnm2.ann1.Glyma.03G126000
+bZIP22, TGA04	bZIP transcription factor 4	glyma.Wm82.gnm2.ann1.Glyma.03g127600
+bZIP23, TGA05	bZIP transcription factor 5	glyma.Wm82.gnm2.ann1.Glyma.03g128200
+BHLH320	bHLH transcription factor bHLH320	glyma.Wm82.gnm2.ann1.Glyma.03g130400
+BHLH300	bHLH transcription factor bHLH300	glyma.Wm82.gnm2.ann1.Glyma.03g130600
+SDP1-4	triacylglycerol lipase SDP1	glyma.Wm82.gnm2.ann1.Glyma.03g130900
+GASA3	gibberellin-regulated protein 3	glyma.Wm82.gnm2.ann1.Glyma.03g131700
+CKX1	cytokinin dehydrogenase 1-like	glyma.Wm82.gnm2.ann1.Glyma.03g133300
+HSF-06	heat stress transcription factor 6	glyma.Wm82.gnm2.ann1.Glyma.03g135800
+CHLH	magnesium chelatase subunit	glyma.Wm82.gnm2.ann1.Glyma.03g137000
+RS	raffinose synthase	glyma.Wm82.gnm2.ann1.Glyma.03g137900
+CYP93A3	cytochrome P450 93A3	glyma.Wm82.gnm2.ann1.Glyma.03g142100
+C2-29	C2 domain containing protein gene 29	glyma.Wm82.gnm2.ann1.Glyma.03G142500
+SPL9C	squamosa promoter-binding-like protein 9c	glyma.Wm82.gnm2.ann1.Glyma.03g143100
+PHR8	MYB-CC domain-containing transcription factor PHR8	glyma.Wm82.gnm2.ann1.Glyma.03g143600
+CYP93A1	3,9-dihydroxypterocarpan 6A-monooxygenase	glyma.Wm82.gnm2.ann1.Glyma.03g143700
+PM9	late embryogenesis abundant group 4 protein PM9	glyma.Wm82.gnm2.ann1.Glyma.03g144400
+PTS1	pterocarpan synthase	glyma.Wm82.gnm2.ann1.Glyma.03g147700
+PTS-L1	pterocarpan synthase-like	glyma.Wm82.gnm2.ann1.Glyma.03g147800
+PTS-L4	pterocarpan synthase-like	glyma.Wm82.gnm2.ann1.Glyma.03g147900
+GID1B	GID Complex Subunit	glyma.Wm82.gnm2.ann1.Glyma.03G148300
+GST1	Glutathione-S Transferase 1	glyma.Wm82.gnm2.ann1.Glyma.03G150300
+MED5-1	Mediator Complex 5 gene 1	glyma.Wm82.gnm2.ann1.Glyma.03g151100
+GIP1	putative aspartic proteinase GIP1	glyma.Wm82.gnm2.ann1.Glyma.03g151900
+ALMT6	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.03g152700
+TPS1	terpene synthase 1	glyma.Wm82.gnm2.ann1.Glyma.03g154400
+CHI3B1	chlacone isomerase 3B1	glyma.Wm82.gnm2.ann1.Glyma.03g154600
+TPS2	terpene synthase 2	glyma.Wm82.gnm2.ann1.Glyma.03g154700
+CYP36	peptidyl-prolyl cis-trans isomerase CYP36	glyma.Wm82.gnm2.ann1.Glyma.03g157900
+IAA10	Indole-3-Acetic Acid Responsive Gene 10	glyma.Wm82.gnm2.ann1.Glyma.03G158600
+IAA11	Indole-3-Acetic Acid Responsive Gene 11	glyma.Wm82.gnm2.ann1.Glyma.03G158700
+WRKY15	WRKY transcription factor 15	glyma.Wm82.gnm2.ann1.Glyma.03g159700
+LBD14	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.03g161400
+LBD15	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.03g161500
+ERF24	Ethylene-responsive factor gene 24	glyma.Wm82.gnm2.ann1.Glyma.03G162500
+ERF25	Ethylene-responsive factor gene 25	glyma.Wm82.gnm2.ann1.Glyma.03G162600
+PHT1-2	inorganic phosphate transporter 1-2	glyma.Wm82.gnm2.ann1.Glyma.03g162800
+glycinin A2B1a, Gy2	glycinin subunit G2	glyma.Wm82.gnm2.ann1.Glyma.03g163500
+NAC155	NAC domain-containing protein 155	glyma.Wm82.gnm2.ann1.Glyma.03g164200
+PCS1	homo-phytochelatin synthase	glyma.Wm82.gnm2.ann1.Glyma.03g165000
+PHR9	MYB-CC domain-containing transcription factor PHR9	glyma.Wm82.gnm2.ann1.Glyma.03g166400
+IAA12	Indole-3-Acetic Acid Responsive Gene 12	glyma.Wm82.gnm2.ann1.Glyma.03G167400
+PDR12	PDR-like ABC-transporter	glyma.Wm82.gnm2.ann1.Glyma.03g168000
+MED11-1	Mediator Complex 11 gene 1	glyma.Wm82.gnm2.ann1.Glyma.03g168300
+MED37-2	Mediator Complex 37 gene 2	glyma.Wm82.gnm2.ann1.Glyma.03g171100
+CHX1	cation/H(+) antiporter 1	glyma.Wm82.gnm2.ann1.Glyma.03g171600
+GSTL1	glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.03g176300
+IQD7	protein IQ-DOMAIN 7	glyma.Wm82.gnm2.ann1.Glyma.03g178200
+NAC156	NAC Transcription Factor gene 156	glyma.Wm82.gnm2.ann1.Glyma.03G179600
+PIP2-7	aquaporin PIP2-7	glyma.Wm82.gnm2.ann1.Glyma.03g180900
+PAL1.3	phenylalanine ammonia-lyase 1	glyma.Wm82.gnm2.ann1.Glyma.03g181600
+PAL1.2	phenylalanine ammonia-lyase 1	glyma.Wm82.gnm2.ann1.Glyma.03g181700
+SPCP1	nodulin-26	glyma.Wm82.gnm2.ann1.Glyma.03g185900
+PPR25	Psudo-Response Regulator gene 25	glyma.Wm82.gnm2.ann1.Glyma.03G189000
+PGMPM18	35 kDa seed maturation protein	glyma.Wm82.gnm2.ann1.Glyma.03g189200
+LRK1	leucine-rich repeat receptor-like kinase 1	glyma.Wm82.gnm2.ann1.Glyma.03g189800
+HDT1	histone deacetylase HDT1-like	glyma.Wm82.gnm2.ann1.Glyma.03g190700
+HSF-07	heat stress transcription factor 7	glyma.Wm82.gnm2.ann1.Glyma.03g191100
+GRF3	growth-regulating factor 3	glyma.Wm82.gnm2.ann1.Glyma.03g192200
+TFL1a	Terminal Flower 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.03g194700
+NAC014	NAC Transcription Factor gene 14	glyma.Wm82.gnm2.ann1.Glyma.03G197900
+CYP13	peptidyl-prolyl cis-trans isomerase CYP13	glyma.Wm82.gnm2.ann1.Glyma.03g198200
+LEA2-12	late embryogenesis abundant 2 gene 12	glyma.Wm82.gnm2.ann1.Glyma.03G201000
+LEA2-13	late embryogenesis abundant 2 gene 13	glyma.Wm82.gnm2.ann1.Glyma.03G201100
+LEA2-14	late embryogenesis abundant 2 gene 14	glyma.Wm82.gnm2.ann1.Glyma.03G201200
+B13-1-9, LEA2-15	late embryogenesis abundant 2 gene 15	glyma.Wm82.gnm2.ann1.Glyma.03G201300
+LEA2-16	late embryogenesis abundant 2 gene 16	glyma.Wm82.gnm2.ann1.Glyma.03G201500
+LEA2-17	late embryogenesis abundant 2 gene 17	glyma.Wm82.gnm2.ann1.Glyma.03G201600
+MED3-1	Mediator Complex 3 gene 1	glyma.Wm82.gnm2.ann1.Glyma.03g201900
+NF-YA03	nuclear transcription factor Y subunit A-3	glyma.Wm82.gnm2.ann1.Glyma.03g203000
+PPR26	Psudo-Response Regulator gene 26	glyma.Wm82.gnm2.ann1.Glyma.03G205100
+TIR1D	protein TRANSPORT INHIBITOR RESPONSE 1D	glyma.Wm82.gnm2.ann1.Glyma.03g209400
+SWEET2	sugar efflux transporter SWEET2	glyma.Wm82.gnm2.ann1.Glyma.03g209600
+COL15	zinc finger protein CONSTANS-LIKE 13-like	glyma.Wm82.gnm2.ann1.Glyma.03g209800
+bZIP26	Basic leucine zipper transcription factor-like protein gene 26	glyma.Wm82.gnm2.ann1.Glyma.03G219300
+MYB12A	R2R3-type MYB transcription factor MYB12a	glyma.Wm82.gnm2.ann1.Glyma.03g221700
+IAA13	Indole-3-Acetic Acid Responsive Gene 13	glyma.Wm82.gnm2.ann1.Glyma.03G224800
+CYP12	peptidyl-prolyl cis-trans isomerase CYP12	glyma.Wm82.gnm2.ann1.Glyma.03g225600
+PPR27	Psudo-Response Regulator gene 27	glyma.Wm82.gnm2.ann1.Glyma.03G227900
+G6PDH1	Glucose-6-phosphate dehydrogenase gene 1	glyma.Wm82.gnm2.ann1.Glyma.03G229400
+DNAJ	chaperone protein DnaJ-like	glyma.Wm82.gnm2.ann1.Glyma.03g232700
+TOPP3	TOPP-type protein phosphatase gene 3	glyma.Wm82.gnm2.ann1.Glyma.03G234700
+PPR28	Psudo-Response Regulator gene 28	glyma.Wm82.gnm2.ann1.Glyma.03G238000
+NF-YC02	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.03g239400
+BG7S-1	basic 7S globulin	glyma.Wm82.gnm2.ann1.Glyma.03g239700
+C2-30	C2 domain containing protein gene 30	glyma.Wm82.gnm2.ann1.Glyma.03G242100
+C2-31	C2 domain containing protein gene 31	glyma.Wm82.gnm2.ann1.Glyma.03G242200
+OAS-TL1	cysteine synthase	glyma.Wm82.gnm2.ann1.Glyma.03g244800
+IQD8	protein IQ-DOMAIN 8	glyma.Wm82.gnm2.ann1.Glyma.03g246200
+MED14-1	Mediator Complex 14 gene 1	glyma.Wm82.gnm2.ann1.Glyma.03g247300
+IAA14	Indole-3-Acetic Acid Responsive Gene 14	glyma.Wm82.gnm2.ann1.Glyma.03G247400
+CrRLk1L03	CrRLK1-Like Kinase 1 gene 3	glyma.Wm82.gnm2.ann1.Glyma.03G247800
+AKR1	probable aldo-keto reductase 1	glyma.Wm82.gnm2.ann1.Glyma.03g248400
+C2-32	C2 domain containing protein gene 32	glyma.Wm82.gnm2.ann1.Glyma.03G249700
+PHR10	MYB-CC domain-containing transcription factor PHR10	glyma.Wm82.gnm2.ann1.Glyma.03g250000
+PPCK1	phosphoenolpyruvate carboxylase kinase	glyma.Wm82.gnm2.ann1.Glyma.03g251400
+TOPP4	TOPP-type protein phosphatase gene 4	glyma.Wm82.gnm2.ann1.Glyma.03G251500
+CYP7	peptidyl-prolyl cis-trans isomerase CYP7	glyma.Wm82.gnm2.ann1.Glyma.03g251600
+C2-33	C2 domain containing protein gene 33	glyma.Wm82.gnm2.ann1.Glyma.03G254400
+ERF26	Ethylene-responsive factor gene 26	glyma.Wm82.gnm2.ann1.Glyma.03G255500
+TUBG1	tubulin gamma-1 chain	glyma.Wm82.gnm2.ann1.Glyma.03g255800
+UGT1	glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.03g256500
+WRKY28	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.03G256700
+LEA2-18	late embryogenesis abundant 2 gene 18	glyma.Wm82.gnm2.ann1.Glyma.03G261400
+LCL-2, LHY2b, MYB114	MYB transcription factor MYB114	glyma.Wm82.gnm2.ann1.Glyma.03g261800
+ERF27, ERF3	EREBP/AP2 transcription factor	glyma.Wm82.gnm2.ann1.Glyma.03g263700
+LEA2-19	late embryogenesis abundant 2 gene 19	glyma.Wm82.gnm2.ann1.Glyma.03G263800
+HAK	potassium transporter 5-like	glyma.Wm82.gnm2.ann1.Glyma.03g264100
+PPR29	Psudo-Response Regulator gene 29	glyma.Wm82.gnm2.ann1.Glyma.03G264700
+HDA2	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.04g000200
+NINA	protein NODULE INCEPTION 1a	glyma.Wm82.gnm2.ann1.Glyma.04g000600
+MED19-1	Mediator Complex 19 gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g001800
+PIP2-1	aquaporin PIP2-1	glyma.Wm82.gnm2.ann1.Glyma.04g003200
+MYB047	transcription factor MYB047	glyma.Wm82.gnm2.ann1.Glyma.04g004100
+CYP39	peptidyl-prolyl cis-trans isomerase CYP39	glyma.Wm82.gnm2.ann1.Glyma.04g004300
+LAX5	auxin transporter-like protein 5	glyma.Wm82.gnm2.ann1.Glyma.04g004800
+CYP4	peptidyl-prolyl cis-trans isomerase CYP4	glyma.Wm82.gnm2.ann1.Glyma.04g005300
+COBL3	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.04G006100
+PUR1	glutamine phosphoribosylpyrophosphate amidotransferase	glyma.Wm82.gnm2.ann1.Glyma.04g007300
+PM12	dehydrin	glyma.Wm82.gnm2.ann1.Glyma.04g009900
+PPR30	Psudo-Response Regulator gene 30	glyma.Wm82.gnm2.ann1.Glyma.04G010200
+bZIP29	Basic leucine zipper transcription factor-like protein gene 29	glyma.Wm82.gnm2.ann1.Glyma.04G010300
+IFR2	isoflavone reductase homolog 2	glyma.Wm82.gnm2.ann1.Glyma.04g012300
+NAC157	NAC domain-containing protein 157	glyma.Wm82.gnm2.ann1.Glyma.04g014900
+CAT4	catalase	glyma.Wm82.gnm2.ann1.Glyma.04g017500
+Amy1	Alpha-amylase 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g017700
+Lac10	Laccase 10	glyma.Wm82.gnm2.ann1.Glyma.04G019500
+Raf52	Raf52 proto-oncogene serine/threonine protein kinase	glyma.Wm82.gnm2.ann1.Glyma.04G020100
+C2-34	C2 domain containing protein gene 34	glyma.Wm82.gnm2.ann1.Glyma.04G020400
+SMT2-1	sterol 24-C methyltransferase 2-1	glyma.Wm82.gnm2.ann1.Glyma.04g020600
+14-1-1	syringolide-induced protein 14-1-1	glyma.Wm82.gnm2.ann1.Glyma.04g020700
+bZIP30, FDc1, FDL04	Flowering Locus D-like gene 4	glyma.Wm82.gnm2.ann1.Glyma.04G022100
+GASA4	gibberellin-regulated protein 4	glyma.Wm82.gnm2.ann1.Glyma.04g024400
+IQD9	protein IQ-DOMAIN 9	glyma.Wm82.gnm2.ann1.Glyma.04g026000
+bZIP31	Basic leucine zipper transcription factor-like protein gene 31	glyma.Wm82.gnm2.ann1.Glyma.04G026200
+bZIP32	Basic leucine zipper transcription factor-like protein gene 32	glyma.Wm82.gnm2.ann1.Glyma.04G029600
+BES1-4	protein BRASSINAZOLE-RESISTANT 1-like	glyma.Wm82.gnm2.ann1.Glyma.04g033800
+ABF2, bZIP33	Basic leucine zipper transcription factor-like protein gene 33	glyma.Wm82.gnm2.ann1.Glyma.04G039300
+MYB68	MYB transcription factor MYB68	glyma.Wm82.gnm2.ann1.Glyma.04g042300
+CYCA3;1	mitotic cyclin a1-type	glyma.Wm82.gnm2.ann1.Glyma.04g043400
+NRAMP3A	metal transporter Nramp3a	glyma.Wm82.gnm2.ann1.Glyma.04g044000
+LBD16	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g044800
+ELF3A	protein EARLY FLOWERING 3a	glyma.Wm82.gnm2.ann1.Glyma.04g050200
+LEA2-20	late embryogenesis abundant 2 gene 20	glyma.Wm82.gnm2.ann1.Glyma.04G051600
+HSF-08	heat stress transcription factor 8	glyma.Wm82.gnm2.ann1.Glyma.04g052000
+IQD10	protein IQ-DOMAIN 10	glyma.Wm82.gnm2.ann1.Glyma.04g052200
+WRKY29	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.04G054200
+GPA1	G protein alpha subunit	glyma.Wm82.gnm2.ann1.Glyma.04g056600
+PPR31	Psudo-Response Regulator gene 31	glyma.Wm82.gnm2.ann1.Glyma.04G057300
+DCL3A	endoribonuclease dicer-like 3a	glyma.Wm82.gnm2.ann1.Glyma.04g057400
+ERF28	Ethylene-responsive factor gene 28	glyma.Wm82.gnm2.ann1.Glyma.04G062900
+IAA15	Indole-3-Acetic Acid Responsive Gene 15	glyma.Wm82.gnm2.ann1.Glyma.04G066300
+ERF29	Ethylene-responsive factor gene 29	glyma.Wm82.gnm2.ann1.Glyma.04G067200
+SPX2	SPX domain-containing protein 2	glyma.Wm82.gnm2.ann1.Glyma.04g067400
+CYP46	peptidyl-prolyl cis-trans isomerase CYP46	glyma.Wm82.gnm2.ann1.Glyma.04g068700
+GA3OX1	gibberellin 3-beta-dioxygenase 1	glyma.Wm82.gnm2.ann1.Glyma.04g071000
+CYCA2;1	mitotic cyclin a2-type	glyma.Wm82.gnm2.ann1.Glyma.04g071600
+WRKY32	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.04G076200
+bZIP34	Basic leucine zipper transcription factor-like protein gene 34	glyma.Wm82.gnm2.ann1.Glyma.04G078300
+NAC015	NAC Transcription Factor gene 15	glyma.Wm82.gnm2.ann1.Glyma.04G078600
+PPR32	Psudo-Response Regulator gene 32	glyma.Wm82.gnm2.ann1.Glyma.04G078800
+GLB3	Nonsymbiotic hemoglobin gene 3	glyma.Wm82.gnm2.ann1.Glyma.04g079200
+GLYI-3	Glyoxylase 1 gene 3	glyma.Wm82.gnm2.ann1.Glyma.04g083100
+TIP4-1	aquaporin TIP4-1	glyma.Wm82.gnm2.ann1.Glyma.04g083200
+AP2-2	AP2 domain-containing transcription factor 2	glyma.Wm82.gnm2.ann1.Glyma.04g084000
+IAA16	Indole-3-Acetic Acid Responsive Gene 16	glyma.Wm82.gnm2.ann1.Glyma.04G089900
+PGM	phosphoglycerate mutase-like protein	glyma.Wm82.gnm2.ann1.Glyma.04g090300
+GF14B	14-3-3 protein SGF14b	glyma.Wm82.gnm2.ann1.Glyma.04g092600
 GF14e, SGF14h	14-3-3 protein SGF14h	glyma.Wm82.gnm2.ann1.Glyma.04g099900
+CRY1a	Cryptochrome 1a	glyma.Wm82.gnm2.ann1.Glyma.04g101500
+LEA2-21	late embryogenesis abundant 2 gene 21	glyma.Wm82.gnm2.ann1.Glyma.04G103700
+DREB3	dehydration responsive element-binding protein 3	glyma.Wm82.gnm2.ann1.Glyma.04g103900
+LBD17	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g106400
+GSTU13	glutathione S-transferase GST 13	glyma.Wm82.gnm2.ann1.Glyma.04g107500
+BRL1A	brassinosteroid receptor-like protein	glyma.Wm82.gnm2.ann1.Glyma.04g115700
+NAC016	NAC Transcription Factor gene 16	glyma.Wm82.gnm2.ann1.Glyma.04G119500
+Lac11	Laccase 11	glyma.Wm82.gnm2.ann1.Glyma.04G119600
+MED2-1	Mediator Complex 2 gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g123300
+AOX1	ubiquinol oxidase 1, mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.04g123800
+bZIP35	Basic leucine zipper transcription factor-like protein gene 35	glyma.Wm82.gnm2.ann1.Glyma.04G124200
+CRK8	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.04g127100
+PPR33	Psudo-Response Regulator gene 33	glyma.Wm82.gnm2.ann1.Glyma.04G127500
+C2-35	C2 domain containing protein gene 35	glyma.Wm82.gnm2.ann1.Glyma.04G141600
+DGK6	diacylglycerol kinase 6	glyma.Wm82.gnm2.ann1.Glyma.04g143000
+E1LB	B3 domain-containing protein E1Lb	glyma.Wm82.gnm2.ann1.Glyma.04g143300
+ERF30	Ethylene-responsive factor gene 30	glyma.Wm82.gnm2.ann1.Glyma.04G147500
+SPX3	SPX domain-containing protein 3	glyma.Wm82.gnm2.ann1.Glyma.04g147600
+HO1	heme oxygenase 1, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.04g147700
+ERF31	Ethylene-responsive factor gene 31	glyma.Wm82.gnm2.ann1.Glyma.04G151100
+TCP46	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 46	glyma.Wm82.gnm2.ann1.Glyma.04G152400
+IQD11	protein IQ-DOMAIN 11	glyma.Wm82.gnm2.ann1.Glyma.04g154200
+E1, E1LA	B3 domain-containing protein E1La	glyma.Wm82.gnm2.ann1.Glyma.04g156400
+PPR34	Psudo-Response Regulator gene 34	glyma.Wm82.gnm2.ann1.Glyma.04G158200
+FULb	Fruitfull gene b	glyma.Wm82.gnm2.ann1.Glyma.04g159300
+COBL4	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.04G160000
+COBL5	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.04G160100
+TCP27	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 27	glyma.Wm82.gnm2.ann1.Glyma.04G161400
+NLP	NAC domain-containing protein	glyma.Wm82.gnm2.ann1.Glyma.04g167200
+GASA5	gibberellin-regulated protein 5	glyma.Wm82.gnm2.ann1.Glyma.04g169600
+MYBJ2	myb-related protein 306-like	glyma.Wm82.gnm2.ann1.Glyma.04g170100
+TCP4	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 4	glyma.Wm82.gnm2.ann1.Glyma.04G170600
+IQD12	protein IQ-DOMAIN 12	glyma.Wm82.gnm2.ann1.Glyma.04g173100
+MYB143	MYB transcription factor MYB143	glyma.Wm82.gnm2.ann1.Glyma.04g177300
+GASA6	gibberellin-regulated protein 6	glyma.Wm82.gnm2.ann1.Glyma.04g179500
+ROP10	Rho-related protein ROP10	glyma.Wm82.gnm2.ann1.Glyma.04g180200
 GF14f	GF14 gene family gene f	glyma.Wm82.gnm2.ann1.Glyma.04G183400
-GF14g	GF14 gene family gene g	glyma.Wm82.gnm2.ann1.Glyma.05G158100
+PPR35	Psudo-Response Regulator gene 35	glyma.Wm82.gnm2.ann1.Glyma.04G183600
+LBD18	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g186900
+HDA3	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.04g187000
+HDA4	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.04g187100
+C2-36	C2 domain containing protein gene 36	glyma.Wm82.gnm2.ann1.Glyma.04G187900
+WNK3	with no lysine kinase	glyma.Wm82.gnm2.ann1.Glyma.04g188800
+SEOC	sieve element occlusion c	glyma.Wm82.gnm2.ann1.Glyma.04g190300
+CYSP1	cysteine proteinase	glyma.Wm82.gnm2.ann1.Glyma.04g190700
+GAPDH	glyceraldehyde 3-phosphate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.04g193500
+AHAS1, ALS-1, ALS1	Acetolactate synthase gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g196100
+NF-YC03, NF-YC4-2	NF-Y subunit C 4 gene 2	glyma.Wm82.gnm2.ann1.Glyma.04g196200
+MED30-1	Mediator Complex 30 gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g196600
+SWEET4	sugar efflux transporter SWEET4	glyma.Wm82.gnm2.ann1.Glyma.04g198400
+SWEET5	sugar efflux transporter SWEET5	glyma.Wm82.gnm2.ann1.Glyma.04g198500
+ICE1	inducer of CBF expression 1	glyma.Wm82.gnm2.ann1.Glyma.04g200500
+MED36-1	Mediator Complex 36 gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g200700
+C2-37	C2 domain containing protein gene 37	glyma.Wm82.gnm2.ann1.Glyma.04G201500
+ERF32	Ethylene-responsive factor gene 32	glyma.Wm82.gnm2.ann1.Glyma.04G201700
+ERF33	Ethylene-responsive factor gene 33	glyma.Wm82.gnm2.ann1.Glyma.04G201900
+SGS3	sRNA biogenesis gene 3	glyma.Wm82.gnm2.ann1.Glyma.04G203600
+SPK-4	protein kinase	glyma.Wm82.gnm2.ann1.Glyma.04g205400
+Cdk8-1	Cyclin-dependent kinase 8 gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g207900
+SRT1	NAD-dependent protein deacylase SRT2-like	glyma.Wm82.gnm2.ann1.Glyma.04g210000
+POLD1	DNA polymerase delta	glyma.Wm82.gnm2.ann1.Glyma.04g210700
+NAC019	NAC Transcription Factor gene 19	glyma.Wm82.gnm2.ann1.Glyma.04G212000
+NAC020	NAC Transcription Factor gene 20	glyma.Wm82.gnm2.ann1.Glyma.04G213300
+GT-2A	trihelix transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g216100
+MED26-1	Mediator Complex 26 gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g216700
+ERF34	Ethylene-responsive factor gene 34	glyma.Wm82.gnm2.ann1.Glyma.04G217400
+BRI1B	brassinosteroid receptor	glyma.Wm82.gnm2.ann1.Glyma.04g218300
+WRKY21	WRKY transcription factor 21	glyma.Wm82.gnm2.ann1.Glyma.04g218700
+LBD19	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g220500
+bZIP4	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04G222200
+CHI4B	chalcone isomerase 4B	glyma.Wm82.gnm2.ann1.Glyma.04g222400
+C2-38	C2 domain containing protein gene 38	glyma.Wm82.gnm2.ann1.Glyma.04G224600
+NAC021	NAC transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g226700
+LEA2-22	late embryogenesis abundant 2 gene 22	glyma.Wm82.gnm2.ann1.Glyma.04G228200
+PRR5b	Pseudo Response Regultor 5 gene b	glyma.Wm82.gnm2.ann1.Glyma.04G228300
+GRF4	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.04g230600
+CB5-A2	cytochrome b5	glyma.Wm82.gnm2.ann1.Glyma.04g231800
+IQD13	protein IQ-DOMAIN 13	glyma.Wm82.gnm2.ann1.Glyma.04g235400
+SWEET7	sugar efflux transporter SWEET7	glyma.Wm82.gnm2.ann1.Glyma.04g238100
+WRKY39	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.04G238300
+SPCH1	transcription factor SPEECHLESS	glyma.Wm82.gnm2.ann1.Glyma.04g238400
+ERF35	Ethylene-responsive factor gene 35	glyma.Wm82.gnm2.ann1.Glyma.04G238700
+Adh2	Alcohol dehydrogenase 2 gene	glyma.Wm82.gnm2.ann1.Glyma.04g240800
+SWEET8	sugar efflux transporter SWEET8	glyma.Wm82.gnm2.ann1.Glyma.04g241400
+USP1	UDP-sugar pyrophosphorylase	glyma.Wm82.gnm2.ann1.Glyma.04g245100
+PIb	Pistillata gene b	glyma.Wm82.gnm2.ann1.Glyma.04G245500
+CYCA1;1	mitotic cyclin a2-type	glyma.Wm82.gnm2.ann1.Glyma.04g246600
+ALAD, HEMB	aminolevulinate, delta-, dehydratase	glyma.Wm82.gnm2.ann1.Glyma.04g247700
+stAPX-b	Ascorbate peroxidase gene b	glyma.Wm82.gnm2.ann1.Glyma.04G248300
+ALDH3H1	aldehyde dehydrogenase family 3 member H1	glyma.Wm82.gnm2.ann1.Glyma.04g248500
+NAC022	NAC domain-containing protein	glyma.Wm82.gnm2.ann1.Glyma.04g249000
+AP2-6	AP2 domain-containing transcription factor 6	glyma.Wm82.gnm2.ann1.Glyma.04g251400
+NSP2	nodulation-signaling pathway 2 protein	glyma.Wm82.gnm2.ann1.Glyma.04g251900
+LAX6	auxin transporter-like protein 6	glyma.Wm82.gnm2.ann1.Glyma.04g252300
+BZIP19, bZIP38	Basic leucine zipper transcription factor-like protein gene 38	glyma.Wm82.gnm2.ann1.Glyma.04G254800
+SOY69	actin	glyma.Wm82.gnm2.ann1.Glyma.05g000900
+MED5-2	Mediator Complex 5 gene 2	glyma.Wm82.gnm2.ann1.Glyma.05g001600
+Raf41-1	Raf41 proto-oncogene serine/threonine protein kinase gene 1	glyma.Wm82.gnm2.ann1.Glyma.05G002600
+NAC025	NAC Transcription Factor gene 25	glyma.Wm82.gnm2.ann1.Glyma.05G002700
+RS3	Raffinose Synthase 3	glyma.Wm82.gnm2.ann1.Glyma.05g003900
+LBD20	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.05g004400
+CRK9	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.05g005100
+MYB99	transcription factor MYB99	glyma.Wm82.gnm2.ann1.Glyma.05g006100
+PPR36	Psudo-Response Regulator gene 36	glyma.Wm82.gnm2.ann1.Glyma.05G008800
+MED17-1	Mediator Complex 17 gene 1	glyma.Wm82.gnm2.ann1.Glyma.05g009700
+AKT1	Potassium channel AKT1-like gene 1	glyma.Wm82.gnm2.ann1.Glyma.05g010600
+FAT1	acyl-ACP thioesterase	glyma.Wm82.gnm2.ann1.Glyma.05g012300
+HDA5	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.05g012900
+TCP47	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 47	glyma.Wm82.gnm2.ann1.Glyma.05G013300
+CYP47	peptidyl-prolyl cis-trans isomerase CYP47	glyma.Wm82.gnm2.ann1.Glyma.05g014300
+bZIP39	Basic leucine zipper transcription factor-like protein gene 39	glyma.Wm82.gnm2.ann1.Glyma.05G017400
+FULC	MADS-box protein FULc	glyma.Wm82.gnm2.ann1.Glyma.05g018800
+COBL6	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.05G019100
+CYP78A10	cytochrome P450 family protein CYP78A10	glyma.Wm82.gnm2.ann1.Glyma.05g019200
+TCP28	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 28	glyma.Wm82.gnm2.ann1.Glyma.05G019900
+HDA6	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.05g021400
+SB100	heat shock protein	glyma.Wm82.gnm2.ann1.Glyma.05g022200
+DGK12	diacylglycerol kinase 12	glyma.Wm82.gnm2.ann1.Glyma.05g022500
+NAC023	NAC Transcription Factor gene 23	glyma.Wm82.gnm2.ann1.Glyma.05G025500
+CDF3c	Cycling Dof Factor 3 gene c	glyma.Wm82.gnm2.ann1.Glyma.05G025900
+Mdh2	malate dehydrogenase 2 gene, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.05g026300
+PPR37	Psudo-Response Regulator gene 37	glyma.Wm82.gnm2.ann1.Glyma.05G026400
+TCP5	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 5	glyma.Wm82.gnm2.ann1.Glyma.05G027400
+IQD14	protein IQ-DOMAIN 14	glyma.Wm82.gnm2.ann1.Glyma.05g028600
+ALDH12A1	aldehyde dehydrogenase 12A1	glyma.Wm82.gnm2.ann1.Glyma.05g029100
+ALDH12A2, P5CD	delta-pyrroline-5-corboxylate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.05G029200
+C2-39	C2 domain containing protein gene 39	glyma.Wm82.gnm2.ann1.Glyma.05G029600
+HIR3	hypersensitive-induced response protein 1-like	glyma.Wm82.gnm2.ann1.Glyma.05g029800
+MYB176	transcription factor MYB176	glyma.Wm82.gnm2.ann1.Glyma.05g032200
+ALDH10A1	betaine aldehyde dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.05g033500
+GASA7	gibberellin-regulated protein 7	glyma.Wm82.gnm2.ann1.Glyma.05g034500
+SWEET9	sugar efflux transporter SWEET9	glyma.Wm82.gnm2.ann1.Glyma.05g036500
+DXR1	1-deoxy-D-xylulose 5-phosphate reductoisomerase, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.05g037500
+LBD21	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.05g040500
+HDA7	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.05g040600
+TUFB1	elongation factor Tu	glyma.Wm82.gnm2.ann1.Glyma.05g041900
+CYP71A9	cytochrome P450 71A9-like	glyma.Wm82.gnm2.ann1.Glyma.05g042800
+IQD15	protein IQ-DOMAIN 15	glyma.Wm82.gnm2.ann1.Glyma.05g049000
+TCP6	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 6	glyma.Wm82.gnm2.ann1.Glyma.05G050400
+MYBJ1	protein ODORANT1-like	glyma.Wm82.gnm2.ann1.Glyma.05g051700
+RPS13	ribosomal protein S13	glyma.Wm82.gnm2.ann1.Glyma.05g052400
+CCS	Cu/Zn-superoxide dismutase copper chaperone	glyma.Wm82.gnm2.ann1.Glyma.05g055000
+FUSA2	elongation factor G-2	glyma.Wm82.gnm2.ann1.Glyma.05g055500
+PM40	seed maturation protein PM40	glyma.Wm82.gnm2.ann1.Glyma.05g055700
+NAC024	NAC Transcription Factor gene 24	glyma.Wm82.gnm2.ann1.Glyma.05G055900
+Lac12	Laccase 12	glyma.Wm82.gnm2.ann1.Glyma.05G056100
+MYB58	transcription factor MYB58	glyma.Wm82.gnm2.ann1.Glyma.05g0619001
+ACX1;2	acyl-CoA oxidase	glyma.Wm82.gnm2.ann1.Glyma.05g062200
+MYB93	MYB transcription factor MYB93	glyma.Wm82.gnm2.ann1.Glyma.05g062300
+ERF36	Ethylene-responsive factor gene 36	glyma.Wm82.gnm2.ann1.Glyma.05G063500
+ERF37	Ethylene-responsive factor gene 37	glyma.Wm82.gnm2.ann1.Glyma.05G063600
+BMY3-1	Beta-amylase 3 gene 1	glyma.Wm82.gnm2.ann1.Glyma.05g068000
+CLC1	chloride channel	glyma.Wm82.gnm2.ann1.Glyma.05g077100
+bZIP40	Basic leucine zipper transcription factor-like protein gene 40	glyma.Wm82.gnm2.ann1.Glyma.05G079800
+CYP8	peptidyl-prolyl cis-trans isomerase CYP8	glyma.Wm82.gnm2.ann1.Glyma.05g080800
+LBD22	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.05g081400
+Lac13	Laccase 13	glyma.Wm82.gnm2.ann1.Glyma.05G082700
+NAC160	NAC transcription factor 160	glyma.Wm82.gnm2.ann1.Glyma.05g086000
+LEA2-23	late embryogenesis abundant 2 gene 23	glyma.Wm82.gnm2.ann1.Glyma.05G094300
+WRKY41	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.05G096500
+C2-40	C2 domain containing protein gene 40	glyma.Wm82.gnm2.ann1.Glyma.05G098700
+SOYCTA	putative cadmium-transporting ATPase	glyma.Wm82.gnm2.ann1.Glyma.05g098800
+CrRLk1L04	CrRLK1-Like Kinase 1 gene 4	glyma.Wm82.gnm2.ann1.Glyma.05G099900
+NRAMP2A	metal transporter Nramp2a	glyma.Wm82.gnm2.ann1.Glyma.05g101700
+LBD23	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.05g103300
+bZIP41	Basic leucine zipper transcription factor-like protein gene 41	glyma.Wm82.gnm2.ann1.Glyma.05G108200
+NAC161	NAC Transcription Factor gene 161	glyma.Wm82.gnm2.ann1.Glyma.05G108700
+PIN8a	PIN-formed 8 gene a	glyma.Wm82.gnm2.ann1.Glyma.05G109800
+RLK1	receptor-like protein kinase 1	glyma.Wm82.gnm2.ann1.Glyma.05g110400
+PM29	seed maturation protein	glyma.Wm82.gnm2.ann1.Glyma.05g112000
+ALMT8	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.05g112700
+NAC026	NAC Transcription Factor gene 26	glyma.Wm82.gnm2.ann1.Glyma.05G113000
+EF4	elongation factor 1-alpha	glyma.Wm82.gnm2.ann1.Glyma.05g114900
+CAMTA5	Calmodulin binding transcription activator 5	glyma.Wm82.gnm2.ann1.Glyma.05G117000
+SF	serine/arginine-rich splicing factor	glyma.Wm82.gnm2.ann1.Glyma.05G117600
+N-21, VTL1a	vacuole iron transporter like	glyma.Wm82.gnm2.ann1.Glyma.05G121600
+EKN	EKN protein	glyma.Wm82.gnm2.ann1.Glyma.05g121700
+SWEET10	sugar efflux transporter SWEET10	glyma.Wm82.gnm2.ann1.Glyma.05g122200
+bZIP5, BZIP9	bZIP transcription factor bZIP9	glyma.Wm82.gnm2.ann1.Glyma.05g122400
+WRKY43	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.05G123600
+PGIP2	polygalacturonase inhibitor 2 gene	glyma.Wm82.gnm2.ann1.Glyma.05g123900
+PGIP1	polygalacturonase inhibitor 1 gene	glyma.Wm82.gnm2.ann1.Glyma.05g124000
+PPR38	Psudo-Response Regulator gene 38	glyma.Wm82.gnm2.ann1.Glyma.05G125500
+HEN1B	protein Hua enhancer 1b	glyma.Wm82.gnm2.ann1.Glyma.05g126600
+CAB3	chlorophyll a/b-binding protein	glyma.Wm82.gnm2.ann1.Glyma.05g128000
+FLS2b	flavanol synthase	glyma.Wm82.gnm2.ann1.Glyma.05g128200
+PPR39	Psudo-Response Regulator gene 39	glyma.Wm82.gnm2.ann1.Glyma.05G131900
+PG7	polygalacturonase precursor	glyma.Wm82.gnm2.ann1.Glyma.05g133400
+bHLH5	bHLH protein	glyma.Wm82.gnm2.ann1.Glyma.05G134400
+BRL2A	brassinosteroid receptor-like protein	glyma.Wm82.gnm2.ann1.Glyma.05g136900
+PPR40	Psudo-Response Regulator gene 40	glyma.Wm82.gnm2.ann1.Glyma.05G137900
+GAI1	DELLA protein GAI 1	glyma.Wm82.gnm2.ann1.Glyma.05g140400
+TCP29	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 29	glyma.Wm82.gnm2.ann1.Glyma.05G142000
+Cdk8-2	Cyclin-dependent kinase 8 gene 2	glyma.Wm82.gnm2.ann1.Glyma.05g145800
+EU4	urease	glyma.Wm82.gnm2.ann1.Glyma.05g146000
+NTF2B-2	nucleus transporter 2B gene 2	glyma.Wm82.gnm2.ann1.Glyma.05g148200
+CAMTA10	Calmodulin binding transcription activator 10	glyma.Wm82.gnm2.ann1.Glyma.05G148300
+ACSL2	long-chain acyl-CoA synthetase ACSL2	glyma.Wm82.gnm2.ann1.Glyma.05g151200
+HSF-09	heat stress transcription factor 9	glyma.Wm82.gnm2.ann1.Glyma.05g151800
+chs2	chalcone synthase 2	glyma.Wm82.gnm2.ann1.Glyma.05g153200
+PPR41	Psudo-Response Regulator gene 41	glyma.Wm82.gnm2.ann1.Glyma.05G155200
+bZIP43	Basic leucine zipper transcription factor-like protein gene 43	glyma.Wm82.gnm2.ann1.Glyma.05G157000
+TFL1	transcriptional repressor	glyma.Wm82.gnm2.ann1.Glyma.05G157300
+ERF38	Ethylene-responsive factor gene 38	glyma.Wm82.gnm2.ann1.Glyma.05G157400
+PPR42	Psudo-Response Regulator gene 42	glyma.Wm82.gnm2.ann1.Glyma.05G157500
+GF14C, GF14g	GF14 gene family gene g	glyma.Wm82.gnm2.ann1.Glyma.05G158100
+PPR43	Psudo-Response Regulator gene 43	glyma.Wm82.gnm2.ann1.Glyma.05G159700
+NIP1-6	aquaporin NIP1-6	glyma.Wm82.gnm2.ann1.Glyma.05g162500
+NIP1-1	aquaporin NIP1-1	glyma.Wm82.gnm2.ann1.Glyma.05g162600
+C2-41	C2 domain containing protein gene 41	glyma.Wm82.gnm2.ann1.Glyma.05G165900
+bZIP44	Basic leucine zipper transcription factor-like protein gene 44	glyma.Wm82.gnm2.ann1.Glyma.05G166400
+bZIP45	Basic leucine zipper transcription factor-like protein gene 45	glyma.Wm82.gnm2.ann1.Glyma.05G168100
+C2-42	C2 domain containing protein gene 42	glyma.Wm82.gnm2.ann1.Glyma.05G168300
+CAMTA1	Calmodulin binding transcription activator 1	glyma.Wm82.gnm2.ann1.Glyma.05G178200
+LEA2-24	late embryogenesis abundant 2 gene 24	glyma.Wm82.gnm2.ann1.Glyma.05G179200
+bZIP46, TGA08	bZIP transcription factor 8	glyma.Wm82.gnm2.ann1.Glyma.05g182500
+MED28-1	Mediator Complex 28 gene 1	glyma.Wm82.gnm2.ann1.Glyma.05g185600
+ERF39	Ethylene-responsive factor gene 39	glyma.Wm82.gnm2.ann1.Glyma.05G186700
+MED26-2	Mediator Complex 26 gene 2	glyma.Wm82.gnm2.ann1.Glyma.05g187800
+NAC028	NAC Transcription Factor gene 28	glyma.Wm82.gnm2.ann1.Glyma.05G191300
+NAC029	NAC Transcription Factor gene 29	glyma.Wm82.gnm2.ann1.Glyma.05G192500
+NAC030	NAC Transcription Factor gene 30	glyma.Wm82.gnm2.ann1.Glyma.05G195000
+Cdk8-3	Cyclin-dependent kinase 8 gene 3	glyma.Wm82.gnm2.ann1.Glyma.05g195300
+ERF40	Ethylene-responsive factor gene 40	glyma.Wm82.gnm2.ann1.Glyma.05G200100
+HLH	helix-loop-helix	glyma.Wm82.gnm2.ann1.Glyma.05g200900
+NAC033	NAC Transcription Factor gene 33	glyma.Wm82.gnm2.ann1.Glyma.05G202300
+WRKY	WRKY protein	glyma.Wm82.gnm2.ann1.Glyma.05g203900
+C2-43	C2 domain containing protein gene 43	glyma.Wm82.gnm2.ann1.Glyma.05G204900
+WRKY50	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.05G211900
+TOPP5	TOPP-type protein phosphatase gene 5	glyma.Wm82.gnm2.ann1.Glyma.05G212100
+LEA2-25	late embryogenesis abundant 2 gene 25	glyma.Wm82.gnm2.ann1.Glyma.05G212600
+ERF41	Ethylene-responsive factor gene 41	glyma.Wm82.gnm2.ann1.Glyma.05G214400
+WRKY51	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.05G215900
+LEA2-26	late embryogenesis abundant 2 gene 26	glyma.Wm82.gnm2.ann1.Glyma.05G217500
+MED37-4	Mediator Complex 37 gene 4 	glyma.Wm82.gnm2.ann1.Glyma.05g219400
+MED37-3	Mediator Complex 37 gene 3	glyma.Wm82.gnm2.ann1.Glyma.05g219600
+ACCase	acetyl-CoA carboxylase	glyma.Wm82.gnm2.ann1.Glyma.05g221100
+C3H	C3H protein	glyma.Wm82.gnm2.ann1.Glyma.05g224400
+NAC032	NAC Transcription Factor gene 32	glyma.Wm82.gnm2.ann1.Glyma.05G225100
+PPR44	Psudo-Response Regulator gene 44	glyma.Wm82.gnm2.ann1.Glyma.05G228000
+GLYI-4	Glyoxylase 1 gene 4	glyma.Wm82.gnm2.ann1.Glyma.05g228500
+IAA17	Indole-3-Acetic Acid Responsive Gene 17	glyma.Wm82.gnm2.ann1.Glyma.05G229300
+ALDH2C1	aldehyde dehydrogenase family 2 member C1	glyma.Wm82.gnm2.ann1.Glyma.05g231800
+NAC031	NAC Transcription Factor gene 31	glyma.Wm82.gnm2.ann1.Glyma.05G234200
+MYB84	MYB transciption factor 84	glyma.Wm82.gnm2.ann1.Glyma.05G234600
+PPR45	Psudo-Response Regulator gene 45	glyma.Wm82.gnm2.ann1.Glyma.05G240300
+LEA2-27	late embryogenesis abundant 2 gene 27	glyma.Wm82.gnm2.ann1.Glyma.05G242600
+PPR46	Psudo-Response Regulator gene 46	glyma.Wm82.gnm2.ann1.Glyma.05G244300
+PPR47	Psudo-Response Regulator gene 47	glyma.Wm82.gnm2.ann1.Glyma.05G244400
+C2-44	C2 domain containing protein gene 44	glyma.Wm82.gnm2.ann1.Glyma.05G246400
+HDA9	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.06g000100
+MED19-2	Mediator Complex 19 gene 2	glyma.Wm82.gnm2.ann1.Glyma.06g001300
+GSA1	glutamate 1-semialdehyde aminotransferase gene 1	glyma.Wm82.gnm2.ann1.Glyma.06g002900
+PIP2-2	aquaporin PIP2-2	glyma.Wm82.gnm2.ann1.Glyma.06g003200
+C2-45	C2 domain containing protein gene 45	glyma.Wm82.gnm2.ann1.Glyma.06G003700
+MYB48	MYB transcription factor MYB48	glyma.Wm82.gnm2.ann1.Glyma.06g003800
+LAX7	auxin transporter-like protein 7	glyma.Wm82.gnm2.ann1.Glyma.06g004500
+CYP3	peptidyl-prolyl cis-trans isomerase CYP3	glyma.Wm82.gnm2.ann1.Glyma.06g005100
+COBL7	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.06G005800
+ADC	arginine decarboxylase	glyma.Wm82.gnm2.ann1.Glyma.06g007500
+DHFR-TS	bifunctional dihydrofolate reductase-thymidylate synthase	glyma.Wm82.gnm2.ann1.Glyma.06g010600
+NAC162	NAC domain-containing protein 162	glyma.Wm82.gnm2.ann1.Glyma.06g014900
+CAT5	catalase	glyma.Wm82.gnm2.ann1.Glyma.06g017900
+Lac14	Laccase 14	glyma.Wm82.gnm2.ann1.Glyma.06G019800
+ODC2	ornithine decarboxylase	glyma.Wm82.gnm2.ann1.Glyma.06g020300
+C2-46	C2 domain containing protein gene 46	glyma.Wm82.gnm2.ann1.Glyma.06G020500
+SMT2-2	24-methylenesterol C-methyltransferase 2-2	glyma.Wm82.gnm2.ann1.Glyma.06g020700
+BZIP47, FDc2	Flowering Locus D	glyma.Wm82.gnm2.ann1.Glyma.06G022300
+SSTP-2	subtilisin-type protease precursor	glyma.Wm82.gnm2.ann1.Glyma.06g022500
+SSTP-1	subtilisin-type protease precursor	glyma.Wm82.gnm2.ann1.Glyma.06g022600
+GASA8	gibberellin-regulated protein 8	glyma.Wm82.gnm2.ann1.Glyma.06g024500
+IQD17	protein IQ-DOMAIN 17	glyma.Wm82.gnm2.ann1.Glyma.06g025800
+BZIP11	bZIP transcription factor bZIP11	glyma.Wm82.gnm2.ann1.Glyma.06g026000
+AP3b, NMH7	MADS-box protein NMH7	glyma.Wm82.gnm2.ann1.Glyma.06g027200
+TOPP6	TOPP-type protein phosphatase gene 6	glyma.Wm82.gnm2.ann1.Glyma.06G027300
+Phy	purple acid phosphatase 2-like	glyma.Wm82.gnm2.ann1.Glyma.06g028200
+bZIP49	Basic leucine zipper transcription factor-like protein gene 49	glyma.Wm82.gnm2.ann1.Glyma.06G029600
+BES1, BZL3	protein BRASSINAZOLE-RESISTANT 1-like	glyma.Wm82.gnm2.ann1.Glyma.06g034000
+MYB124	MYB transcription factor MYB124	glyma.Wm82.gnm2.ann1.Glyma.06g036800
+NRAMP3B	metal transporter Nramp3b	glyma.Wm82.gnm2.ann1.Glyma.06g044200
+GASA9	gibberellin-regulated protein 9	glyma.Wm82.gnm2.ann1.Glyma.06g044400
+SCTF-1, ZAT6	C2H2-type Zinc Finger transcription factor 6	glyma.Wm82.gnm2.ann1.Glyma.06G045400
+SCA2	plasma membrane Ca2+-ATPase	glyma.Wm82.gnm2.ann1.Glyma.06g046000
+BCAT	Branched-chain amino acid aminotransferase	glyma.Wm82.gnm2.ann1.Glyma.06G050100
+LEA2-28	late embryogenesis abundant 2 gene 28	glyma.Wm82.gnm2.ann1.Glyma.06G052400
+IQD18	protein IQ-DOMAIN 18	glyma.Wm82.gnm2.ann1.Glyma.06g052800
+Raf49-3	Raf49 proto-oncogene serine/threonine protein kinase gene 3	glyma.Wm82.gnm2.ann1.Glyma.06G055300
+HMA8	chloroplast copper-translocating HMA8 P-ATPase	glyma.Wm82.gnm2.ann1.Glyma.06g056300
+PPR48	Psudo-Response Regulator gene 48	glyma.Wm82.gnm2.ann1.Glyma.06G057900
+PP2C;L2	phloem-specific pumpkin2C gene L2	glyma.Wm82.gnm2.ann1.Glyma.06G059700
+WRKY17	WRKY transcription factor 17	glyma.Wm82.gnm2.ann1.Glyma.06g061900
+bZIP52	Basic leucine zipper transcription factor-like protein gene 52	glyma.Wm82.gnm2.ann1.Glyma.06G062000
+B12	AS3/PDS5-related	glyma.Wm82.gnm2.ann1.Glyma.06g062700
+ERF42	Ethylene-responsive factor gene 42	glyma.Wm82.gnm2.ann1.Glyma.06G064000
+C2-47	C2 domain containing protein gene 47	glyma.Wm82.gnm2.ann1.Glyma.06G066600
+IAA18	Indole-3-Acetic Acid Responsive Gene 18	glyma.Wm82.gnm2.ann1.Glyma.06G067700
+APX6	Ascorbate peroxidase 6 	glyma.Wm82.gnm2.ann1.Glyma.06G068200
+GRR1	putative EIN3-binding F-box protein	glyma.Wm82.gnm2.ann1.Glyma.06g068400
+C2-48	C2 domain containing protein gene 48	glyma.Wm82.gnm2.ann1.Glyma.06G068600
+C2-49	C2 domain containing protein gene 49	glyma.Wm82.gnm2.ann1.Glyma.06G068700
+ERF43	Ethylene-responsive factor gene 43	glyma.Wm82.gnm2.ann1.Glyma.06G068800
+CYP43	peptidyl-prolyl cis-trans isomerase CYP43	glyma.Wm82.gnm2.ann1.Glyma.06g070300
+GA3OX2	gibberellin 3-beta-dioxygenase 2	glyma.Wm82.gnm2.ann1.Glyma.06g072600
+WRKY37	WRKY transcription factor 37	glyma.Wm82.gnm2.ann1.Glyma.06g077400
+bZIP53	Basic leucine zipper transcription factor-like protein gene 53	glyma.Wm82.gnm2.ann1.Glyma.06G079800
+NAC034	NAC Transcription Factor gene 34	glyma.Wm82.gnm2.ann1.Glyma.06G080200
+PPR49	Psudo-Response Regulator gene 49	glyma.Wm82.gnm2.ann1.Glyma.06G080500
+AAT	aspartate aminotransferase glyoxysomal isozyme AAT1 precursor	glyma.Wm82.gnm2.ann1.Glyma.06g082400
+GLYI-5	Glyoxylase 1 gene 5	glyma.Wm82.gnm2.ann1.Glyma.06g084500
+AP2-1	dehydration-responsive element-binding protein 3-like	glyma.Wm82.gnm2.ann1.Glyma.06g085700
+CCD8	carotenoid cleavage dioxygenase	glyma.Wm82.gnm2.ann1.Glyma.06g085800
+ITPK3	inositol phosphate kinase	glyma.Wm82.gnm2.ann1.Glyma.06g089800
+IAA19	Indole-3-Acetic Acid Responsive Gene 19	glyma.Wm82.gnm2.ann1.Glyma.06G091700
 GF14h, SGF14J	14-3-3 protein SGF14j	glyma.Wm82.gnm2.ann1.Glyma.06g094400
 GF14i, SGF14I	14-3-3 protein SGF14i	glyma.Wm82.gnm2.ann1.Glyma.06g101500
-GF14j	GF14 gene family gene j	glyma.Wm82.gnm2.ann1.Glyma.06G182800
-GF14k, SGF14Q	putative 14-3-3 protein SGF14q	glyma.Wm82.gnm2.ann1.Glyma.07g226000
-GF14l, SGF14L	14-3-3 protein SGF14l	glyma.Wm82.gnm2.ann1.Glyma.08g115800
-GF14m, SGF14M	14-3-3 protein SGF14m	glyma.Wm82.gnm2.ann1.Glyma.08g363800
-GF14n, SGF14O	14-3-3 protein SGF14o	glyma.Wm82.gnm2.ann1.Glyma.12g210400
-GF14o, SGF14n	14-3-3 protein SGF14n	glyma.Wm82.gnm2.ann1.Glyma.12g229200
-GF14p, SGF14P	14-3-3 protein SGF14p	glyma.Wm82.gnm2.ann1.Glyma.13g270600
-GF14q	GF14 gene family gene q	glyma.Wm82.gnm2.ann1.Glyma.13G290900
-GF14r, SGF14K	14-3-3 protein SGF14k	glyma.Wm82.gnm2.ann1.Glyma.14g176900
-GF14s	GF14 gene family gene s	glyma.Wm82.gnm2.ann1.Glyma.17G208100
-GF14t	GF14 gene family gene t	glyma.Wm82.gnm2.ann1.Glyma.18G298300
-GF14u, SGF14R	putative 14-3-3 protein SGF14r	glyma.Wm82.gnm2.ann1.Glyma.20g025900
-GF14v	GF14 gene family gene v	glyma.Wm82.gnm2.ann1.Glyma.20G043700
-GH	gamma glutamyl hydrolase	glyma.Wm82.gnm2.ann1.Glyma.13g267800
-GH1, IAA1	Indole-3-Acetic Acid Responsive Gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G019400
-GH3.1	auxin synthesis-related gene	glyma.Wm82.gnm2.ann1.Glyma.02G125600
-GH3.6	auxin synthesis-related gene	glyma.Wm82.gnm2.ann1.Glyma.06G260800
-GI1	gigantea protein gene 1	glyma.Wm82.gnm1.ann1.Glyma20g30980
-GI1A, GIGANTEA	protein GIGANTEA	glyma.Wm82.gnm2.ann1.Glyma.20g170000
-GI3, GIa (E2)	Gigantea gene a	glyma.Wm82.gnm2.ann1.Glyma.10G221500
-GID1B	GID Complex Subunit	glyma.Wm82.gnm2.ann1.Glyma.03G148300
-GID1C, GR2	giberellic acid responsive gene 2	glyma.Wm82.gnm2.ann1.Glyma.20G230600
-GIP1	putative aspartic proteinase GIP1	glyma.Wm82.gnm2.ann1.Glyma.03g151900
-GK	glycerol kinase	glyma.Wm82.gnm2.ann1.Glyma.07g028600
-GLB1, HB1	Non-symbiotic hemoglobin 2 gene	glyma.Wm82.gnm2.ann1.Glyma.11g121800
-GLB3	Nonsymbiotic hemoglobin gene 3	glyma.Wm82.gnm2.ann1.Glyma.04g079200
-GLXI, GLYI-15	Glyoxylase 1 gene 15	glyma.Wm82.gnm2.ann1.Glyma.11g194300
-GLYI-1	Glyoxylase 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.01g146300
-GLYI-10	Glyoxylase 1 gene 10	glyma.Wm82.gnm2.ann1.Glyma.09g004300
-GLYI-11	Glyoxylase 1 gene 11	glyma.Wm82.gnm2.ann1.Glyma.09g193800
-GLYI-12	Glyoxylase 1 gene 12	glyma.Wm82.gnm2.ann1.Glyma.09g226500
-GLYI-13	Glyoxylase 1 gene 13	glyma.Wm82.gnm2.ann1.Glyma.11g075000
-GLYI-14	Glyoxylase 1 gene 14	glyma.Wm82.gnm2.ann1.Glyma.11g194200
-GLYI-16	Glyoxylase 1 gene 16	glyma.Wm82.gnm2.ann1.Glyma.12g079700
-GLYI-17	putative lactoylglutathione lyase	glyma.Wm82.gnm2.ann1.Glyma.12g167400
-GLYI-18	putative lactoylglutathione lyase	glyma.Wm82.gnm2.ann1.Glyma.13g106600
-GLYI-19	putative lactoylglutathione lyase	glyma.Wm82.gnm2.ann1.Glyma.13g168200
-GLYI-2	Glyoxylase 1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.01g168400
-GLYI-20	putative lactoylglutathione lyase	glyma.Wm82.gnm2.ann1.Glyma.15g009500
-GLYI-21	putative lactoylglutathione lyase	glyma.Wm82.gnm2.ann1.Glyma.15g108400
-GLYI-22	putative lactoylglutathione lyase	glyma.Wm82.gnm2.ann1.Glyma.16g003500
-GLYI-23	putative lactoylglutathione lyase	glyma.Wm82.gnm2.ann1.Glyma.17g052700
-GLYI-24	putative lactoylglutathione lyase	glyma.Wm82.gnm2.ann1.Glyma.17g115900
-GLYI-3	Glyoxylase 1 gene 3	glyma.Wm82.gnm2.ann1.Glyma.04g083100
-GLYI-4	Glyoxylase 1 gene 4	glyma.Wm82.gnm2.ann1.Glyma.05g228500
-GLYI-5	Glyoxylase 1 gene 5	glyma.Wm82.gnm2.ann1.Glyma.06g084500
-GLYI-6	Glyoxylase 1 gene 6	glyma.Wm82.gnm2.ann1.Glyma.07g031700
-GLYI-7	Glyoxylase 1 gene 7	glyma.Wm82.gnm2.ann1.Glyma.07g261400
-GLYI-8	Glyoxylase 1 gene 8	glyma.Wm82.gnm2.ann1.Glyma.08g035400
-GLYI-9	Glyoxylase 1 gene 9	glyma.Wm82.gnm2.ann1.Glyma.08g211100
-GLYII-1	hydroxyacylglutathione hydrolase cytoplasmic-like	glyma.Wm82.gnm2.ann1.Glyma.02g220100
-GLYII-10	putative hydroxyacylglutathione hydrolase	glyma.Wm82.gnm2.ann1.Glyma.15g245500
-GLYII-12	glyoxalase GLYII-12	glyma.Wm82.gnm2.ann1.Glyma.20g118000
-GLYII-3	putative hydroxyacylglutathione hydrolase	glyma.Wm82.gnm2.ann1.Glyma.06g140800
-GLYII-4	putative hydroxyacylglutathione hydrolase	glyma.Wm82.gnm2.ann1.Glyma.11g126200
-GLYII-5	putative hydroxyacylglutathione hydrolase	glyma.Wm82.gnm2.ann1.Glyma.12g050800
-GLYII-6	putative hydroxyacylglutathione hydrolase	glyma.Wm82.gnm2.ann1.Glyma.13g261400
-GLYII-7	putative hydroxyacylglutathione hydrolase	glyma.Wm82.gnm2.ann1.Glyma.13g345400
-GLYII-8	putative hydroxyacylglutathione hydrolase	glyma.Wm82.gnm2.ann1.Glyma.14g187700
-GLYII-9	putative hydroxyacylglutathione hydrolase	glyma.Wm82.gnm2.ann1.Glyma.15g028900
-GM2S-1	2S albumin	glyma.Wm82.gnm2.ann1.Glyma.13g288100
-GME1	GDP-mannose 3',5'-epimerase	glyma.Wm82.gnm2.ann1.Glyma.19g244600
-GMNAC184, NAC184	NAC Transcription Factor gene 184	glyma.Wm82.gnm2.ann1.Glyma.20G175500
-GMP1	mannose-1-phosphate guanylyltransferase 1-like	glyma.Wm82.gnm2.ann1.Glyma.14g065900
-GMP2	mannose-1-phosphate guanylyltransferase 1-like	glyma.Wm82.gnm2.ann1.Glyma.11g223700
-GMR1	ras-related protein RABA5d-like	glyma.Wm82.gnm2.ann1.Glyma.18g300600
-GMR2	ras-related protein RABA5d-like	glyma.Wm82.gnm2.ann1.Glyma.08g361000
-GND	6-phosphogluconate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.18g277300
-GOS12	SNARE GOS12	glyma.Wm82.gnm2.ann1.Glyma.01g137300
-GPA1	G protein alpha subunit	glyma.Wm82.gnm2.ann1.Glyma.04g056600
-GPA2	guanine nucleotide-binding protein alpha-2 subunit	glyma.Wm82.gnm2.ann1.Glyma.17g226700
-GPPS	geranyl-diphosphate synthase	glyma.Wm82.gnm2.ann1.Glyma.14g023000
-GPRP3	glycine and proline rich protein 3	glyma.Wm82.gnm2.ann1.Glyma.16g076800
-GPRP4	glycine-rich protein A3-like	glyma.Wm82.gnm2.ann1.Glyma.01g154000
-GPX	Glutathione Peroxidase	glyma.Wm82.gnm2.ann1.Glyma.08G013800
-GR, GR-2b	Chloroplastic glutathione reductase 2 gene b	glyma.Wm82.gnm2.ann1.Glyma.02G141800
-GR-1a	Cytosolic glutathione reductase 1 gene a	glyma.Wm82.gnm2.ann1.Glyma.16G155700
-GR-1b	Cytosolic glutathione reductase 1 gene b	glyma.Wm82.gnm2.ann1.Glyma.02G074200
-GR-2a	Chloroplastic glutathione reductase 2 gene a	glyma.Wm82.gnm2.ann1.Glyma.10G032100
-GRF1	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.01g148600
-GRF10	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.11g008500
-GRF11	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.11g110700
-GRF12	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.11g208800
-GRF13	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.12g014700
-GRF14	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.13g109500
-GRF15	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.15g176500
-GRF16	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.16g007600
-GRF17	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.17g050200
-GRF18	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.17g232600
-GRF19	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.17g232700
-GRF2	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.01g234400
-GRF20	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.19g192700
-GRF21	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.u028600
-GRF22	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.u028700
-GRF3	growth-regulating factor 3	glyma.Wm82.gnm2.ann1.Glyma.03g192200
-GRF4	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.04g230600
+CRY1b1	Cryptochrome 1b1	glyma.Wm82.gnm2.ann1.Glyma.06g103200
+LEA2-29	late embryogenesis abundant 2 gene 29	glyma.Wm82.gnm2.ann1.Glyma.06G104900
+LBD25	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.06g106500
+bZIP54, TGA09	bZIP transcription factor 9	glyma.Wm82.gnm2.ann1.Glyma.06g107300
+INR2	inducible nitrate reductase 2	glyma.Wm82.gnm2.ann1.Glyma.06g109200
+OSBP	oxysterol-binding protein	glyma.Wm82.gnm2.ann1.Glyma.06g109500
+LAX8	auxin transporter-like protein 8	glyma.Wm82.gnm2.ann1.Glyma.06g110200
+AP2-5, ERF44	Ethylene-responsive factor gene 44	glyma.Wm82.gnm2.ann1.Glyma.06G111300
+NAC035, NAC2	NAC domain protein NAC2	glyma.Wm82.gnm2.ann1.Glyma.06g114000
+ALDH3H2	aldehyde dehydrogenase family 3 member H2	glyma.Wm82.gnm2.ann1.Glyma.06g114300
+stAPX-a	Ascorbate peroxidase gene a	glyma.Wm82.gnm2.ann1.Glyma.06G114400
+PDIL	protein disulfide isomerase	glyma.Wm82.gnm2.ann1.Glyma.06G114800
+NRAMP7	metal transporter Nramp7	glyma.Wm82.gnm2.ann1.Glyma.06g115800
+TCHQD1	glutathione S-transferase TCHQD-like	glyma.Wm82.gnm2.ann1.Glyma.06g117800
+CHS14	chalcone synthase	glyma.Wm82.gnm2.ann1.Glyma.06g118500
+SWEET13	sugar efflux transporter SWEET13	glyma.Wm82.gnm2.ann1.Glyma.06g122200
+ERF45	Ethylene-responsive factor gene 45	glyma.Wm82.gnm2.ann1.Glyma.06G125100
+SPCH2	transcription factor SPEECHLESS-like	glyma.Wm82.gnm2.ann1.Glyma.06g125500
+SIG5B	RNA polymerase sigma factor sigE, chloroplastic/mitochondrial-like	glyma.Wm82.gnm2.ann1.Glyma.06g125700
+SWEET14	sugar efflux transporter SWEET14	glyma.Wm82.gnm2.ann1.Glyma.06g125800
+IQD19	protein IQ-DOMAIN 19	glyma.Wm82.gnm2.ann1.Glyma.06g129300
 GRF5	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.06g134600
+PRR5a	Pseudo Response Regultor 5 gene a	glyma.Wm82.gnm2.ann1.Glyma.06G136600
+LEA2-30	late embryogenesis abundant 2 gene 30	glyma.Wm82.gnm2.ann1.Glyma.06G136700
+IMT1	myo-inositol-O-methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.06g137100
+NAC036	NAC Transcription Factor gene 36	glyma.Wm82.gnm2.ann1.Glyma.06G138100
+C2-50	C2 domain containing protein gene 50	glyma.Wm82.gnm2.ann1.Glyma.06G140100
+GLYII-3	putative hydroxyacylglutathione hydrolase	glyma.Wm82.gnm2.ann1.Glyma.06g140800
+WRKY58	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.06G142100
+CHI4, CHI4A	chalcone isomerase 4A	glyma.Wm82.gnm2.ann1.Glyma.06g143000
+DD2/63	expansin	glyma.Wm82.gnm2.ann1.Glyma.06g143300
+LBD26	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.06g145400
+BRI1A	brassinosteroid receptor	glyma.Wm82.gnm2.ann1.Glyma.06g147600
+ERF46	Ethylene-responsive factor gene 46	glyma.Wm82.gnm2.ann1.Glyma.06G148400
+MED26-3	Mediator Complex 26 gene 3	glyma.Wm82.gnm2.ann1.Glyma.06g149200
+NAC037	NAC Transcription Factor gene 37	glyma.Wm82.gnm2.ann1.Glyma.06G152900
+SRT2	NAD-dependent protein deacylase SRT2-like	glyma.Wm82.gnm2.ann1.Glyma.06g156000
+NAC018, NAC039	NAC Transcription Factor gene 39	glyma.Wm82.gnm2.ann1.Glyma.06G157400
+MYB56	MYB transcription factor MYB56	glyma.Wm82.gnm2.ann1.Glyma.06g160500
+PPR50	Psudo-Response Regulator gene 50	glyma.Wm82.gnm2.ann1.Glyma.06G161900
+ERF47	Ethylene-responsive factor gene 47	glyma.Wm82.gnm2.ann1.Glyma.06G163700
+C2-51	C2 domain containing protein gene 51	glyma.Wm82.gnm2.ann1.Glyma.06G163800
+MED36-2	Mediator Complex 36 gene 2	glyma.Wm82.gnm2.ann1.Glyma.06g164800
+ICE4	inducer of CBF expression 4	glyma.Wm82.gnm2.ann1.Glyma.06g165000
+NAC040	NAC Transcription Factor gene 40	glyma.Wm82.gnm2.ann1.Glyma.06G166500
+SWEET15	sugar efflux transporter SWEET15	glyma.Wm82.gnm2.ann1.Glyma.06g166800
+SWEET16	sugar efflux transporter SWEET16	glyma.Wm82.gnm2.ann1.Glyma.06g166900
+SWEET17	sugar efflux transporter SWEET17	glyma.Wm82.gnm2.ann1.Glyma.06g167000
+WRKY61	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.06G168400
+MED30-2	Mediator Complex 30 gene 2	glyma.Wm82.gnm2.ann1.Glyma.06g169200
+NF-YC04, NF-YC4-1	NF-Y subunit C 4 gene 1	glyma.Wm82.gnm2.ann1.Glyma.06g169600
+AHAS2, ALS-2, ALS2	Acetolactate synthase gene 2	glyma.Wm82.gnm2.ann1.Glyma.06g169700
+PAP12	purple acid phosphatase gene 12	glyma.Wm82.gnm2.ann1.Glyma.06G170300
+GAPC1	glyceraldehyde-3-phosphate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.06g172600
+CYSP2	cysteine proteinase	glyma.Wm82.gnm2.ann1.Glyma.06g174800
+SEOD	sieve element occlusion d	glyma.Wm82.gnm2.ann1.Glyma.06g175200
+CYP71A10	cytochrome P450 71A10	glyma.Wm82.gnm2.ann1.Glyma.06g176100
+WNK7	with no lysine kinase 7	glyma.Wm82.gnm2.ann1.Glyma.06g176800
+TUFA	elongation factor Tu, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.06g176900
+C2-52	C2 domain containing protein gene 52	glyma.Wm82.gnm2.ann1.Glyma.06G177800
+LBD27	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.06g178900
+RS2	Raffinose Synthase 2	glyma.Wm82.gnm2.ann1.Glyma.06g179200
+BOR2	boron transporter BOR2	glyma.Wm82.gnm2.ann1.Glyma.06g181900
+PEX14	peroxisomal membrane protein PEX14	glyma.Wm82.gnm2.ann1.Glyma.06g182600
+CA1	carbonic anhydrase	glyma.Wm82.gnm2.ann1.Glyma.06g182700
+GF14j	GF14 gene family gene j	glyma.Wm82.gnm2.ann1.Glyma.06G182800
+ALDH2B4	aldehyde dehydrogenase family 2 member B4, mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.06g183900
+GASA10	gibberellin-regulated protein 10	glyma.Wm82.gnm2.ann1.Glyma.06g185300
+ERA1A	farnesyltransferase	glyma.Wm82.gnm2.ann1.Glyma.06g185500
+ALDH10A2	betaine aldehyde dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.06g186300
+EDS1	Enhanced disease susceptibility 1	glyma.Wm82.gnm2.ann1.Glyma.06G187300
+EDS1-2	protein EDS1-like	glyma.Wm82.gnm2.ann1.Glyma.06g187400
+MYB183	MYB transcription factor MYB183	glyma.Wm82.gnm2.ann1.Glyma.06g187600
+MED4-1	Mediator Complex 4 gene 1	glyma.Wm82.gnm2.ann1.Glyma.06g188800
+IQD20	protein IQ-DOMAIN 20	glyma.Wm82.gnm2.ann1.Glyma.06g191200
+TCP7	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 7	glyma.Wm82.gnm2.ann1.Glyma.06G193000
+GASA11	gibberellin-regulated protein 11	glyma.Wm82.gnm2.ann1.Glyma.06g193800
+CDF3a	Cycling Dof Factor 3 gene a	glyma.Wm82.gnm2.ann1.Glyma.06G194800
+NAC041, NAC5	NAC domain protein NAC5	glyma.Wm82.gnm2.ann1.Glyma.06g195500
+MYB150	MYB transcription factor MYB150	glyma.Wm82.gnm2.ann1.Glyma.06g201500
+F3'H, SF3'H1, T	Tawny	glyma.Wm82.gnm2.ann1.Glyma.06g202300
+TCP30	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 30	glyma.Wm82.gnm2.ann1.Glyma.06G204300
+COBL8	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.06G205400
+COBL9	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.06G205500
+AGL8b, AP1A, FULa	Fruitfull gene a	glyma.Wm82.gnm2.ann1.Glyma.06g205800
+PPR51	Psudo-Response Regulator gene 51	glyma.Wm82.gnm2.ann1.Glyma.06G206900
+DR1	class 2 transcription repressor NC2 beta 2	glyma.Wm82.gnm2.ann1.Glyma.06g209000
+BRC1, TCP48	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 48	glyma.Wm82.gnm2.ann1.Glyma.06G210600
+ENOD93	early nodulin-93	glyma.Wm82.gnm2.ann1.Glyma.06g216500
+ERF48	Ethylene-responsive factor gene 48	glyma.Wm82.gnm2.ann1.Glyma.06G221800
+HO3	heme oxygenase 3	glyma.Wm82.gnm2.ann1.Glyma.06g221900
+DGK5	diacylglycerol kinase 5	glyma.Wm82.gnm2.ann1.Glyma.06g223900
+PEPC3, ppc2	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.06g229900
+TCP31	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 31	glyma.Wm82.gnm2.ann1.Glyma.06G232300
+HGO3	homogentisate 1,2-dioxygenase	glyma.Wm82.gnm2.ann1.Glyma.06g233800
+HGO2	homogentisate 1,2-dioxygenase	glyma.Wm82.gnm2.ann1.Glyma.06g234200
+NAC042	NAC Transcription Factor gene 42	glyma.Wm82.gnm2.ann1.Glyma.06G236000
+ERF49	Ethylene-responsive factor gene 49	glyma.Wm82.gnm2.ann1.Glyma.06G236400
+C2-53	C2 domain containing protein gene 53	glyma.Wm82.gnm2.ann1.Glyma.06G241700
+WRKY65	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.06G242200
+MT3	type 3 metallothionein MT3	glyma.Wm82.gnm2.ann1.Glyma.06g242900
+NAC3	NAC domain protein NAC3	glyma.Wm82.gnm2.ann1.Glyma.06g248900
+SNAC41	NAC domain-containing protein 18-like	glyma.Wm82.gnm2.ann1.Glyma.06g249100
+CYP48	peptidyl-prolyl cis-trans isomerase CYP48	glyma.Wm82.gnm2.ann1.Glyma.06g249300
+PAA1	proteasome subunit alpha type-6	glyma.Wm82.gnm2.ann1.Glyma.06g254200
+PPR52	Psudo-Response Regulator gene 52	glyma.Wm82.gnm2.ann1.Glyma.06G254600
+DGK8	diacylglycerol kinase 8	glyma.Wm82.gnm2.ann1.Glyma.06g254900
+GH3.6	auxin synthesis-related gene	glyma.Wm82.gnm2.ann1.Glyma.06G260800
+LRR	Leucine-rich repeat receptor-like kinase	glyma.Wm82.gnm2.ann1.Glyma.06G265400
+KR3	disease resistance protein KR3	glyma.Wm82.gnm2.ann1.Glyma.06g267300
+SC-04	thiamin biosynthetic enzyme	glyma.Wm82.gnm2.ann1.Glyma.06g269700
+PEPC4, ppc3	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.06g277500
+RIC2	CLE-related protein RIC2	glyma.Wm82.gnm2.ann1.Glyma.06g284100
+Lac15	Laccase 15	glyma.Wm82.gnm2.ann1.Glyma.06G284300
+TCP32	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 32	glyma.Wm82.gnm2.ann1.Glyma.06G284500
+BZIP50	bZIP transcription factor bZIP50	glyma.Wm82.gnm2.ann1.Glyma.06g284900
+LBD28	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.06g285100
+F3G2Gt 1, F3G2Gt-a, F3G2Gt-b, Fg3, UGT79B30, UGT79B30-1	anthocyanidin 3-O-glucoside 2''-O-glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.06g285700
+NAC163	NAC domain-containing protein 163	glyma.Wm82.gnm2.ann1.Glyma.06g288500
+CPIP	Soybean mosaic virus coat protein-interacting protein	glyma.Wm82.gnm2.ann1.Glyma.06g289000
+ERF50	Ethylene-responsive factor gene 50	glyma.Wm82.gnm2.ann1.Glyma.06G290000
+C2-54	C2 domain containing protein gene 54	glyma.Wm82.gnm2.ann1.Glyma.06G292000
+EXPB4	expansin-B3-like	glyma.Wm82.gnm2.ann1.Glyma.06g294500
+DGK4	diacylglycerol kinase 4	glyma.Wm82.gnm2.ann1.Glyma.06g299200
+BMY1-1	Beta-amylase 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.06g301500
+PPR53	Psudo-Response Regulator gene 53	glyma.Wm82.gnm2.ann1.Glyma.06G301600
+TPS3	geraniol synthase	glyma.Wm82.gnm2.ann1.Glyma.06g302200
+PC7	peroxidase	glyma.Wm82.gnm2.ann1.Glyma.06g302600
+MYB73	MYB transcription factor MYB73	glyma.Wm82.gnm2.ann1.Glyma.06g303100
+ICL1	isocitrate lyase 1-like	glyma.Wm82.gnm2.ann1.Glyma.06g303200
+LEA2-31	late embryogenesis abundant 2 gene 31	glyma.Wm82.gnm2.ann1.Glyma.06G303300
+SIP1-6	aquaporin SIP1-6	glyma.Wm82.gnm2.ann1.Glyma.06g307000
+Lac16	Laccase 16	glyma.Wm82.gnm2.ann1.Glyma.06G307100
+bZIP56	Basic leucine zipper transcription factor-like protein gene 56	glyma.Wm82.gnm2.ann1.Glyma.06G307200
+WRKY66	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.06G307700
+PPR54	Psudo-Response Regulator gene 54	glyma.Wm82.gnm2.ann1.Glyma.06G311600
+PPR55	Psudo-Response Regulator gene 55	glyma.Wm82.gnm2.ann1.Glyma.06G311700
+bZIP57	Basic leucine zipper transcription factor-like protein gene 57	glyma.Wm82.gnm2.ann1.Glyma.06G314400
+Lac17	Laccase 17	glyma.Wm82.gnm2.ann1.Glyma.06G318800
+NAC045	NAC Transcription Factor gene 45	glyma.Wm82.gnm2.ann1.Glyma.06G318900
+BRL1B	brassinosteroid receptor-like protein	glyma.Wm82.gnm2.ann1.Glyma.06g320600
+WRKY59, WRKY67	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.06G320700
+IF7GT6	isoflavone 7-O-glucosyltransferase UGT6	glyma.Wm82.gnm2.ann1.Glyma.06g320800
+PPR56	Psudo-Response Regulator gene 56	glyma.Wm82.gnm2.ann1.Glyma.06G322500
+AGL11	MADS domain transporter AGL11	glyma.Wm82.gnm2.ann1.Glyma.06g324400
+AMS1	beta-amyrin synthase	glyma.Wm82.gnm2.ann1.Glyma.07g001300
+MKK4	mitogen-activated protein kinase kinase 4	glyma.Wm82.gnm2.ann1.Glyma.07g003200
+RPL37	ribosomal protein L37	glyma.Wm82.gnm2.ann1.Glyma.07g004900
+VLXC	lipoxygenase	glyma.Wm82.gnm2.ann1.Glyma.07g006900
+LOX1.4, SC514	lipoxygenase	glyma.Wm82.gnm2.ann1.Glyma.07g007000
+COPZ1	nonclathrin coat protein zeta1-COP	glyma.Wm82.gnm2.ann1.Glyma.07g008000
+IQD21	protein IQ-DOMAIN 21	glyma.Wm82.gnm2.ann1.Glyma.07g008400
+CWINV	beta-fructofuranosidase	glyma.Wm82.gnm2.ann1.Glyma.07g008800
+MED9-1	Mediator Complex 9 gene 1	glyma.Wm82.gnm2.ann1.Glyma.07g009300
+LBD29	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.07g009500
+LEA2-32	late embryogenesis abundant 2 gene 32	glyma.Wm82.gnm2.ann1.Glyma.07G009700
+C2-55	C2 domain containing protein gene 55	glyma.Wm82.gnm2.ann1.Glyma.07G010900
+ABCC8	ABC Transporter C8	glyma.Wm82.gnm2.ann1.Glyma.07G011600
+G6PDH8	Glucose-6-phosphate dehydrogenase gene 8	glyma.Wm82.gnm2.ann1.Glyma.07G013800
+VSP25, VSPA, VSPA28	Vegetative storage protein A 28 kD	glyma.Wm82.gnm2.ann1.Glyma.07g014500
+IQD22	protein IQ-DOMAIN 22	glyma.Wm82.gnm2.ann1.Glyma.07g014800
+IAA20	Indole-3-Acetic Acid Responsive Gene 20	glyma.Wm82.gnm2.ann1.Glyma.07G015200
+IAA21	Indole-3-Acetic Acid Responsive Gene 21	glyma.Wm82.gnm2.ann1.Glyma.07G018100
+WRKY68	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.07G023300
+NRAMP5A	metal transporter Nramp5a	glyma.Wm82.gnm2.ann1.Glyma.07g023600
+GK	glycerol kinase	glyma.Wm82.gnm2.ann1.Glyma.07g028600
+PPR57	Psudo-Response Regulator gene 57	glyma.Wm82.gnm2.ann1.Glyma.07G029000
+MED7-1	Mediator Complex 7 gene 1	glyma.Wm82.gnm2.ann1.Glyma.07g029300
+FAD5.1	delta-7 desaturase	glyma.Wm82.gnm2.ann1.Glyma.07g030000
+C2-56	C2 domain containing protein gene 56	glyma.Wm82.gnm2.ann1.Glyma.07G031100
+ERF51	Ethylene-responsive factor gene 51	glyma.Wm82.gnm2.ann1.Glyma.07G031200
+GLYI-6	Glyoxylase 1 gene 6	glyma.Wm82.gnm2.ann1.Glyma.07g031700
+PPR58	Psudo-Response Regulator gene 58	glyma.Wm82.gnm2.ann1.Glyma.07G033300
+IAA22	Indole-3-Acetic Acid Responsive Gene 22	glyma.Wm82.gnm2.ann1.Glyma.07G034200
+LOX9	Lipoxygenase 9 gene	glyma.Wm82.gnm2.ann1.Glyma.07g034800
+NF-YA05	nuclear transcription factor Y subunit A-5	glyma.Wm82.gnm2.ann1.Glyma.07g036200
 GRF6	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.07g038400
-GRF7	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.09g068700
-GRF8	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.09g212500
-GRF9	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.10g067200
-GRP	glycine-rich RNA-binding protein	glyma.Wm82.gnm2.ann1.Glyma.12g043000
-GRR1	putative EIN3-binding F-box protein	glyma.Wm82.gnm2.ann1.Glyma.06g068400
-GS, GS-gamma2-a, GS1GAMMA2	glutamine synthetase cytosolic isozyme 2	glyma.Wm82.gnm2.ann1.Glyma.02g244000
-GS-2	glutamine synthetase precursor	glyma.Wm82.gnm2.ann1.Glyma.13g210800
-GS1-GAMMA, GS1-gamma1	Gamma glutamine synthase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.14g213300
-GS1alpha	Glutamine synthase 1 alpha gene	glyma.Wm82.gnm2.ann1.Glyma.09g173200
-GS1beta2	Glutamine synthase 1 beta 2 gene	glyma.Wm82.gnm2.ann1.Glyma.18g041100
-GS52	ecto-apyrase GS52	glyma.Wm82.gnm2.ann1.Glyma.16g043300
-GSA1	glutamate 1-semialdehyde aminotransferase gene 1	glyma.Wm82.gnm2.ann1.Glyma.06g002900
-GSH1	gamma glutamylcysteine synthestase	glyma.Wm82.gnm2.ann1.Glyma.02G142000
-GSK-3	glycogen synthase kinase-3	glyma.Wm82.gnm2.ann1.Glyma.10g144600
-GSRLCK	receptor-like cytoplasmic serine/threonine protein kinase GsRLCK	glyma.Wm82.gnm2.ann1.Glyma.17g117800
-GST1	Glutathione-S Transferase 1	glyma.Wm82.gnm2.ann1.Glyma.03G150300
-GST24	glutathione S-transferase 24	glyma.Wm82.gnm2.ann1.Glyma.14g031000
-GST3	lactoylglutathione lyase gene 	glyma.Wm82.gnm2.ann1.Glyma.15g252200
-GSTF1	glutathione S-transferase F1	glyma.Wm82.gnm2.ann1.Glyma.02g154300
-GSTF13	phi class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.18g111200
-GSTF2	glutathione S-transferase F2	glyma.Wm82.gnm2.ann1.Glyma.02g154400
-GSTF5	phi class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.08g306800
-GSTF7	glutathione S-transferase GST 21	glyma.Wm82.gnm2.ann1.Glyma.10g019900
-GSTIR	TIR-NBS-LRR type disease resistance protein	glyma.Wm82.gnm2.ann1.Glyma.02g023800
-GSTL1	glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.03g176300
-GSTL2	glutathione S-transferase L2	glyma.Wm82.gnm2.ann1.Glyma.10g047700
-GSTL3	glutathione S-transferase L3	glyma.Wm82.gnm2.ann1.Glyma.13g135500
-GSTT3	glutathione S-transferase T1-like	glyma.Wm82.gnm2.ann1.Glyma.08g013700
-GSTU1	tau class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.01g040000
-GSTU13	glutathione S-transferase GST 13	glyma.Wm82.gnm2.ann1.Glyma.04g107500
+GER8	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.07g038500
+GER9	germin-like protein 9	glyma.Wm82.gnm2.ann1.Glyma.07g039100
+NSP1	nodulation-signaling pathway 1 protein	glyma.Wm82.gnm2.ann1.Glyma.07g039400
+ERF52, ERF7	ethylene-responsive transcription factor 7	glyma.Wm82.gnm2.ann1.Glyma.07g044300
+NAC164	NAC Transcription Factor gene 164	glyma.Wm82.gnm2.ann1.Glyma.07G047900
+NAC046	NAC Transcription Factor gene 46	glyma.Wm82.gnm2.ann1.Glyma.07G048000
+NAC047	NAC Transcription Factor gene 47	glyma.Wm82.gnm2.ann1.Glyma.07G048100
+LCL-4, LCL4, LHY1b	LATE ELONGATED HYPOCOTYL 1 gene b	glyma.Wm82.gnm2.ann1.Glyma.07G048500
+LEA2-33	late embryogenesis abundant 2 gene 33	glyma.Wm82.gnm2.ann1.Glyma.07G049300
+EN2	endonuclease	glyma.Wm82.gnm2.ann1.Glyma.07g050300
+NAC048, NST1A	NAC family transcription factor	glyma.Wm82.gnm2.ann1.Glyma.07g050600
+IQD23	protein IQ-DOMAIN 23	glyma.Wm82.gnm2.ann1.Glyma.07g050800
+WNK6	with no lysine kinase 6	glyma.Wm82.gnm2.ann1.Glyma.07g053500
+Lac18	Laccase 18	glyma.Wm82.gnm2.ann1.Glyma.07G054100
+Lac19	Laccase 19	glyma.Wm82.gnm2.ann1.Glyma.07G054200
+PPR59	Psudo-Response Regulator gene 59	glyma.Wm82.gnm2.ann1.Glyma.07G057000
+CENH3	Centromere specific histone 3	glyma.Wm82.gnm2.ann1.Glyma.07G057300
+WRKY55, WRKY69	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.07G057400
+MED19-3	Mediator Complex 19 gene 3	glyma.Wm82.gnm2.ann1.Glyma.07g058600
+NRAMP4A	metal transporter Nramp4a	glyma.Wm82.gnm2.ann1.Glyma.07g058900
+BAG6A	BAG family molecular chaperone regulator 6	glyma.Wm82.gnm2.ann1.Glyma.07g061500
+MYB133	MYB transcription factor MYB133	glyma.Wm82.gnm2.ann1.Glyma.07g066100
+MPK4B	mitogen-activated protein kinase MPk4b	glyma.Wm82.gnm2.ann1.Glyma.07g066800
+UBC4	ubiquitin carrier protein 4	glyma.Wm82.gnm2.ann1.Glyma.07g069300
+PRD3	Putative recombination initiation defects 3	glyma.Wm82.gnm2.ann1.Glyma.07G070400
+MED12-2	Mediator Complex 12 gene 2	glyma.Wm82.gnm2.ann1.Glyma.07g070700
+C2-57	C2 domain containing protein gene 57	glyma.Wm82.gnm2.ann1.Glyma.07G072500
+C2-58	C2 domain containing protein gene 58	glyma.Wm82.gnm2.ann1.Glyma.07G075300
+C2-59	C2 domain containing protein gene 59	glyma.Wm82.gnm2.ann1.Glyma.07G076100
+C2-60	C2 domain containing protein gene 60	glyma.Wm82.gnm2.ann1.Glyma.07G076200
+C2-61	C2 domain containing protein gene 61	glyma.Wm82.gnm2.ann1.Glyma.07G076300
+C2-62	C2 domain containing protein gene 62	glyma.Wm82.gnm2.ann1.Glyma.07G076400
+C2-63	C2 domain containing protein gene 63	glyma.Wm82.gnm2.ann1.Glyma.07G076600
+TCP8	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 8	glyma.Wm82.gnm2.ann1.Glyma.07G080300
+C2-64	C2 domain containing protein gene 64	glyma.Wm82.gnm2.ann1.Glyma.07G080400
+AGL20	Agamous-Like 20	glyma.Wm82.gnm2.ann1.Glyma.07G080900
+GA20OX2	gibberellin 20 oxidase 2	glyma.Wm82.gnm2.ann1.Glyma.07g081700
+C2-65	C2 domain containing protein gene 65	glyma.Wm82.gnm2.ann1.Glyma.07G082700
+LEA2-34	late embryogenesis abundant 2 gene 34	glyma.Wm82.gnm2.ann1.Glyma.07G084600
+NYC1_1	protein NON-YELLOW COLORING 1	glyma.Wm82.gnm2.ann1.Glyma.07g085700
+LEA2-35	late embryogenesis abundant 2 gene 35	glyma.Wm82.gnm2.ann1.Glyma.07G087000
+ALDH2C3	aldehyde dehydrogenase family 2 member C3	glyma.Wm82.gnm2.ann1.Glyma.07g087400
+ALDH2C4	aldehyde dehydrogenase family 2 member C4	glyma.Wm82.gnm2.ann1.Glyma.07g087500
+C2-66	C2 domain containing protein gene 66	glyma.Wm82.gnm2.ann1.Glyma.07G089100
+ALMT11	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.07g090300
+MAT1	maturation-associated protein 1 gene	glyma.Wm82.gnm2.ann1.Glyma.07g090400
+COL21	CONSTANS-like zinc finger protein	glyma.Wm82.gnm2.ann1.Glyma.07g091400
+LBD30	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.07g091600
+NAC049	NAC Transcription Factor gene 49	glyma.Wm82.gnm2.ann1.Glyma.07G092000
+C2-67	C2 domain containing protein gene 67	glyma.Wm82.gnm2.ann1.Glyma.07G092400
+BES1-7	protein BRI1-EMS-SUPPRESSOR 1	glyma.Wm82.gnm2.ann1.Glyma.07g099100
+LEA2-36	late embryogenesis abundant 2 gene 36	glyma.Wm82.gnm2.ann1.Glyma.07G099500
+C2-68	C2 domain containing protein gene 68	glyma.Wm82.gnm2.ann1.Glyma.07G102400
+PIN1B	auxin efflux carrier component 1b	glyma.Wm82.gnm2.ann1.Glyma.07g102500
+LEA2-37	late embryogenesis abundant 2 gene 37	glyma.Wm82.gnm2.ann1.Glyma.07G103700
+LEA2-38	late embryogenesis abundant 2 gene 38	glyma.Wm82.gnm2.ann1.Glyma.07G103800
+LEA2-39	late embryogenesis abundant 2 gene 39	glyma.Wm82.gnm2.ann1.Glyma.07G103900
+FCL1	homeobox protein knotted-1-like 1	glyma.Wm82.gnm2.ann1.Glyma.07g104800
+DHBK	putative 3,4-dihydroxy-2-butanone kinase	glyma.Wm82.gnm2.ann1.Glyma.07g107100
+ERF53	Ethylene-responsive factor gene 53	glyma.Wm82.gnm2.ann1.Glyma.07G113800
+ERF54	Ethylene-responsive factor gene 54	glyma.Wm82.gnm2.ann1.Glyma.07G114000
+ERF55	Ethylene-responsive factor gene 55	glyma.Wm82.gnm2.ann1.Glyma.07G114300
+WRKY70	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.07G116300
+NAC050	NAC Transcription Factor gene 50	glyma.Wm82.gnm2.ann1.Glyma.07G126500
+PPR60	Psudo-Response Regulator gene 60	glyma.Wm82.gnm2.ann1.Glyma.07G127400
+PPR61	Psudo-Response Regulator gene 61	glyma.Wm82.gnm2.ann1.Glyma.07G128600
+MET2	metallothionein type 2	glyma.Wm82.gnm2.ann1.Glyma.07g132000
+PHANa	phantastica transcription factor a	glyma.Wm82.gnm2.ann1.Glyma.07g132400
+EXP2	expansin	glyma.Wm82.gnm2.ann1.Glyma.07g132600
+WRKY71	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.07G133700
+Lac20	Laccase 20	glyma.Wm82.gnm2.ann1.Glyma.07G133900
+Lac21	Laccase 21	glyma.Wm82.gnm2.ann1.Glyma.07G134100
+IAA23	Indole-3-Acetic Acid Responsive Gene 23	glyma.Wm82.gnm2.ann1.Glyma.07G134900
+N479	C2H2 zinc finger protein	glyma.Wm82.gnm2.ann1.Glyma.07g135800
+HSP26-A	Probable glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.07g139700
 GSTU24	probable glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.07g139800
 GSTU27	glutathione S-transferase GST 6	glyma.Wm82.gnm2.ann1.Glyma.07g140100
 GSTU28	tau class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.07g140200
 GSTU30	glutathione S-transferase GST 8	glyma.Wm82.gnm2.ann1.Glyma.07g140400
-GSTU37	glutathione S-transferase GST 9	glyma.Wm82.gnm2.ann1.Glyma.08g174700
-GSTU38	tau class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.08g174900
-GSTU4	tau class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.01g106000
-GSTU41	glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.08g175200
-GSTU42	glutathione S-transferase GST 15	glyma.Wm82.gnm2.ann1.Glyma.10g192900
-GSTU43	tau class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.11g198500
-GSTU47	glutathione transferase	glyma.Wm82.gnm2.ann1.Glyma.15g251500
-GSTU50	tau class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.15g251800
-GSTU58	tau class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.18g190200
-GSTU60	tau class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.18g190500
-GSTU62	glutathione S-transferase GST 18	glyma.Wm82.gnm2.ann1.Glyma.20g101100
-GSTU9	glutathione S-transferase GST 19	glyma.Wm82.gnm2.ann1.Glyma.02g187200
-GSTZ1	glutathione S-transferase zeta class	glyma.Wm82.gnm2.ann1.Glyma.01g142800
-GSTZ3	glutathione S-transferase GST 25	glyma.Wm82.gnm2.ann1.Glyma.17g003300
-GSTa	2,4-D inducible glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.15g251600
-GT-2A	trihelix transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g216100
-GT-2B	trihelix transcription factor	glyma.Wm82.gnm2.ann1.Glyma.10g161200
-GT4, UGT73F2	Plant uridine 5' -diphosphate glycosyltransferase 73F2	glyma.Wm82.gnm2.ann1.Glyma.07G254600
-GTR1	glutamyl-tRNA reductase 1	glyma.Wm82.gnm2.ann1.Glyma.02g218300
-GTR2	glutamyl-tRNA reductase 2	glyma.Wm82.gnm2.ann1.Glyma.08g064700
-Gic	Gigantea gene c	glyma.Wm82.gnm2.ann1.Glyma.16G163200
-GinCrRI,k1l,18	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G053700
-GinCrRI,k1l,21	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G054300
-GinCrRI,k1l,22	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G054400
-GinCrRI,k1l,23	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G201400
-GinCrRI,k1l,26	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.17G102600
-GinCrRI,k1l,28	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G215800
-GinCrRI,k1l,36	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.19G033100
-GinCrRLk1L30	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G270100
-GinCrRl,k1l,19	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G053800
-GinCrRl,k1l,2-l	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.15G042900
-GinCrRl,k1l,32	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G270700
-GinCrRl,k1l,33	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G270900
-GinCrRl,k1l,38	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20G225800
-GnCrRLk1L27	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.17G166200
-GnCrRLk1L34	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G271000
-GnCrRLk1L35	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G271100
-GnCrRLk1L37	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20G162300
-GrnCrRLk1L17	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G053600
-Gy1	Glycinin gene 1	glyma.Wm82.gnm1.ann1.Glyma03g32030
-H-1	ferritin light chain	glyma.Wm82.gnm2.ann1.Glyma.18g205800
-H1	homeobox protein SBH1	glyma.Wm82.gnm2.ann1.Glyma.09g007500
-H4	stress-induced protein H4	glyma.Wm82.gnm2.ann1.Glyma.17g030200
-HAD1, HAD3-1	acid phosphatase	glyma.Wm82.gnm2.ann1.Glyma.10G134700
-HAK	potassium transporter 5-like	glyma.Wm82.gnm2.ann1.Glyma.03g264100
-HB2	Non-symbiotic hemoglobin 1-like gene	glyma.Wm82.gnm2.ann1.Glyma.11g121700
-HD2A	histone deacetylase HDT1	glyma.Wm82.gnm2.ann1.Glyma.12g084700
-HDA1	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.01g245100
-HDA11	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.11g000300
-HDA12	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.11g187800
-HDA13	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.12g086700
-HDA14	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.12g188200
-HDA15	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.17g078000
-HDA16	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.17g085700
-HDA17	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.17g120900
-HDA18	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.17g229600
-HDA2	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.04g000200
-HDA3	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.04g187000
-HDA4	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.04g187100
-HDA5	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.05g012900
-HDA6	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.05g021400
-HDA7	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.05g040600
-HDA9	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.06g000100
-HDL56	homeodomain-leucine zipper protein 56	glyma.Wm82.gnm2.ann1.Glyma.08g132800
-HDL57	homeodomain-leucine zipper protein 57	glyma.Wm82.gnm2.ann1.Glyma.02g022300
-HDT1	histone deacetylase HDT1-like	glyma.Wm82.gnm2.ann1.Glyma.03g190700
-HDT2	histone deacetylase HDT1-like	glyma.Wm82.gnm2.ann1.Glyma.11g189500
-HDT4	histone deacetylase HDT1-like	glyma.Wm82.gnm2.ann1.Glyma.12g181400
-HDT6	histone deacetylase HDT1-like	glyma.Wm82.gnm2.ann1.Glyma.19g191000
-HELRP	ATP-dependent RNA helicase DEAH12, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.18g014800
-HEMG	protoporphyrinogen IX oxidase	glyma.Wm82.gnm2.ann1.Glyma.19g087600
-HEN1A	protein Hua enhancer 1a	glyma.Wm82.gnm2.ann1.Glyma.08g081600
-HEN1B	protein Hua enhancer 1b	glyma.Wm82.gnm2.ann1.Glyma.05g126600
-HGO	HOMOGENTISATE 1,2-DIOXYGENASE	glyma.Wm82.gnm1.ann1.Glyma12g20220
-HGO1	homogentisate 1,2-dioxygenase	glyma.Wm82.gnm2.ann1.Glyma.12g158600
-HGO2	homogentisate 1,2-dioxygenase	glyma.Wm82.gnm2.ann1.Glyma.06g234200
-HGO3	homogentisate 1,2-dioxygenase	glyma.Wm82.gnm2.ann1.Glyma.06g233800
-HGS	homoglutathione synthetase	glyma.Wm82.gnm2.ann1.Glyma.19g237700
-HIDH	2-hydroxyisoflavanone dehydratase	glyma.Wm82.gnm2.ann1.Glyma.01g239600
-HIR1	hypersensitive-induced response protein 2-like	glyma.Wm82.gnm2.ann1.Glyma.19g020000
-HIR3	hypersensitive-induced response protein 1-like	glyma.Wm82.gnm2.ann1.Glyma.05g029800
-HIR4	hypersensitive-induced response protein 4-like	glyma.Wm82.gnm2.ann1.Glyma.16g204900
-HIUHase	hydroxyisourate hydrolase	glyma.Wm82.gnm2.ann1.Glyma.02g018700
-HK01	Ubiquitous, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma03g37760
-HK02	Root Exclusive, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma04g06190
-HK03	Root Specific, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma14g12330
-HK04	Root Specific, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma17g33670
-HK05	Root Specific, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma06g06240
-HK06	root preferential, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma06g06180
-HK07	Ubiquitous, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma01g36950
-HK08	Root preferential, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma11g08310
-HK09	Ubiquitous, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma02g05220
-HK10	root preferential, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma02g47610
-HK11	Ubiquitous, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma14g01040
-HK12	Root Specific, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma08g11060
-HK13	Root Specific, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma05g28070
-HK14	Ubiquitous, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma07g27540
-HK15	root preferential, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma02g09550
-HK16	Root Specific, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma05g34310
-HK17	root preferential, Histidine Kinase	glyma.Wm82.gnm1.ann1.Glyma08g05370
-HLH	helix-loop-helix	glyma.Wm82.gnm2.ann1.Glyma.05g200900
-HMA8	chloroplast copper-translocating HMA8 P-ATPase	glyma.Wm82.gnm2.ann1.Glyma.06g056300
-HMGB6	Transcription factor	glyma.Wm82.gnm1.ann1.Glyma20g23370
-HO1	heme oxygenase 1, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.04g147700
-HO3	heme oxygenase 3	glyma.Wm82.gnm2.ann1.Glyma.06g221900
-HP01	Root Preferential, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma15g10660
-HP02	Ubiquitous, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma13g28390
-HP03	Root Specific, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma07g38310
-HP04	Root Specific, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma10g29890
-HP05	Ubiquitous, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma20g37450
-HP06	Root Preferential, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma19g33420
-HP07	Shoot preferential, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma07g01840
-HP08	Ubiquitous, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma08g21510
-HP09	Ubiquitous, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma02g16980
-HP10	Ubiquitous, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma10g02820
-HPPD	4-hydroxyphenylpyruvate dioxygenase	glyma.Wm82.gnm2.ann1.Glyma.14g030400
-HPS	hydrophobic seed protein precursor	glyma.Wm82.gnm2.ann1.Glyma.15g119700
-HPT1	homogentisate phytylprenyltransferase	glyma.Wm82.gnm2.ann1.Glyma.17g061900
-HRBP1	harpin binding protein 1	glyma.Wm82.gnm2.ann1.Glyma.20g207100
-HS1	calcineurin-like metallophosphoesterase transmembrane protein	glyma.Wm82.gnm2.ann1.Glyma.02g269500
-HS1pro1	nematode resistance HS1pro1 protein	glyma.Wm82.gnm2.ann1.Glyma.02g255400
-HSF-01	heat stress transcription factor 1	glyma.Wm82.gnm2.ann1.Glyma.01g185800
-HSF-02	heat stress transcription factor 2	glyma.Wm82.gnm2.ann1.Glyma.01g015900
-HSF-03	heat stress transcription factor 3	glyma.Wm82.gnm2.ann1.Glyma.01g217400
-HSF-04	heat stress transcription factor 4	glyma.Wm82.gnm2.ann1.Glyma.01g233000
-HSF-05	heat stress transcription factor 5	glyma.Wm82.gnm2.ann1.Glyma.01g143500
-HSF-06	heat stress transcription factor 6	glyma.Wm82.gnm2.ann1.Glyma.03g135800
-HSF-07	heat stress transcription factor 7	glyma.Wm82.gnm2.ann1.Glyma.03g191100
-HSF-08	heat stress transcription factor 8	glyma.Wm82.gnm2.ann1.Glyma.04g052000
-HSF-09	heat stress transcription factor 9	glyma.Wm82.gnm2.ann1.Glyma.05g151800
-HSF-13	heat stress transcription factor 13	glyma.Wm82.gnm2.ann1.Glyma.08g119900
-HSF-14	heat stress transcription factor 14	glyma.Wm82.gnm2.ann1.Glyma.08g047400
-HSF-15	heat stress transcription factor 15	glyma.Wm82.gnm2.ann1.Glyma.08g108600
-HSF-16	heat stress transcription factor 16	glyma.Wm82.gnm2.ann1.Glyma.09g190600
-HSF-17	heat stress transcription factor 17	glyma.Wm82.gnm2.ann1.Glyma.09g206600
-HSF-18	heat stress transcription factor 18	glyma.Wm82.gnm2.ann1.Glyma.09g143200
-HSF-19	heat stress transcription factor 19	glyma.Wm82.gnm2.ann1.Glyma.10g237800
-HSF-20	heat stress transcription factor 20	glyma.Wm82.gnm2.ann1.Glyma.10g066100
-HSF-21	heat stress transcription factor 21	glyma.Wm82.gnm2.ann1.Glyma.10g029600
-HSF-22	heat stress transcription factor 22	glyma.Wm82.gnm2.ann1.Glyma.10g003100
-HSF-23	heat stress transcription factor 23	glyma.Wm82.gnm2.ann1.Glyma.10g244000
-HSF-24	heat stress transcription factor 24	glyma.Wm82.gnm2.ann1.Glyma.11g009800
-HSF-25	heat stress transcription factor 25	glyma.Wm82.gnm2.ann1.Glyma.11g056200
-HSF-26	heat stress transcription factor 26	glyma.Wm82.gnm2.ann1.Glyma.11g025700
-HSF-27	heat stress transcription factor 27	glyma.Wm82.gnm2.ann1.Glyma.13g180200
-HSF-28	heat stress transcription factor 28	glyma.Wm82.gnm2.ann1.Glyma.13g151200
-HSF-29	heat stress transcription factor 29	glyma.Wm82.gnm2.ann1.Glyma.13g225700
-HSF-30	heat stress transcription factor 30	glyma.Wm82.gnm2.ann1.Glyma.14g096800
-HSF-31	heat stress transcription factor 31	glyma.Wm82.gnm2.ann1.Glyma.15g086400
-HSF-32	heat stress transcription factor 32	glyma.Wm82.gnm2.ann1.Glyma.16g196200
-HSF-33	heat stress transcription factor 33	glyma.Wm82.gnm2.ann1.Glyma.16g091800
-HSF-34	heat stress transcription factor 34	glyma.Wm82.gnm2.ann1.Glyma.17g227600
-HSF-35	heat stress transcription factor 35	glyma.Wm82.gnm2.ann1.Glyma.17g174900
-HSF-36	heat stress transcription factor 36	glyma.Wm82.gnm2.ann1.Glyma.19g137800
-HSF-37	heat stress transcription factor 37	glyma.Wm82.gnm2.ann1.Glyma.20g150300
-HSF-38	heat stress transcription factor 38	glyma.Wm82.gnm2.ann1.Glyma.20g156800
-HSP15.7-CI	15.7 kDa class I-related small heat shock protein-like	glyma.Wm82.gnm1.ann1.Glyma02g41150
-HSP17.3-B	17.3 kDa class I heat shock protein	glyma.Wm82.gnm2.ann1.Glyma.08g069000
-HSP17.5-E	17.5 kDa class I heat shock protein	glyma.Wm82.gnm2.ann1.Glyma.13g176200
-HSP17.5-M	17.5 kDa class I heat shock protein	glyma.Wm82.gnm2.ann1.Glyma.07g200500
-HSP17.6-L	17.6 kDa class I heat shock protein	glyma.Wm82.gnm2.ann1.Glyma.13g176000
-HSP17.9-D	17.9 kDa class II heat shock protein	glyma.Wm82.gnm2.ann1.Glyma.17g224900
-HSP18.5-C	18.5 kDa class I heat shock protein	glyma.Wm82.gnm2.ann1.Glyma.07g200200
-HSP21	HEAT SHOCK PROTEIN 21	glyma.Wm82.gnm1.ann1.Glyma18g10760
-HSP22.0	22.0 kDa class IV heat shock protein	glyma.Wm82.gnm2.ann1.Glyma.20g213900
-HSP22.3	low molecular weight heat shock protein Hsp22.3	glyma.Wm82.gnm2.ann1.Glyma.19g011400
-HSP22.5	heat shock protein Hsp22.5	glyma.Wm82.gnm2.ann1.Glyma.16g206200
-HSP23.9	low molecular weight heat shock protein Hsp23.9	glyma.Wm82.gnm2.ann1.Glyma.12g013100
-HSP26-A	Probable glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.07g139700
-HSP40.1	DnaJ domain-containing protein HSP40.1	glyma.Wm82.gnm2.ann1.Glyma.15g057800
-HSP6834-A	class I heat shock protein	glyma.Wm82.gnm2.ann1.Glyma.08g068800
-HSP70	heat shock 70 kDa protein-like	glyma.Wm82.gnm2.ann1.Glyma.17g072400
-HSP90-1	heat shock protein 90-1	glyma.Wm82.gnm2.ann1.Glyma.18g074100
-HSP90-2	heat shock cognate protein 80-like	glyma.Wm82.gnm2.ann1.Glyma.08g332900
-HSP90A1	heat shock protein 90-A1	glyma.Wm82.gnm2.ann1.Glyma.09g131500
-HSP90A2	heat shock protein 90-A2	glyma.Wm82.gnm2.ann1.Glyma.16g178800
-HTA8	HISTONE H2A 8	glyma.Wm82.gnm1.ann1.Glyma02g16150
-Hop-1, HOP1	hsp70-Hsp90 organizing protein 1	glyma.Wm82.gnm2.ann1.Glyma.17g137700
-I2'H	isoflavone 2'-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.09g049300
-IAA10	Indole-3-Acetic Acid Responsive Gene 10	glyma.Wm82.gnm2.ann1.Glyma.03G158600
-IAA11	Indole-3-Acetic Acid Responsive Gene 11	glyma.Wm82.gnm2.ann1.Glyma.03G158700
-IAA12	Indole-3-Acetic Acid Responsive Gene 12	glyma.Wm82.gnm2.ann1.Glyma.03G167400
-IAA13	Indole-3-Acetic Acid Responsive Gene 13	glyma.Wm82.gnm2.ann1.Glyma.03G224800
-IAA14	Indole-3-Acetic Acid Responsive Gene 14	glyma.Wm82.gnm2.ann1.Glyma.03G247400
-IAA15	Indole-3-Acetic Acid Responsive Gene 15	glyma.Wm82.gnm2.ann1.Glyma.04G066300
-IAA16	Indole-3-Acetic Acid Responsive Gene 16	glyma.Wm82.gnm2.ann1.Glyma.04G089900
-IAA17	Indole-3-Acetic Acid Responsive Gene 17	glyma.Wm82.gnm2.ann1.Glyma.05G229300
-IAA18	Indole-3-Acetic Acid Responsive Gene 18	glyma.Wm82.gnm2.ann1.Glyma.06G067700
-IAA19	Indole-3-Acetic Acid Responsive Gene 19	glyma.Wm82.gnm2.ann1.Glyma.06G091700
-IAA2	Indole-3-Acetic Acid Responsive Gene 2	glyma.Wm82.gnm2.ann1.Glyma.01G039300
-IAA20	Indole-3-Acetic Acid Responsive Gene 20	glyma.Wm82.gnm2.ann1.Glyma.07G015200
-IAA21	Indole-3-Acetic Acid Responsive Gene 21	glyma.Wm82.gnm2.ann1.Glyma.07G018100
-IAA22	Indole-3-Acetic Acid Responsive Gene 22	glyma.Wm82.gnm2.ann1.Glyma.07G034200
-IAA23	Indole-3-Acetic Acid Responsive Gene 23	glyma.Wm82.gnm2.ann1.Glyma.07G134900
-IAA24	Indole-3-Acetic Acid Responsive Gene 24	glyma.Wm82.gnm2.ann1.Glyma.08G036400
-IAA25	Indole-3-Acetic Acid Responsive Gene 25	glyma.Wm82.gnm2.ann1.Glyma.08G200700
-IAA26	Indole-3-Acetic Acid Responsive Gene 26	glyma.Wm82.gnm2.ann1.Glyma.08G203100
-IAA27	Indole-3-Acetic Acid Responsive Gene 27	glyma.Wm82.gnm2.ann1.Glyma.08G207900
-IAA28	Indole-3-Acetic Acid Responsive Gene 28	glyma.Wm82.gnm2.ann1.Glyma.08G273500
-IAA29	Indole-3-Acetic Acid Responsive Gene 29	glyma.Wm82.gnm2.ann1.Glyma.09G193000
-IAA3	Indole-3-Acetic Acid Responsive Gene 3	glyma.Wm82.gnm2.ann1.Glyma.01G098000
-IAA30	Indole-3-Acetic Acid Responsive Gene 30	glyma.Wm82.gnm2.ann1.Glyma.09G203300
-IAA31	Indole-3-Acetic Acid Responsive Gene 31	glyma.Wm82.gnm2.ann1.Glyma.10G000700
-IAA32	Indole-3-Acetic Acid Responsive Gene 32	glyma.Wm82.gnm2.ann1.Glyma.10G031800
-IAA33	Indole-3-Acetic Acid Responsive Gene 33	glyma.Wm82.gnm2.ann1.Glyma.10G031900
-IAA34	Indole-3-Acetic Acid Responsive Gene 34	glyma.Wm82.gnm2.ann1.Glyma.10G040400
-IAA35	Indole-3-Acetic Acid Responsive Gene 35	glyma.Wm82.gnm2.ann1.Glyma.10G138500
-IAA36	Indole-3-Acetic Acid Responsive Gene 36	glyma.Wm82.gnm2.ann1.Glyma.10G162400
-IAA37	Indole-3-Acetic Acid Responsive Gene 37	glyma.Wm82.gnm2.ann1.Glyma.10G180000
-IAA38, SLR1	auxin-induced protein ali50	glyma.Wm82.gnm2.ann1.Glyma.10g180100
-IAA39	Indole-3-Acetic Acid Responsive Gene 39	glyma.Wm82.gnm2.ann1.Glyma.10G270500
-IAA4	Indole-3-Acetic Acid Responsive Gene 4	glyma.Wm82.gnm2.ann1.Glyma.02G000500
-IAA40	Indole-3-Acetic Acid Responsive Gene 40	glyma.Wm82.gnm2.ann1.Glyma.13G117100
-IAA41	Indole-3-Acetic Acid Responsive Gene 41	glyma.Wm82.gnm2.ann1.Glyma.13G127000
-IAA42	Indole-3-Acetic Acid Responsive Gene 42	glyma.Wm82.gnm2.ann1.Glyma.13G140500
-IAA43	Indole-3-Acetic Acid Responsive Gene 43	glyma.Wm82.gnm2.ann1.Glyma.13G159000
-IAA44	Indole-3-Acetic Acid Responsive Gene 44	glyma.Wm82.gnm2.ann1.Glyma.13G354100
-IAA45	Indole-3-Acetic Acid Responsive Gene 45	glyma.Wm82.gnm2.ann1.Glyma.13G356600
-IAA46	Indole-3-Acetic Acid Responsive Gene 46	glyma.Wm82.gnm2.ann1.Glyma.13G361100
-IAA47	Indole-3-Acetic Acid Responsive Gene 47	glyma.Wm82.gnm2.ann1.Glyma.13G361200
-IAA48	Indole-3-Acetic Acid Responsive Gene 48	glyma.Wm82.gnm2.ann1.Glyma.14G185400
-IAA49	Indole-3-Acetic Acid Responsive Gene 49	glyma.Wm82.gnm2.ann1.Glyma.15G012700
-IAA5	Indole-3-Acetic Acid Responsive Gene 5	glyma.Wm82.gnm2.ann1.Glyma.02G007300
-IAA50	Indole-3-Acetic Acid Responsive Gene 50	glyma.Wm82.gnm2.ann1.Glyma.15G012800
-IAA51	Indole-3-Acetic Acid Responsive Gene 51	glyma.Wm82.gnm2.ann1.Glyma.15G017500
-IAA52	Indole-3-Acetic Acid Responsive Gene 52	glyma.Wm82.gnm2.ann1.Glyma.15G020300
-IAA53	Indole-3-Acetic Acid Responsive Gene 53	glyma.Wm82.gnm2.ann1.Glyma.17G042800
-IAA54	Indole-3-Acetic Acid Responsive Gene 54	glyma.Wm82.gnm2.ann1.Glyma.17G112300
-IAA55	Indole-3-Acetic Acid Responsive Gene 55	glyma.Wm82.gnm2.ann1.Glyma.19G161000
-IAA57	Indole-3-Acetic Acid Responsive Gene 57	glyma.Wm82.gnm2.ann1.Glyma.19G168500
-IAA58	Indole-3-Acetic Acid Responsive Gene 58	glyma.Wm82.gnm2.ann1.Glyma.19G221900
-IAA59	Indole-3-Acetic Acid Responsive Gene 59	glyma.Wm82.gnm2.ann1.Glyma.19G245200
-IAA6	Indole-3-Acetic Acid Responsive Gene 6	glyma.Wm82.gnm2.ann1.Glyma.02G142400
-IAA60	Indole-3-Acetic Acid Responsive Gene 60	glyma.Wm82.gnm2.ann1.Glyma.20G120800
-IAA61	Indole-3-Acetic Acid Responsive Gene 61	glyma.Wm82.gnm2.ann1.Glyma.20G210400
-IAA62	Indole-3-Acetic Acid Responsive Gene 62	glyma.Wm82.gnm2.ann1.Glyma.20G210500
-IAA63	Indole-3-Acetic Acid Responsive Gene 63	glyma.Wm82.gnm2.ann1.Glyma.20G225000
-IAA7	Indole-3-Acetic Acid Responsive Gene 7	glyma.Wm82.gnm2.ann1.Glyma.02G142500
-IAA8	Indole-3-Acetic Acid Responsive Gene 8	glyma.Wm82.gnm2.ann1.Glyma.02G142600
-IAA9	Indole-3-Acetic Acid Responsive Gene 9	glyma.Wm82.gnm2.ann1.Glyma.02G218100
-ICE1	inducer of CBF expression 1	glyma.Wm82.gnm2.ann1.Glyma.04g200500
-ICE2	inducer of CBF expression 2	glyma.Wm82.gnm2.ann1.Glyma.19g102000
-ICE4	inducer of CBF expression 4	glyma.Wm82.gnm2.ann1.Glyma.06g165000
-ICEE	transcription factor ICE1-like	glyma.Wm82.gnm2.ann1.Glyma.16g147200
-ICHG	isoflavone conjugate-specific beta-glucosidase	glyma.Wm82.gnm2.ann1.Glyma.12g053800
-ICL1	isocitrate lyase 1-like	glyma.Wm82.gnm2.ann1.Glyma.06g303200
-ICS1	isochorismate synthase, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.03g070600
-IDD	Zinc finger transcription factor	glyma.Wm82.gnm2.ann1.Glyma.14G095900
-IDH	isocitrate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.14g211000
-IDH1	NADP-dependent isocitrate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.08g160500
-IF7GT	UDP-glucose:isoflavone 7-O-glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.16g175600
-IF7GT3	isoflavone 7-O-glucosyltransferase UGT3	glyma.Wm82.gnm2.ann1.Glyma.16g175200
-IF7GT5	isoflavone 7-O-glucosyltransferase UGT5	glyma.Wm82.gnm2.ann1.Glyma.16g176000
-IF7GT6	isoflavone 7-O-glucosyltransferase UGT6	glyma.Wm82.gnm2.ann1.Glyma.06g320800
-IF7MaT	malonyl-CoA:isoflavone 7-O-glucoside-6''-O-malonyltransferase	glyma.Wm82.gnm2.ann1.Glyma.13g056100
-IFR	isoflavone reductase	glyma.Wm82.gnm2.ann1.Glyma.11g070500
-IFR1	isoflavone reductase homolog 1	glyma.Wm82.gnm2.ann1.Glyma.11g070300
-IFR2	isoflavone reductase homolog 2	glyma.Wm82.gnm2.ann1.Glyma.04g012300
-IFS1	isoflavone synthase 1	glyma.Wm82.gnm2.ann1.Glyma.07g202300
-IFS2	2-hydroxyisoflavanone synthase	glyma.Wm82.gnm2.ann1.Glyma.13g173500
-ILPA1	anaphase-promoting complex subunit 8-like protein	glyma.Wm82.gnm2.ann1.Glyma.11g026400
-IMAT1	isoflavone malonyltransferase IMaT1	glyma.Wm82.gnm2.ann1.Glyma.18g268200
-IMPDH1	inosine monophosphate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.15g263100
-IMT1	myo-inositol-O-methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.06g137100
-INFA	translation initiation factor IF1	glyma.Wm82.gnm2.ann1.Glyma.17g080200
-INR2	inducible nitrate reductase 2	glyma.Wm82.gnm2.ann1.Glyma.06g109200
-INV	alkaline/neutral invertase	glyma.Wm82.gnm2.ann1.Glyma.01G211000
-IOMT1	isoflavone 4'-O-methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.13g173300
-IOMT2	isoflavone 4'-O-methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.13g173600
-IPK1	inositol pentakisphosphate 2-kinase	glyma.Wm82.gnm2.ann1.Glyma.14g072200
-IPK2	inositol polyphosphate 6-/3-/5-kinase	glyma.Wm82.gnm2.ann1.Glyma.12g240900
-IPT	isopentenyl transferase	glyma.Wm82.gnm2.ann1.Glyma.15g103800
-IQD1	protein IQ-DOMAIN 1	glyma.Wm82.gnm2.ann1.Glyma.01g007000
-IQD10	protein IQ-DOMAIN 10	glyma.Wm82.gnm2.ann1.Glyma.04g052200
-IQD11	protein IQ-DOMAIN 11	glyma.Wm82.gnm2.ann1.Glyma.04g154200
-IQD12	protein IQ-DOMAIN 12	glyma.Wm82.gnm2.ann1.Glyma.04g173100
-IQD13	protein IQ-DOMAIN 13	glyma.Wm82.gnm2.ann1.Glyma.04g235400
-IQD14	protein IQ-DOMAIN 14	glyma.Wm82.gnm2.ann1.Glyma.05g028600
-IQD15	protein IQ-DOMAIN 15	glyma.Wm82.gnm2.ann1.Glyma.05g049000
-IQD17	protein IQ-DOMAIN 17	glyma.Wm82.gnm2.ann1.Glyma.06g025800
-IQD18	protein IQ-DOMAIN 18	glyma.Wm82.gnm2.ann1.Glyma.06g052800
-IQD19	protein IQ-DOMAIN 19	glyma.Wm82.gnm2.ann1.Glyma.06g129300
-IQD2	protein IQ-DOMAIN 2	glyma.Wm82.gnm2.ann1.Glyma.01g043800
-IQD20	protein IQ-DOMAIN 20	glyma.Wm82.gnm2.ann1.Glyma.06g191200
-IQD21	protein IQ-DOMAIN 21	glyma.Wm82.gnm2.ann1.Glyma.07g008400
-IQD22	protein IQ-DOMAIN 22	glyma.Wm82.gnm2.ann1.Glyma.07g014800
-IQD23	protein IQ-DOMAIN 23	glyma.Wm82.gnm2.ann1.Glyma.07g050800
-IQD25	protein IQ-DOMAIN 25	glyma.Wm82.gnm2.ann1.Glyma.07g204000
-IQD26	protein IQ-DOMAIN 26	glyma.Wm82.gnm2.ann1.Glyma.07g207300
-IQD27	protein IQ-DOMAIN 27	glyma.Wm82.gnm2.ann1.Glyma.08g033100
-IQD28	protein IQ-DOMAIN 28	glyma.Wm82.gnm2.ann1.Glyma.08g191400
-IQD29	protein IQ-DOMAIN 29	glyma.Wm82.gnm2.ann1.Glyma.08g200400
-IQD3	protein IQ-DOMAIN 3	glyma.Wm82.gnm2.ann1.Glyma.01g217200
-IQD30	protein IQ-DOMAIN 30	glyma.Wm82.gnm2.ann1.Glyma.08g297500
-IQD31	protein IQ-DOMAIN 31	glyma.Wm82.gnm2.ann1.Glyma.09g143900
-IQD32	protein IQ-DOMAIN 32	glyma.Wm82.gnm2.ann1.Glyma.09g177200
-IQD33	protein IQ-DOMAIN 33	glyma.Wm82.gnm2.ann1.Glyma.09g225300
-IQD34	protein IQ-DOMAIN 34	glyma.Wm82.gnm2.ann1.Glyma.10g003700
-IQD35	protein IQ-DOMAIN 35	glyma.Wm82.gnm2.ann1.Glyma.10g050000
-IQD36	protein IQ-DOMAIN 36	glyma.Wm82.gnm2.ann1.Glyma.10g213100
-IQD37	protein IQ-DOMAIN 37	glyma.Wm82.gnm2.ann1.Glyma.10g238300
-IQD38	protein IQ-DOMAIN 38	glyma.Wm82.gnm2.ann1.Glyma.10g245000
-IQD39	protein IQ-DOMAIN 39	glyma.Wm82.gnm2.ann1.Glyma.11g149200
-IQD4	protein IQ-DOMAIN 4	glyma.Wm82.gnm2.ann1.Glyma.02g004600
-IQD40	protein IQ-DOMAIN 40	glyma.Wm82.gnm2.ann1.Glyma.12g011600
-IQD42	protein IQ-DOMAIN 42	glyma.Wm82.gnm2.ann1.Glyma.12g228200
-IQD43	protein IQ-DOMAIN 43	glyma.Wm82.gnm2.ann1.Glyma.13g137500
-IQD44	protein IQ-DOMAIN 44	glyma.Wm82.gnm2.ann1.Glyma.13g172000
-IQD45	protein IQ-DOMAIN 45	glyma.Wm82.gnm2.ann1.Glyma.13g232700
-IQD46	protein IQ-DOMAIN 46	glyma.Wm82.gnm2.ann1.Glyma.13g271800
-IQD47	protein IQ-DOMAIN 47	glyma.Wm82.gnm2.ann1.Glyma.13g311700
-IQD48	protein IQ-DOMAIN 48	glyma.Wm82.gnm2.ann1.Glyma.13g348400
-IQD49	protein IQ-DOMAIN 49	glyma.Wm82.gnm2.ann1.Glyma.13g353800
-IQD5	protein IQ-DOMAIN 5	glyma.Wm82.gnm2.ann1.Glyma.02g019700
-IQD50	protein IQ-DOMAIN 50	glyma.Wm82.gnm2.ann1.Glyma.14g097000
-IQD51	protein IQ-DOMAIN 51	glyma.Wm82.gnm2.ann1.Glyma.14g159300
-IQD52	protein IQ-DOMAIN 52	glyma.Wm82.gnm2.ann1.Glyma.15g020600
-IQD53	protein IQ-DOMAIN 53	glyma.Wm82.gnm2.ann1.Glyma.15g025400
-IQD54	protein IQ-DOMAIN 54	glyma.Wm82.gnm2.ann1.Glyma.15g080000
-IQD55	protein IQ-DOMAIN 55	glyma.Wm82.gnm2.ann1.Glyma.16g019700
-IQD56	protein IQ-DOMAIN 56	glyma.Wm82.gnm2.ann1.Glyma.16g121000
-IQD57	protein IQ-DOMAIN 57	glyma.Wm82.gnm2.ann1.Glyma.16g196900
-IQD58	protein IQ-DOMAIN 58	glyma.Wm82.gnm2.ann1.Glyma.17g098200
-IQD59	protein IQ-DOMAIN 59	glyma.Wm82.gnm2.ann1.Glyma.17g130900
-IQD6	protein IQ-DOMAIN 6	glyma.Wm82.gnm2.ann1.Glyma.02g138000
-IQD60	protein IQ-DOMAIN 60	glyma.Wm82.gnm2.ann1.Glyma.17g185200
-IQD61	protein IQ-DOMAIN 61	glyma.Wm82.gnm2.ann1.Glyma.17g227400
-IQD62	protein IQ-DOMAIN 62	glyma.Wm82.gnm2.ann1.Glyma.18g124200
-IQD63	protein IQ-DOMAIN 63	glyma.Wm82.gnm2.ann1.Glyma.19g179000
-IQD64	protein IQ-DOMAIN 64	glyma.Wm82.gnm2.ann1.Glyma.19g243700
-IQD65	protein IQ-DOMAIN 65	glyma.Wm82.gnm2.ann1.Glyma.20g149600
-IQD66	protein IQ-DOMAIN 66	glyma.Wm82.gnm2.ann1.Glyma.20g156200
-IQD67	protein IQ-DOMAIN 67	glyma.Wm82.gnm2.ann1.Glyma.20g177900
-IQD7	protein IQ-DOMAIN 7	glyma.Wm82.gnm2.ann1.Glyma.03g178200
-IQD8	protein IQ-DOMAIN 8	glyma.Wm82.gnm2.ann1.Glyma.03g246200
-IQD9	protein IQ-DOMAIN 9	glyma.Wm82.gnm2.ann1.Glyma.04g026000
-IRT	probable zinc transporter 10-like	glyma.Wm82.gnm2.ann1.Glyma.07g2232001
-ITPK1	inositol phosphate kinase	glyma.Wm82.gnm2.ann1.Glyma.16g092200
-ITPK2	inositol phosphate kinase	glyma.Wm82.gnm2.ann1.Glyma.17g089000
-ITPK3	inositol phosphate kinase	glyma.Wm82.gnm2.ann1.Glyma.06g089800
-ITPK4	inositol phosphate kinase	glyma.Wm82.gnm2.ann1.Glyma.10g255000
-J1	DnaJ-like protein	glyma.Wm82.gnm2.ann1.Glyma.08g109700
-JAG1	JAGGED gene 1	glyma.Wm82.gnm2.ann1.Glyma.20g116200
-JAG2	JAGGED gene 2	glyma.Wm82.gnm2.ann1.Glyma.10g273800
-JOX1	jasnonate-induced oxygenase 1	glyma.Wm82.gnm2.ann1.Glyma.09G107100
-JOX2	jasnonate-induced oxygenase 2	glyma.Wm82.gnm2.ann1.Glyma.18G026500
-JOX3	jasnonate-induced oxygenase 3	glyma.Wm82.gnm2.ann1.Glyma.18G201900
-KAPP1	kinase-associated protein phosphatase 1	glyma.Wm82.gnm2.ann1.Glyma.11g004000
-KAPP2	kinase-associated protein phosphatase 2	glyma.Wm82.gnm2.ann1.Glyma.01g239700
-KAR	3-oxoacyl-[acyl-carrier-protein] reductase	glyma.Wm82.gnm1.ann1.Glyma08G10760
-KASI	Beta-ketoacyl-ACP carrier protein synthase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.08G084300
-KASII-A	beta-ketoacyl-ACP synthetase 2 gene 1	glyma.Wm82.gnm2.ann1.Glyma.17g047000
-KASII-B, KASIIb	3-ketoacyl-ACP synthase II	glyma.Wm82.gnm1.ann1.Glyma13g17290
-KASIII-1	beta-ketoacyl-ACP synthetase 3 gene 1	glyma.Wm82.gnm2.ann1.Glyma.09g277400
-KASIII-2	beta-ketoacyl-ACP synthetase 3 gene 2	glyma.Wm82.gnm2.ann1.Glyma.15g003100
-KASIIa	3-ketoacyl-ACP synthase II	glyma.Wm82.gnm1.ann1.Glyma17g05200
-KEU	protein transporter  	glyma.Wm82.gnm1.ann1.Glyma11g03230
-KR1	resistance protein KR1	glyma.Wm82.gnm2.ann1.Glyma.19g054900
-KR3	disease resistance protein KR3	glyma.Wm82.gnm2.ann1.Glyma.06g267300
-KTI-1, KTI-S, KTi2	Kunitz trypsin inhibitor gene 2	glyma.Wm82.gnm2.ann1.Glyma.08g341400
-KTI-2	kunitz trypsin protease inhibitor	glyma.Wm82.gnm2.ann1.Glyma.09g155500
-KTI-3	kunitz family trypsin and protease inhibitor protein	glyma.Wm82.gnm2.ann1.Glyma.16g211700
-L-4, LOX4, LoxB, LOXB1	lipoxygenase	glyma.Wm82.gnm2.ann1.Glyma.13g347700
-L-5, LOX8, VLXB	lipoxygenase L-5	glyma.Wm82.gnm2.ann1.Glyma.15g026500
-LAR1	leucoanthocyanidin reductase	glyma.Wm82.gnm2.ann1.Glyma.20g185700
-LAX1	auxin transporter-like protein 1	glyma.Wm82.gnm2.ann1.Glyma.01g114000
-LAX10	auxin transporter-like protein 10	glyma.Wm82.gnm2.ann1.Glyma.11g106000
-LAX11	auxin transporter-like protein 11	glyma.Wm82.gnm2.ann1.Glyma.11g228300
-LAX12	auxin transporter-like protein 12	glyma.Wm82.gnm2.ann1.Glyma.12g030900
-LAX13	auxin transporter-like protein 13	glyma.Wm82.gnm2.ann1.Glyma.14g060700
-LAX14	auxin transporter-like protein 14	glyma.Wm82.gnm2.ann1.Glyma.18g029000
-LAX15	auxin transporter-like protein 15	glyma.Wm82.gnm2.ann1.Glyma.18g198400
-LAX2	auxin transporter-like protein 2	glyma.Wm82.gnm2.ann1.Glyma.02g255800
-LAX3	auxin transporter-like protein 3	glyma.Wm82.gnm2.ann1.Glyma.03g063600
-LAX4	auxin transporter-like protein 4	glyma.Wm82.gnm2.ann1.Glyma.03g063900
-LAX5	auxin transporter-like protein 5	glyma.Wm82.gnm2.ann1.Glyma.04g004800
-LAX6	auxin transporter-like protein 6	glyma.Wm82.gnm2.ann1.Glyma.04g252300
-LAX7	auxin transporter-like protein 7	glyma.Wm82.gnm2.ann1.Glyma.06g004500
-LAX8	auxin transporter-like protein 8	glyma.Wm82.gnm2.ann1.Glyma.06g110200
-LAX9	auxin transporter-like protein 9	glyma.Wm82.gnm2.ann1.Glyma.07g147000
-LB	leghemoglobin	glyma.Wm82.gnm2.ann1.Glyma.10g198900
-LBA	Leghemoglobin A	glyma.Wm82.gnm2.ann1.Glyma.10g199100
-LBC1	leghemoglobin C1	glyma.Wm82.gnm2.ann1.Glyma.10g199000
-LBD1	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.01g131000
-LBD10	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g264500
-LBD12	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.03g023000
-LBD13	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.03g023100
-LBD14	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.03g161400
-LBD15	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.03g161500
-LBD16	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g044800
-LBD17	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g106400
-LBD18	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g186900
-LBD19	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.04g220500
-LBD20	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.05g004400
-LBD21	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.05g040500
-LBD22	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.05g081400
-LBD23	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.05g103300
-LBD25	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.06g106500
-LBD26	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.06g145400
-LBD27	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.06g178900
-LBD28	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.06g285100
-LBD29	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.07g009500
-LBD3	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.01g143900
-LBD30	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.07g091600
-LBD31	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.07g223600
-LBD32	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g169000
-LBD33	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g192600
-LBD34	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g235200
-LBD35	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g261900
-LBD36	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g334200
-LBD37	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g365100
-LBD4	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.01g183900
-LBD5	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.01g192600
-LBD6	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g166400
-LBD7.2	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g234600
-LBD8	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g249700
-LBD9	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.02g262400
-LCL-1, LCL1, LHY1a	LATE ELONGATED HYPOCOTYL 1 gene a	glyma.Wm82.gnm2.ann1.Glyma.16G017400
-LCL-2, LHY2b, MYB114	MYB transcription factor MYB114	glyma.Wm82.gnm2.ann1.Glyma.03g261800
-LCL-3, LCL3, LHY2a	LATE ELONGATED HYPOCOTYL 2 gene a	glyma.Wm82.gnm2.ann1.Glyma.19G260900
-LCL-4, LCL4, LHY1b	LATE ELONGATED HYPOCOTYL 1 gene b	glyma.Wm82.gnm2.ann1.Glyma.07G048500
-LDL1-1	LSD1-like1 gene 1	glyma.Wm82.gnm1.ann1.Glyma07g09980
-LDL1-2	LSD1-like1 gene 2	glyma.Wm82.gnm1.ann1.Glyma09g31770
-LDL2-1	LSD2-like2 gene 1	glyma.Wm82.gnm1.ann1.Glyma06g38600
-LE1, Le1-1	Lectin 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02g012600
-LEA-1, LEA2-79	late embryogenesis abundant 2 gene 79	glyma.Wm82.gnm2.ann1.Glyma.14G037300
-LEA-2, LEA2-101	late embryogenesis abundant 2 gene 101	glyma.Wm82.gnm2.ann1.Glyma.20G044800
-LEA2-1	late embryogenesis abundant 2 gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G152600
-LEA2-10	late embryogenesis abundant 2 gene 10	glyma.Wm82.gnm2.ann1.Glyma.02G303100
-LEA2-100	late embryogenesis abundant 2 gene 100	glyma.Wm82.gnm2.ann1.Glyma.19G260500
-LEA2-102	late embryogenesis abundant 2 gene 102	glyma.Wm82.gnm2.ann1.Glyma.20G140900
-LEA2-103	late embryogenesis abundant 2 gene 103	glyma.Wm82.gnm2.ann1.Glyma.20G216300
-LEA2-11	late embryogenesis abundant 2 gene 11	glyma.Wm82.gnm2.ann1.Glyma.03G000800
-LEA2-12	late embryogenesis abundant 2 gene 12	glyma.Wm82.gnm2.ann1.Glyma.03G201000
-LEA2-13	late embryogenesis abundant 2 gene 13	glyma.Wm82.gnm2.ann1.Glyma.03G201100
-LEA2-14	late embryogenesis abundant 2 gene 14	glyma.Wm82.gnm2.ann1.Glyma.03G201200
-LEA2-16	late embryogenesis abundant 2 gene 16	glyma.Wm82.gnm2.ann1.Glyma.03G201500
-LEA2-17	late embryogenesis abundant 2 gene 17	glyma.Wm82.gnm2.ann1.Glyma.03G201600
-LEA2-18	late embryogenesis abundant 2 gene 18	glyma.Wm82.gnm2.ann1.Glyma.03G261400
-LEA2-19	late embryogenesis abundant 2 gene 19	glyma.Wm82.gnm2.ann1.Glyma.03G263800
-LEA2-2	late embryogenesis abundant 2 gene 2	glyma.Wm82.gnm2.ann1.Glyma.01G222800
-LEA2-20	late embryogenesis abundant 2 gene 20	glyma.Wm82.gnm2.ann1.Glyma.04G051600
-LEA2-21	late embryogenesis abundant 2 gene 21	glyma.Wm82.gnm2.ann1.Glyma.04G103700
-LEA2-22	late embryogenesis abundant 2 gene 22	glyma.Wm82.gnm2.ann1.Glyma.04G228200
-LEA2-23	late embryogenesis abundant 2 gene 23	glyma.Wm82.gnm2.ann1.Glyma.05G094300
-LEA2-24	late embryogenesis abundant 2 gene 24	glyma.Wm82.gnm2.ann1.Glyma.05G179200
-LEA2-25	late embryogenesis abundant 2 gene 25	glyma.Wm82.gnm2.ann1.Glyma.05G212600
-LEA2-26	late embryogenesis abundant 2 gene 26	glyma.Wm82.gnm2.ann1.Glyma.05G217500
-LEA2-27	late embryogenesis abundant 2 gene 27	glyma.Wm82.gnm2.ann1.Glyma.05G242600
-LEA2-28	late embryogenesis abundant 2 gene 28	glyma.Wm82.gnm2.ann1.Glyma.06G052400
-LEA2-29	late embryogenesis abundant 2 gene 29	glyma.Wm82.gnm2.ann1.Glyma.06G104900
-LEA2-3	late embryogenesis abundant 2 gene 3	glyma.Wm82.gnm2.ann1.Glyma.01G226100
-LEA2-30	late embryogenesis abundant 2 gene 30	glyma.Wm82.gnm2.ann1.Glyma.06G136700
-LEA2-31	late embryogenesis abundant 2 gene 31	glyma.Wm82.gnm2.ann1.Glyma.06G303300
-LEA2-32	late embryogenesis abundant 2 gene 32	glyma.Wm82.gnm2.ann1.Glyma.07G009700
-LEA2-33	late embryogenesis abundant 2 gene 33	glyma.Wm82.gnm2.ann1.Glyma.07G049300
-LEA2-34	late embryogenesis abundant 2 gene 34	glyma.Wm82.gnm2.ann1.Glyma.07G084600
-LEA2-35	late embryogenesis abundant 2 gene 35	glyma.Wm82.gnm2.ann1.Glyma.07G087000
-LEA2-36	late embryogenesis abundant 2 gene 36	glyma.Wm82.gnm2.ann1.Glyma.07G099500
-LEA2-37	late embryogenesis abundant 2 gene 37	glyma.Wm82.gnm2.ann1.Glyma.07G103700
-LEA2-38	late embryogenesis abundant 2 gene 38	glyma.Wm82.gnm2.ann1.Glyma.07G103800
-LEA2-39	late embryogenesis abundant 2 gene 39	glyma.Wm82.gnm2.ann1.Glyma.07G103900
-LEA2-4	late embryogenesis abundant 2 gene 4	glyma.Wm82.gnm2.ann1.Glyma.01G240600
-LEA2-40	late embryogenesis abundant 2 gene 40	glyma.Wm82.gnm2.ann1.Glyma.08G019000
-LEA2-41	late embryogenesis abundant 2 gene 41	glyma.Wm82.gnm2.ann1.Glyma.08G023500
-LEA2-42	late embryogenesis abundant 2 gene 42	glyma.Wm82.gnm2.ann1.Glyma.08G077900
-LEA2-43	late embryogenesis abundant 2 gene 43	glyma.Wm82.gnm2.ann1.Glyma.08G136900
-LEA2-44	late embryogenesis abundant 2 gene 44	glyma.Wm82.gnm2.ann1.Glyma.08G184000
-LEA2-45	late embryogenesis abundant 2 gene 45	glyma.Wm82.gnm2.ann1.Glyma.09G071900
-LEA2-46	late embryogenesis abundant 2 gene 46	glyma.Wm82.gnm2.ann1.Glyma.09G179400
-LEA2-47	late embryogenesis abundant 2 gene 47	glyma.Wm82.gnm2.ann1.Glyma.09G189900
-LEA2-48	late embryogenesis abundant 2 gene 48	glyma.Wm82.gnm2.ann1.Glyma.09G192300
-LEA2-49	late embryogenesis abundant 2 gene 49	glyma.Wm82.gnm2.ann1.Glyma.09G217800
-LEA2-5	late embryogenesis abundant 2 gene 5	glyma.Wm82.gnm2.ann1.Glyma.02G197600
-LEA2-50	late embryogenesis abundant 2 gene 50	glyma.Wm82.gnm2.ann1.Glyma.10G079400
-LEA2-51	late embryogenesis abundant 2 gene 51	glyma.Wm82.gnm2.ann1.Glyma.10G079900
-LEA2-52	late embryogenesis abundant 2 gene 52	glyma.Wm82.gnm2.ann1.Glyma.10G080000
-LEA2-53	late embryogenesis abundant 2 gene 53	glyma.Wm82.gnm2.ann1.Glyma.10G174100
-LEA2-54	late embryogenesis abundant 2 gene 54	glyma.Wm82.gnm2.ann1.Glyma.10G252500
-LEA2-55	late embryogenesis abundant 2 gene 55	glyma.Wm82.gnm2.ann1.Glyma.11G003000
-LEA2-56	late embryogenesis abundant 2 gene 56	glyma.Wm82.gnm2.ann1.Glyma.11G020500
-LEA2-57	late embryogenesis abundant 2 gene 57	glyma.Wm82.gnm2.ann1.Glyma.11G020600
-LEA2-58	late embryogenesis abundant 2 gene 58	glyma.Wm82.gnm2.ann1.Glyma.11G097100
-LEA2-59	late embryogenesis abundant 2 gene 59	glyma.Wm82.gnm2.ann1.Glyma.11G179900
-LEA2-6	late embryogenesis abundant 2 gene 6	glyma.Wm82.gnm2.ann1.Glyma.02G197800
-LEA2-60	late embryogenesis abundant 2 gene 60	glyma.Wm82.gnm2.ann1.Glyma.11G182400
-LEA2-61	late embryogenesis abundant 2 gene 61	glyma.Wm82.gnm2.ann1.Glyma.11G199600
-LEA2-62	late embryogenesis abundant 2 gene 62	glyma.Wm82.gnm2.ann1.Glyma.11G203000
-LEA2-63	late embryogenesis abundant 2 gene 63	glyma.Wm82.gnm2.ann1.Glyma.12G023200
-LEA2-64	late embryogenesis abundant 2 gene 64	glyma.Wm82.gnm2.ann1.Glyma.12G093600
-LEA2-65	late embryogenesis abundant 2 gene 65	glyma.Wm82.gnm2.ann1.Glyma.12G187600
-LEA2-66	late embryogenesis abundant 2 gene 66	glyma.Wm82.gnm2.ann1.Glyma.12G194700
-LEA2-67	late embryogenesis abundant 2 gene 67	glyma.Wm82.gnm2.ann1.Glyma.12G202900
-LEA2-68	late embryogenesis abundant 2 gene 68	glyma.Wm82.gnm2.ann1.Glyma.13G000500
-LEA2-69	late embryogenesis abundant 2 gene 69	glyma.Wm82.gnm2.ann1.Glyma.13G248600
-LEA2-7	late embryogenesis abundant 2 gene 7	glyma.Wm82.gnm2.ann1.Glyma.02G239100
-LEA2-70	late embryogenesis abundant 2 gene 70	glyma.Wm82.gnm2.ann1.Glyma.13G298800
-LEA2-71	late embryogenesis abundant 2 gene 71	glyma.Wm82.gnm2.ann1.Glyma.13G307700
-LEA2-72	late embryogenesis abundant 2 gene 72	glyma.Wm82.gnm2.ann1.Glyma.13G307900
-LEA2-73	late embryogenesis abundant 2 gene 73	glyma.Wm82.gnm2.ann1.Glyma.13G313600
-LEA2-74	late embryogenesis abundant 2 gene 74	glyma.Wm82.gnm2.ann1.Glyma.13G313700
-LEA2-75	late embryogenesis abundant 2 gene 75	glyma.Wm82.gnm2.ann1.Glyma.13G349900
-LEA2-76	late embryogenesis abundant 2 gene 76	glyma.Wm82.gnm2.ann1.Glyma.13G357600
-LEA2-77	late embryogenesis abundant 2 gene 77	glyma.Wm82.gnm2.ann1.Glyma.13G359200
-LEA2-78	late embryogenesis abundant 2 gene 78	glyma.Wm82.gnm2.ann1.Glyma.14G010800
-LEA2-8	late embryogenesis abundant 2 gene 8	glyma.Wm82.gnm2.ann1.Glyma.02G274400
-LEA2-80	late embryogenesis abundant 2 gene 80	glyma.Wm82.gnm2.ann1.Glyma.14G041700
-LEA2-81	late embryogenesis abundant 2 gene 81	glyma.Wm82.gnm2.ann1.Glyma.14G160000
-LEA2-82	late embryogenesis abundant 2 gene 82	glyma.Wm82.gnm2.ann1.Glyma.14G208000
-LEA2-83	late embryogenesis abundant 2 gene 83	glyma.Wm82.gnm2.ann1.Glyma.15G015800
-LEA2-84	late embryogenesis abundant 2 gene 84	glyma.Wm82.gnm2.ann1.Glyma.15G024400
-LEA2-85	late embryogenesis abundant 2 gene 85	glyma.Wm82.gnm2.ann1.Glyma.15G048800
-LEA2-86	late embryogenesis abundant 2 gene 86	glyma.Wm82.gnm2.ann1.Glyma.15G065400
-LEA2-87	late embryogenesis abundant 2 gene 87	glyma.Wm82.gnm2.ann1.Glyma.16G031000
-LEA2-88, PM22	Maturation protein 22 gene	glyma.Wm82.gnm2.ann1.Glyma.16g031300
-LEA2-89	late embryogenesis abundant 2 gene 89	glyma.Wm82.gnm2.ann1.Glyma.16G221900
-LEA2-9	late embryogenesis abundant 2 gene 9	glyma.Wm82.gnm2.ann1.Glyma.02G277300
-LEA2-90	late embryogenesis abundant 2 gene 90	glyma.Wm82.gnm2.ann1.Glyma.17G172900
-LEA2-91	late embryogenesis abundant 2 gene 91	glyma.Wm82.gnm2.ann1.Glyma.18G047800
-LEA2-92	late embryogenesis abundant 2 gene 92	glyma.Wm82.gnm2.ann1.Glyma.18G073200
-LEA2-93	late embryogenesis abundant 2 gene 93	glyma.Wm82.gnm2.ann1.Glyma.18G218700
-LEA2-94	late embryogenesis abundant 2 gene 94	glyma.Wm82.gnm2.ann1.Glyma.18G218800
-LEA2-95	late embryogenesis abundant 2 gene 95	glyma.Wm82.gnm2.ann1.Glyma.18G238700
-LEA2-97	late embryogenesis abundant 2 gene 97	glyma.Wm82.gnm2.ann1.Glyma.19G19870
-LEA2-98	late embryogenesis abundant 2 gene 98	glyma.Wm82.gnm2.ann1.Glyma.19G198800
-LEA2-99	late embryogenesis abundant 2 gene 99	glyma.Wm82.gnm2.ann1.Glyma.19G198900
-LEA5	desiccation protective protein LEA5	glyma.Wm82.gnm2.ann1.Glyma.17g027400
-LEC1-A	transcription factor LEC1-A	glyma.Wm82.gnm2.ann1.Glyma.07g268100
-LEC1-B	nuclear transcription factor Y subunit B-6-like	glyma.Wm82.gnm2.ann1.Glyma.17g005600
-LEC2a	B3 domain transcription factor	glyma.Wm82.gnm2.ann1.Glyma.20G035800
-LEC2b	B3 domain transcription factor	glyma.Wm82.gnm2.ann1.Glyma.20G035700
-LEM3	ligand-effect modulator 3	glyma.Wm82.gnm1.ann1.Glyma08g17460
-LHCB1-7	photosystem II type I chlorophyll a/b-binding protein	glyma.Wm82.gnm2.ann1.Glyma.16g165800
-LHP1, LHP1-1	chromo domain-containing protein LHP1-1	glyma.Wm82.gnm2.ann1.Glyma.16g079900
-LHP1-2	chromo domain-containing protein LHP1-2	glyma.Wm82.gnm2.ann1.Glyma.03g094200
-LOG	Lonely Guy	glyma.Wm82.gnm2.ann1.Glyma.12G174900
-LOX	seed linoleate 9S-lipoxygenase-3	glyma.Wm82.gnm2.ann1.Glyma.08g189200
-LOX1.4, SC514	lipoxygenase	glyma.Wm82.gnm2.ann1.Glyma.07g007000
-LOX10	lipoxygenase-10 gene	glyma.Wm82.gnm2.ann1.Glyma.08g189600
-LOX9	Lipoxygenase 9 gene	glyma.Wm82.gnm2.ann1.Glyma.07g034800
-LPAAT	lysophosphatidic acid acyltransferase	glyma.Wm82.gnm2.ann1.Glyma.15g034100
-LPAT	Lysophosphatidyl acyltransferase	glyma.Wm82.gnm1.ann1.Glyma11G12830
-LRK1	leucine-rich repeat receptor-like kinase 1	glyma.Wm82.gnm2.ann1.Glyma.03g189800
-LRPK	serine/threonine-protein kinase LRPK	glyma.Wm82.gnm2.ann1.Glyma.16g015400
-LRR	Leucine-rich repeat receptor-like kinase	glyma.Wm82.gnm2.ann1.Glyma.06G265400
-LSD1	Lys-Specific Demethylase 1	glyma.Wm82.gnm1.ann1.Glyma02g18610
-LUXA	transcription factor LUXa	glyma.Wm82.gnm2.ann1.Glyma.01g162600
-LUXB	transcription factor LUXb	glyma.Wm82.gnm2.ann1.Glyma.12g060200
-LUXC	transcription factor LUXc	glyma.Wm82.gnm2.ann1.Glyma.11g136600
-LYK10	protein LYK2	glyma.Wm82.gnm2.ann1.Glyma.19g088300
-LYK4	lysM domain receptor-like kinase 4	glyma.Wm82.gnm2.ann1.Glyma.01g179000
-Lac1	Laccase 1	glyma.Wm82.gnm2.ann1.Glyma.01G108200
-Lac10	Laccase 10	glyma.Wm82.gnm2.ann1.Glyma.04G019500
-Lac11	Laccase 11	glyma.Wm82.gnm2.ann1.Glyma.04G119600
-Lac12	Laccase 12	glyma.Wm82.gnm2.ann1.Glyma.05G056100
-Lac13	Laccase 13	glyma.Wm82.gnm2.ann1.Glyma.05G082700
-Lac14	Laccase 14	glyma.Wm82.gnm2.ann1.Glyma.06G019800
-Lac15	Laccase 15	glyma.Wm82.gnm2.ann1.Glyma.06G284300
-Lac16	Laccase 16	glyma.Wm82.gnm2.ann1.Glyma.06G307100
-Lac17	Laccase 17	glyma.Wm82.gnm2.ann1.Glyma.06G318800
-Lac18	Laccase 18	glyma.Wm82.gnm2.ann1.Glyma.07G054100
-Lac19	Laccase 19	glyma.Wm82.gnm2.ann1.Glyma.07G054200
-Lac2	Laccase 2	glyma.Wm82.gnm2.ann1.Glyma.01G112600
-Lac20	Laccase 20	glyma.Wm82.gnm2.ann1.Glyma.07G133900
-Lac21	Laccase 21	glyma.Wm82.gnm2.ann1.Glyma.07G134100
 Lac22	Laccase 22	glyma.Wm82.gnm2.ann1.Glyma.07G142400
 Lac23	Laccase 23	glyma.Wm82.gnm2.ann1.Glyma.07G142500
 Lac24	Laccase 24	glyma.Wm82.gnm2.ann1.Glyma.07G142600
+FBP	fructose-1,6-bisphosphatase	glyma.Wm82.gnm2.ann1.Glyma.07g142700
+LAX9	auxin transporter-like protein 9	glyma.Wm82.gnm2.ann1.Glyma.07g147000
+FAD7-1	chloroplast omega 3 fatty acid desaturase isoform 2	glyma.Wm82.gnm2.ann1.Glyma.07g151300
+AMT2.1	ammonium transporter AMT2.1	glyma.Wm82.gnm2.ann1.Glyma.07g153800
+CYP49	peptidyl-prolyl cis-trans isomerase CYP49	glyma.Wm82.gnm2.ann1.Glyma.07g157800
+PPR62	Psudo-Response Regulator gene 62	glyma.Wm82.gnm2.ann1.Glyma.07G159200
+WRKY72	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.07G161100
+CYP74A1	allene oxide synthase, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.07g162900
+PIN3C	auxin efflux carrier component 3c	glyma.Wm82.gnm2.ann1.Glyma.07g164600
+MED37-5	Mediator Complex 37 gene 5	glyma.Wm82.gnm2.ann1.Glyma.07g170800
+SCB1	Seed coat BURP domian protein 1	glyma.Wm82.gnm2.ann1.Glyma.07g176700
+TCP9	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 9	glyma.Wm82.gnm2.ann1.Glyma.07G177200
+C2-69	C2 domain containing protein gene 69	glyma.Wm82.gnm2.ann1.Glyma.07G177900
+UF3GT1-3, UGT78K1	UDP-glucose:flavonoid 3-O-glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.07g183200
+UF3GT1-1	anthocyanidin 3-O-glucosyltransferase 7 gene 1	glyma.Wm82.gnm2.ann1.Glyma.07g183300
+UF3GT1-2	anthocyanidin 3-O-glucosyltransferase 7 gene 2	glyma.Wm82.gnm2.ann1.Glyma.07g183400
+ALDH6B1	putative methylmalonate-semialdehyde dehydrogenase [acylating], mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.07g183600
+FWL6	protein FW2.2-like 6	glyma.Wm82.gnm2.ann1.Glyma.07g185200
+TPS4	terpene synthase 4	glyma.Wm82.gnm2.ann1.Glyma.07g187600
+TPS5	terpene synthase 5	glyma.Wm82.gnm2.ann1.Glyma.07g187700
+STP1	monosaccharide transporter	glyma.Wm82.gnm2.ann1.Glyma.07g189500
+NAC165	NAC domain-containing protein 165	glyma.Wm82.gnm2.ann1.Glyma.07g192900
+PPR63	Psudo-Response Regulator gene 63	glyma.Wm82.gnm2.ann1.Glyma.07G196400
+HSP18.5-C	18.5 kDa class I heat shock protein	glyma.Wm82.gnm2.ann1.Glyma.07g200200
+HSP17.5-M	17.5 kDa class I heat shock protein	glyma.Wm82.gnm2.ann1.Glyma.07g200500
+NAC051	NAC Transcription Factor gene 51	glyma.Wm82.gnm2.ann1.Glyma.07G201800
+IFS1	isoflavone synthase 1	glyma.Wm82.gnm2.ann1.Glyma.07g202300
+IQD25	protein IQ-DOMAIN 25	glyma.Wm82.gnm2.ann1.Glyma.07g204000
+bHLH7	bHLH protein	glyma.Wm82.gnm2.ann1.Glyma.07G205800
+OAS-TL4	OAS-TL4 cysteine synthase	glyma.Wm82.gnm2.ann1.Glyma.07g206800
+ACPD-2, SAD2	stearoyl-ACP desaturase 2	glyma.Wm82.gnm2.ann1.Glyma.07g207200
+IQD26	protein IQ-DOMAIN 26	glyma.Wm82.gnm2.ann1.Glyma.07g207300
+C2-70	C2 domain containing protein gene 70	glyma.Wm82.gnm2.ann1.Glyma.07G207700
+SAN1B	senescence-associated nodulin 1B	glyma.Wm82.gnm2.ann1.Glyma.07g208900
+SAN1A	senescence-associated nodulin 1A	glyma.Wm82.gnm2.ann1.Glyma.07g209100
+CYP16	peptidyl-prolyl cis-trans isomerase CYP16	glyma.Wm82.gnm2.ann1.Glyma.07g210200
+PPR64	Psudo-Response Regulator gene 64	glyma.Wm82.gnm2.ann1.Glyma.07G211900
+ERF56	Ethylene-responsive factor gene 56	glyma.Wm82.gnm2.ann1.Glyma.07G212400
+MYB159	R2R3 MYB transcription factor MYB100	glyma.Wm82.gnm2.ann1.Glyma.07g216000
+PPR65	Psudo-Response Regulator gene 65	glyma.Wm82.gnm2.ann1.Glyma.07G216300
+PIN3A	auxin efflux carrier component 3a	glyma.Wm82.gnm2.ann1.Glyma.07g217900
+C2-71	C2 domain containing protein gene 71	glyma.Wm82.gnm2.ann1.Glyma.07G219900
+PHT1-9	inorganic phosphate transporter 1-9	glyma.Wm82.gnm2.ann1.Glyma.07g222700
+IRT	probable zinc transporter 10-like	glyma.Wm82.gnm2.ann1.Glyma.07g2232001
+LBD31	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.07g223600
 Lac25	Laccase 25	glyma.Wm82.gnm2.ann1.Glyma.07G225300
 Lac26	Laccase 26	glyma.Wm82.gnm2.ann1.Glyma.07G225400
+GF14k, SGF14Q	putative 14-3-3 protein SGF14q	glyma.Wm82.gnm2.ann1.Glyma.07g226000
+WRKY73	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.07G227200
+PHO1-H2	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.07g228400
+NAC51	transcription factor NAC51	glyma.Wm82.gnm2.ann1.Glyma.07g229100
+PHR11	MYB-CC domain-containing transcription factor PHR11	glyma.Wm82.gnm2.ann1.Glyma.07g229800
+C2-72	C2 domain containing protein gene 72	glyma.Wm82.gnm2.ann1.Glyma.07G230700
+PTI1A	Pti1 kinase-like protein	glyma.Wm82.gnm2.ann1.Glyma.07g234300
+WRKY74	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.07G238000
+ALDH22A1	aldehyde dehydrogenase 22A1	glyma.Wm82.gnm2.ann1.Glyma.07g240300
+CAMTA13	Calmodulin binding transcription activator 13	glyma.Wm82.gnm2.ann1.Glyma.07G242000
+COBL10	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.07G243200
+PR-10	stress-induced protein SAM22	glyma.Wm82.gnm2.ann1.Glyma.07g243700
+PPR66	Psudo-Response Regulator gene 66	glyma.Wm82.gnm2.ann1.Glyma.07G245500
+C2-73	C2 domain containing protein gene 73	glyma.Wm82.gnm2.ann1.Glyma.07G248600
+PPR67	Psudo-Response Regulator gene 67	glyma.Wm82.gnm2.ann1.Glyma.07G249400
+ERF57	Ethylene-responsive factor gene 57	glyma.Wm82.gnm2.ann1.Glyma.07G250100
+DXS1	1-deoxy-D-xylulose 5-phosphate synthase 1	glyma.Wm82.gnm2.ann1.Glyma.07g252600
+GT4, UGT73F2	Plant uridine 5' -diphosphate glycosyltransferase 73F2	glyma.Wm82.gnm2.ann1.Glyma.07G254600
+SG-1-LIKE	putative UDP-glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.07g254900
+MAPK16-4	mitogen-activated protein kinase 16	glyma.Wm82.gnm2.ann1.Glyma.07g255400
+PRX2B	peroxidase	glyma.Wm82.gnm2.ann1.Glyma.07g260300
+GLYI-7	Glyoxylase 1 gene 7	glyma.Wm82.gnm2.ann1.Glyma.07g261400
 Lac27	Laccase 27	glyma.Wm82.gnm2.ann1.Glyma.07G261800
+WRKY34	WRKY transcription factor 34	glyma.Wm82.gnm2.ann1.Glyma.07g262700
+STM	Short Transmembrane Mitochondrial Protein	glyma.Wm82.gnm2.ann1.Glyma.07G263600
+Raf19-1	Raf19 proto-oncogene serine/threonine protein kinase gene 1	glyma.Wm82.gnm2.ann1.Glyma.07G264700
+LEC1-A	transcription factor LEC1-A	glyma.Wm82.gnm2.ann1.Glyma.07g268100
+C2-74	C2 domain containing protein gene 74	glyma.Wm82.gnm2.ann1.Glyma.07G268400
+SSH1	polyphosphoinositide binding protein Ssh1p	glyma.Wm82.gnm2.ann1.Glyma.07g268700
+C2-75	C2 domain containing protein gene 75	glyma.Wm82.gnm2.ann1.Glyma.07G269000
+NAC053	NAC Transcription Factor gene 53	glyma.Wm82.gnm2.ann1.Glyma.07G271100
+EF1BGAMMA1	elongation factor 1-gamma-like	glyma.Wm82.gnm2.ann1.Glyma.07g273500
+PAD4	uncharacterized LOC100788725	glyma.Wm82.gnm2.ann1.Glyma.08g002100
+ALDH3I1	aldehyde dehydrogenase family 3 member I1	glyma.Wm82.gnm2.ann1.Glyma.08g002700
+Cdk8-4	Cyclin-dependent kinase 8 gene 4	glyma.Wm82.gnm2.ann1.Glyma.08g002900
+SPK-3	protein kinase 3	glyma.Wm82.gnm2.ann1.Glyma.08g005100
+CDPK	Calcium-dependent protein kinase SK5	glyma.Wm82.gnm2.ann1.Glyma.08g005600
+C2-76	C2 domain containing protein gene 76	glyma.Wm82.gnm2.ann1.Glyma.08G007500
+NAC054	NAC Transcription Factor gene 54	glyma.Wm82.gnm2.ann1.Glyma.08G009700
+SWEET20	sugar efflux transporter SWEET20	glyma.Wm82.gnm2.ann1.Glyma.08g009900
+SWEET21	sugar efflux transporter SWEET21	glyma.Wm82.gnm2.ann1.Glyma.08g010000
+WRKY25, WRKY76	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.08G011300
+C2-77	C2 domain containing protein gene 77	glyma.Wm82.gnm2.ann1.Glyma.08G011900
+GSTT3	glutathione S-transferase T1-like	glyma.Wm82.gnm2.ann1.Glyma.08g013700
+GPX	Glutathione Peroxidase	glyma.Wm82.gnm2.ann1.Glyma.08G013800
+TUBB1, Tubulin	tubulin	glyma.Wm82.gnm2.ann1.Glyma.08G014200
+PIP1-6	aquaporin PIP1-6	glyma.Wm82.gnm2.ann1.Glyma.08g015300
+MDHAR-6	Monodehydroascorbate reductase 6, cytosolic	glyma.Wm82.gnm2.ann1.Glyma.08g017800
+WRKY77	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.08G018300
+TOPP7	TOPP-type protein phosphatase gene 7	glyma.Wm82.gnm2.ann1.Glyma.08G018500
+LEA2-40	late embryogenesis abundant 2 gene 40	glyma.Wm82.gnm2.ann1.Glyma.08G019000
+ERF58	Ethylene-responsive factor gene 58	glyma.Wm82.gnm2.ann1.Glyma.08G020900
+WRKY46, WRKY78	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.08G021900
+CEL8	endo-1,4-beta-glucanase	glyma.Wm82.gnm2.ann1.Glyma.08g022300
+LEA2-41	late embryogenesis abundant 2 gene 41	glyma.Wm82.gnm2.ann1.Glyma.08G023500
+BMY1-3	Beta-amylase 1 gene 3	glyma.Wm82.gnm2.ann1.Glyma.08g025500
+MED37-6	Mediator Complex 37 gene 6	glyma.Wm82.gnm2.ann1.Glyma.08g025700
+BIP2, MED37-7	Mediator Complex 37 gene 7	glyma.Wm82.gnm2.ann1.Glyma.08g025900
+ACCC-3	biotin carboxylase precursor	glyma.Wm82.gnm2.ann1.Glyma.08g027600
+MYB127	MYB transcription factor MYB127	glyma.Wm82.gnm2.ann1.Glyma.08g029400
+NAC055	NAC Transcription Factor gene 55	glyma.Wm82.gnm2.ann1.Glyma.08G031900
+IQD27	protein IQ-DOMAIN 27	glyma.Wm82.gnm2.ann1.Glyma.08g033100
+MST1	monosaccharide transporter	glyma.Wm82.gnm2.ann1.Glyma.08g035300
+GLYI-8	Glyoxylase 1 gene 8	glyma.Wm82.gnm2.ann1.Glyma.08g035400
+IAA24	Indole-3-Acetic Acid Responsive Gene 24	glyma.Wm82.gnm2.ann1.Glyma.08G036400
+YUC2A	indole-3-pyruvate monooxygenase YUCCA2	glyma.Wm82.gnm2.ann1.Glyma.08g038600
+ALDH2C5	aldehyde dehydrogenase family 2 member C5	glyma.Wm82.gnm2.ann1.Glyma.08g039200
+ALDH2C6	aldehyde dehydrogenase family 2 member C6	glyma.Wm82.gnm2.ann1.Glyma.08g039300
+ALMT12	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.08g040700
+ERF59	Ethylene-responsive factor gene 59	glyma.Wm82.gnm2.ann1.Glyma.08G040900
+NAC056	NAC Transcription Factor gene 56	glyma.Wm82.gnm2.ann1.Glyma.08G041500
+C2-78	C2 domain containing protein gene 78	glyma.Wm82.gnm2.ann1.Glyma.08G041800
+MYB184	MYB transcription factor MYB184	glyma.Wm82.gnm2.ann1.Glyma.08g042100
+FWL3	protein FW2.2-like 3	glyma.Wm82.gnm2.ann1.Glyma.08g043500
+PGM2, PGMb	beta-phosphoglucomutase-like	glyma.Wm82.gnm2.ann1.Glyma.08g044100
+ADO3, FKF2	Flavin-binding Kelch Repeat F-Box 2 gene	glyma.Wm82.gnm2.ann1.Glyma.08g046500
+HSF-14	heat stress transcription factor 14	glyma.Wm82.gnm2.ann1.Glyma.08g047400
+CCT-D	cytosolic chaperonin	glyma.Wm82.gnm2.ann1.Glyma.08g050100
+STV2B	sialyltransferase-like	glyma.Wm82.gnm2.ann1.Glyma.08g051300
+AT-1SNBP	HMG I/Y like protein	glyma.Wm82.gnm2.ann1.Glyma.08g052600
+C2-79	C2 domain containing protein gene 79	glyma.Wm82.gnm2.ann1.Glyma.08G054500
+PIN1A	auxin efflux carrier component 1a	glyma.Wm82.gnm2.ann1.Glyma.08g054700
+TPS6	terpene synthase 6	glyma.Wm82.gnm2.ann1.Glyma.08g061600
+GTR2	glutamyl-tRNA reductase 2	glyma.Wm82.gnm2.ann1.Glyma.08g064700
+ALDH6B2	putative methylmalonate-semialdehyde dehydrogenase [acylating], mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.08g0666001
+UGT78K2, UGT78K2-1	UDP-glucose:flavonoid 3-O-glucosyltransferase gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g066800
+HSP6834-A	class I heat shock protein	glyma.Wm82.gnm2.ann1.Glyma.08g068800
+HSP17.3-B	17.3 kDa class I heat shock protein	glyma.Wm82.gnm2.ann1.Glyma.08g069000
+CAMTA4	Calmodulin binding transcription activator 4	glyma.Wm82.gnm2.ann1.Glyma.08G072100
+AOX3	alternative oxidase 3, mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.08g072200
+AOX2	alternative oxidase 2a	glyma.Wm82.gnm2.ann1.Glyma.08g072300
+NAC057	NAC Transcription Factor gene 57	glyma.Wm82.gnm2.ann1.Glyma.08G075300
+VTL1b	vacuole iron transporter like	glyma.Wm82.gnm2.ann1.Glyma.08G076300
+BZIP10, bZIP60	Basic leucine zipper transcription factor-like protein gene 60	glyma.Wm82.gnm2.ann1.Glyma.08G077400
+LEA2-42	late embryogenesis abundant 2 gene 42	glyma.Wm82.gnm2.ann1.Glyma.08G077900
+WRKY79	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.08G078100
+WRKY80	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.08G078700
+PGIP3	polygalacturonase inhibitor 3 gene	glyma.Wm82.gnm2.ann1.Glyma.08g079100
+PGIP4	polygalacturonase inhibitor 4 gene	glyma.Wm82.gnm2.ann1.Glyma.08g079200
+PPR68	Psudo-Response Regulator gene 68	glyma.Wm82.gnm2.ann1.Glyma.08G080300
+HEN1A	protein Hua enhancer 1a	glyma.Wm82.gnm2.ann1.Glyma.08g081600
+WRKY81	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.08G082400
+FLS2a	flavanol synthase	glyma.Wm82.gnm2.ann1.Glyma.08g083300
+KASI	Beta-ketoacyl-ACP carrier protein synthase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.08G084300
+EU3	Ni-binding urease accessory protein UreG	glyma.Wm82.gnm2.ann1.Glyma.08g084800
+RNA polymerase II	DNA-directed RNA polymerase II subunit RPB7	glyma.Wm82.gnm2.ann1.Glyma.08g085100
+PPR69	Psudo-Response Regulator gene 69	glyma.Wm82.gnm2.ann1.Glyma.08G086500
+SOS1	Na+/H+ antiporter	glyma.Wm82.gnm2.ann1.Glyma.08g092000
+BRL2B	brassinosteroid receptor-like protein	glyma.Wm82.gnm2.ann1.Glyma.08g092200
+PPR70	Psudo-Response Regulator gene 70	glyma.Wm82.gnm2.ann1.Glyma.08G092900
+PAP	purple acid phosphatase	glyma.Wm82.gnm2.ann1.Glyma.08g093500
+NCED2	9-cis-epoxycarotenoid dioxygenase 2	glyma.Wm82.gnm2.ann1.Glyma.08g096200
+TCP33	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 33	glyma.Wm82.gnm2.ann1.Glyma.08G097900
+CDF1	cation diffusion facilitator 1	glyma.Wm82.gnm2.ann1.Glyma.08g102000
+FabG	3-ketoacyl-ACP reductase	glyma.Wm82.gnm2.ann1.Glyma.08g102100
+Cdk8-5	Cyclin-dependent kinase 8 gene 6	glyma.Wm82.gnm2.ann1.Glyma.08g102600
+EU5	urease SBU-III	glyma.Wm82.gnm2.ann1.Glyma.08g103000
+NTF2B-1	nucleus transporter2B gene 1	glyma.Wm82.gnm2.ann1.Glyma.08G105100
+CAMTA15	Calmodulin binding transcription activator 15	glyma.Wm82.gnm2.ann1.Glyma.08G105200
+AGL3L	agamous-like MADS-box protein AGL3-like	glyma.Wm82.gnm2.ann1.Glyma.08g105400
+BRU1	xyloglucan endotransglucosylase/hydrolase 1	glyma.Wm82.gnm2.ann1.Glyma.08g107300
+RHG4	receptor-like kinase RHG4	glyma.Wm82.gnm2.ann1.Glyma.08g107700
+AK-HSDH	aspartokinase-homoserine dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.08g107800
+SBP56	56kDa selenium binding protein 56	glyma.Wm82.gnm2.ann1.Glyma.08G108000
+HSF-15	heat stress transcription factor 15	glyma.Wm82.gnm2.ann1.Glyma.08g108600
+SHMT, SHMT08	serine hyrdroxmethyltransferase	glyma.Wm82.gnm2.ann1.Glyma.08g108900
+SUB1	SUB1 homolog (S. cerevisiae)	glyma.Wm82.gnm2.ann1.Glyma.08g109000
+chs5	chalcone synthase 5	glyma.Wm82.gnm2.ann1.Glyma.08g109200
+CHS3, SOYCHS	chalcone synthase	glyma.Wm82.gnm2.ann1.Glyma.08g109300
+CHS1	chalcone synthase 1	glyma.Wm82.gnm2.ann1.Glyma.08g109400
+CHS9	chalcone synthase 9	glyma.Wm82.gnm2.ann1.Glyma.08g109500
+J1	DnaJ-like protein	glyma.Wm82.gnm2.ann1.Glyma.08g109700
+CHS3C	chalcone synthase 3	glyma.Wm82.gnm2.ann1.Glyma.08g110300
+CHS4B	chalcone synthase 4b	glyma.Wm82.gnm2.ann1.Glyma.08g110500
+CHS4, CHS4A	chalcone synthase 4a	glyma.Wm82.gnm2.ann1.Glyma.08g110700
+CHS3B	chalcone synthase 3	glyma.Wm82.gnm2.ann1.Glyma.08g110900
+ARPC4	ARP2/3 complex 20 kDa subunit  4	glyma.Wm82.gnm2.ann1.Glyma.08G111500
+Bic-C1, RHA	RNA helicase A	glyma.Wm82.gnm2.ann1.Glyma.08G113000
+PPR71	Psudo-Response Regulator gene 71	glyma.Wm82.gnm2.ann1.Glyma.08G113100
+COP10	constitutive photomorphogenesis protein 10	glyma.Wm82.gnm2.ann1.Glyma.08g113700
+bZIP61	Basic leucine zipper transcription factor-like protein gene 61	glyma.Wm82.gnm2.ann1.Glyma.08G115300
+GF14l, SGF14L	14-3-3 protein SGF14l	glyma.Wm82.gnm2.ann1.Glyma.08g115800
+P34	P34 probable thiol protease	glyma.Wm82.gnm2.ann1.Glyma.08g116300
+PPR72	Psudo-Response Regulator gene 72	glyma.Wm82.gnm2.ann1.Glyma.08G117400
+WRKY48, WRKY82	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.08G118200
+HSF-13	heat stress transcription factor 13	glyma.Wm82.gnm2.ann1.Glyma.08g119900
+N-26	nodulin-26	glyma.Wm82.gnm2.ann1.Glyma.08g120100
+NIP1-2	aquaporin NIP1-2	glyma.Wm82.gnm2.ann1.Glyma.08g120200
+PPR73	Psudo-Response Regulator gene 73	glyma.Wm82.gnm2.ann1.Glyma.08G123700
+C2-80	C2 domain containing protein gene 80	glyma.Wm82.gnm2.ann1.Glyma.08G124000
+NF-YA	nuclear factor Y subunit A	glyma.Wm82.gnm2.ann1.Glyma.08g124200
+bZIP62, ZIP	homeobox-leucine zipper	glyma.Wm82.gnm2.ann1.Glyma.08g124400
+BZIP63	bZIP transcription factor 63	glyma.Wm82.gnm2.ann1.Glyma.08g126500
+C2-81	C2 domain containing protein gene 81	glyma.Wm82.gnm2.ann1.Glyma.08G126700
+SEOE	sieve element occlusion e	glyma.Wm82.gnm2.ann1.Glyma.08g130500
+HDL56	homeodomain-leucine zipper protein 56	glyma.Wm82.gnm2.ann1.Glyma.08g132800
+CAMTA2	Calmodulin binding transcription activator 2	glyma.Wm82.gnm2.ann1.Glyma.08G135200
+LEA2-43	late embryogenesis abundant 2 gene 43	glyma.Wm82.gnm2.ann1.Glyma.08G136900
+DREB2	ethylene-responsive transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g137600
+MIPS4	inositol-3-phosphate synthase	glyma.Wm82.gnm2.ann1.Glyma.08g138200
 Lac28	Laccase 28	glyma.Wm82.gnm2.ann1.Glyma.08G138900
+BZIP24, bZIP64	Basic leucine zipper transcription factor-like protein gene 64	glyma.Wm82.gnm2.ann1.Glyma.08G140100
+WRKY6, WRKY83	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.08G142400
+WRKY84	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.08G143400
+MED28-2	Mediator Complex 28 gene 2	glyma.Wm82.gnm2.ann1.Glyma.08g143600
+ERF60	Ethylene-responsive factor gene 60	glyma.Wm82.gnm2.ann1.Glyma.08G145300
+MED26-4	Mediator Complex 26 gene 4	glyma.Wm82.gnm2.ann1.Glyma.08g146000
+SAc3	Actin 3 gene	glyma.Wm82.gnm2.ann1.Glyma.08g146500
+NF-YC05	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.08g148200
+C2-82	C2 domain containing protein gene 82	glyma.Wm82.gnm2.ann1.Glyma.08G152000
+PPR74	Psudo-Response Regulator gene 74	glyma.Wm82.gnm2.ann1.Glyma.08G152900
+AN1	zinc finger A20 and AN1 domain-containing stress-associated protein 5-like	glyma.Wm82.gnm2.ann1.Glyma.08g153200
+NAC058	NAC Transcription Factor gene 58	glyma.Wm82.gnm2.ann1.Glyma.08G156500
+MED22-1	Mediator Complex 22 gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g160100
+PPR75	Psudo-Response Regulator gene 75	glyma.Wm82.gnm2.ann1.Glyma.08G160200
+IDH1	NADP-dependent isocitrate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.08g160500
+PM41	seed maturation protein PM41	glyma.Wm82.gnm2.ann1.Glyma.08g160800
+NAC059	NAC Transcription Factor gene 59	glyma.Wm82.gnm2.ann1.Glyma.08G161300
+NAC166	NAC domain-containing protein 166	glyma.Wm82.gnm2.ann1.Glyma.08g163100
+PHR12	MYB-CC domain-containing transcription factor PHR12	glyma.Wm82.gnm2.ann1.Glyma.08g163500
+ALDH5F1	putative succinate-semialdehyde dehydrogenase, mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.08g163700
+DW1	ent-kaurene synthase	glyma.Wm82.gnm2.ann1.Glyma.08g163900
+NF-YC06	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.08g165700
+LBD32	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g169000
+NAC060	NAC Transcription Factor gene 60	glyma.Wm82.gnm2.ann1.Glyma.08G169400
+PPR76	Psudo-Response Regulator gene 76	glyma.Wm82.gnm2.ann1.Glyma.08G172500
+PM28	seed maturation protein PM28	glyma.Wm82.gnm2.ann1.Glyma.08g172800
+NAC061, NAC34	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.08g173400
+GSTU37	glutathione S-transferase GST 9	glyma.Wm82.gnm2.ann1.Glyma.08g174700
+GSTU38	tau class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.08g174900
+GSTU41	glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.08g175200
+CAMTA6	Calmodulin binding transcription activator 6	glyma.Wm82.gnm2.ann1.Glyma.08G178900
+SGT3, UGT91H	Plant uridine 5' -diphosphate glycosyltransferase 91H	glyma.Wm82.gnm2.ann1.Glyma.08G181000
+SWEET24	sugar efflux transporter SWEET24	glyma.Wm82.gnm2.ann1.Glyma.08g183500
+bZIP65	Basic leucine zipper transcription factor-like protein gene 65	glyma.Wm82.gnm2.ann1.Glyma.08G183600
+LEA2-44	late embryogenesis abundant 2 gene 44	glyma.Wm82.gnm2.ann1.Glyma.08G184000
+AKT2	Potassium channel AKT2 gene	glyma.Wm82.gnm2.ann1.Glyma.08g187600
+LOX	seed linoleate 9S-lipoxygenase-3	glyma.Wm82.gnm2.ann1.Glyma.08g189200
+LOX10	lipoxygenase-10 gene	glyma.Wm82.gnm2.ann1.Glyma.08g189600
+MYB107	MYB transcription factor MYB107	glyma.Wm82.gnm2.ann1.Glyma.08g189900
+IQD28	protein IQ-DOMAIN 28	glyma.Wm82.gnm2.ann1.Glyma.08g191400
+MED9-2	Mediator Complex 9 gene 2	glyma.Wm82.gnm2.ann1.Glyma.08g192500
+LBD33	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g192600
+C2-83	C2 domain containing protein gene 83	glyma.Wm82.gnm2.ann1.Glyma.08G194100
+ACP1	acid phosphatase 1	glyma.Wm82.gnm2.ann1.Glyma.08g195100
+G6PDH3	Glucose-6-phosphate dehydrogenase gene 3	glyma.Wm82.gnm2.ann1.Glyma.08G199000
+MED6-1	Mediator Complex 6 gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g199200
+VSP27, VSPB	Vegetative storage protein B	glyma.Wm82.gnm2.ann1.Glyma.08g200100
+IQD29	protein IQ-DOMAIN 29	glyma.Wm82.gnm2.ann1.Glyma.08g200400
+IAA25	Indole-3-Acetic Acid Responsive Gene 25	glyma.Wm82.gnm2.ann1.Glyma.08G200700
+TIP2-4	aquaporin TIP2-4	glyma.Wm82.gnm2.ann1.Glyma.08g203000
+IAA26	Indole-3-Acetic Acid Responsive Gene 26	glyma.Wm82.gnm2.ann1.Glyma.08G203100
+Aux22, IAA27	Indole-3-Acetic Acid Responsive Gene 27	glyma.Wm82.gnm2.ann1.Glyma.08G207900
+PPR77	Psudo-Response Regulator gene 77	glyma.Wm82.gnm2.ann1.Glyma.08G208900
+GLYI-9	Glyoxylase 1 gene 9	glyma.Wm82.gnm2.ann1.Glyma.08g211100
+ERF61	Ethylene-responsive factor gene 61	glyma.Wm82.gnm2.ann1.Glyma.08G211600
+C2-84	C2 domain containing protein gene 84	glyma.Wm82.gnm2.ann1.Glyma.08G211700
+FAD5.2	delta-7 desaturase	glyma.Wm82.gnm2.ann1.Glyma.08g212900
+MED7-2	Mediator Complex 7 gene 2	glyma.Wm82.gnm2.ann1.Glyma.08g213500
+PPR78	Psudo-Response Regulator gene 78	glyma.Wm82.gnm2.ann1.Glyma.08G213800
+MED15-1	Mediator Complex 15 gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g214900
+ERF62	Ethylene-responsive factor gene 62	glyma.Wm82.gnm2.ann1.Glyma.08G216600
+NIP6-2	aquaporin NIP6-2	glyma.Wm82.gnm2.ann1.Glyma.08g217400
+NRAMP5B	metal transporter Nramp5b	glyma.Wm82.gnm2.ann1.Glyma.08g218200
+WRKY56, WRKY85	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.08G218600
+PLMT	phospholipid N-methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.08g218900
+MAN1	mannosyl-oligosaccharide 1,2-alpha-mannosidase	glyma.Wm82.gnm2.ann1.Glyma.08g221900
+GER7	germin-like protein 7	glyma.Wm82.gnm2.ann1.Glyma.08g226800
+bZIP66	Basic leucine zipper transcription factor-like protein gene 66	glyma.Wm82.gnm2.ann1.Glyma.08G227000
+WRI1A	ethylene-responsive transcription factor WRI1a	glyma.Wm82.gnm2.ann1.Glyma.08g227700
+PR08-Bet VI	pathogenesis-related protein	glyma.Wm82.gnm2.ann1.Glyma.08G230500
+LBD34	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g235200
+CYP72A67	cytochrome P450 72A15	glyma.Wm82.gnm2.ann1.Glyma.08g238100
+C2-85	C2 domain containing protein gene 85	glyma.Wm82.gnm2.ann1.Glyma.08G239300
+SNRK1.1	sucrose non-fermenting-1 related protein kinase	glyma.Wm82.gnm2.ann1.Glyma.08g240300
+WRKY4, WRKY86	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.08G240800
+UGD1	UDP-glucose dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.08g243000
+SOMT-2	flavonoid 4'-O-methyltransferase SOMT-2	glyma.Wm82.gnm2.ann1.Glyma.08g2467002
+TCP34	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 34	glyma.Wm82.gnm2.ann1.Glyma.08G247300
+CrRLk1L05	CrRLK1-Like Kinase 1 gene 5	glyma.Wm82.gnm2.ann1.Glyma.08G248900
+CrRLk1L06	CrRLK1-Like Kinase 1 gene 6	glyma.Wm82.gnm2.ann1.Glyma.08G249200
+CrRLk1L07	CrRLK1-Like Kinase 1 gene 7	glyma.Wm82.gnm2.ann1.Glyma.08G249400
+COBL11	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.08G249700
+COBL12	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.08G249800
+AP1c	Apetella 1 gene c	glyma.Wm82.gnm2.ann1.Glyma.08g250800
+PPR79	Psudo-Response Regulator gene 79	glyma.Wm82.gnm2.ann1.Glyma.08G252400
+PPR80	Psudo-Response Regulator gene 80	glyma.Wm82.gnm2.ann1.Glyma.08G254300
+bZIP67, BZIP73B	BZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g254400
+COL1a	Constance-like 1 gene a	glyma.Wm82.gnm2.ann1.Glyma.08G255200
+FTL9	flowering locus T-like protein 9	glyma.Wm82.gnm2.ann1.Glyma.08g256000
+TCP49	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 49	glyma.Wm82.gnm2.ann1.Glyma.08G256400
+AOC5	allene oxide cyclase 4, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.08g256600
+ERF63	Ethylene-responsive factor gene 63	glyma.Wm82.gnm2.ann1.Glyma.08G257300
+ALMT13	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.08g260200
+ERF64	Ethylene-responsive factor gene 64	glyma.Wm82.gnm2.ann1.Glyma.08G261500
+LBD35	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g261900
+bZIP68	Basic leucine zipper transcription factor-like protein gene 68	glyma.Wm82.gnm2.ann1.Glyma.08G265600
+IAA28	Indole-3-Acetic Acid Responsive Gene 28	glyma.Wm82.gnm2.ann1.Glyma.08G273500
+ERF65	Ethylene-responsive factor gene 65	glyma.Wm82.gnm2.ann1.Glyma.08G278800
+ERF66, LF1	putative AP2 domain-containing protein Lf1	glyma.Wm82.gnm2.ann1.Glyma.08g281900
+PAO1	peroxisomal copper-containing amine oxidase	glyma.Wm82.gnm2.ann1.Glyma.08g282800
+CRK11	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.08g284100
+MED4-2	Mediator Complex 4 gene 2	glyma.Wm82.gnm2.ann1.Glyma.08g287300
+ALDH2B5	aldehyde dehydrogenase family 2 member B5, mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.08g288000
+PPR81	Psudo-Response Regulator gene 81	glyma.Wm82.gnm2.ann1.Glyma.08G291700
+PPR82	Psudo-Response Regulator gene 82	glyma.Wm82.gnm2.ann1.Glyma.08G291800
+GASA12	gibberellin-regulated protein 12	glyma.Wm82.gnm2.ann1.Glyma.08g291900
+MYB149	MYB transcription factor MYB149	glyma.Wm82.gnm2.ann1.Glyma.08g293300
+PPR83	Psudo-Response Regulator gene 83	glyma.Wm82.gnm2.ann1.Glyma.08G294900
+PPR84	Psudo-Response Regulator gene 84	glyma.Wm82.gnm2.ann1.Glyma.08G295900
+MED10-1	Mediator Complex 10 gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g296500
+Amy3	Alpha-amylase 3 gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g296800
+IQD30	protein IQ-DOMAIN 30	glyma.Wm82.gnm2.ann1.Glyma.08g297500
+TCP10	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 10	glyma.Wm82.gnm2.ann1.Glyma.08G299400
+SLD1.3, SLD2-2	delta(8)-fatty-acid desaturase 2 gene 2	glyma.Wm82.gnm2.ann1.Glyma.08g299900
+NAC063	NAC Transcription Factor gene 63	glyma.Wm82.gnm2.ann1.Glyma.08G301100
+PPR85	Psudo-Response Regulator gene 85	glyma.Wm82.gnm2.ann1.Glyma.08G302300
+STF2	transcription factor STF2	glyma.Wm82.gnm2.ann1.Glyma.08g302500
+GSTF5	phi class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.08g306800
+NAC064	NAC Transcription Factor gene 64	glyma.Wm82.gnm2.ann1.Glyma.08G307100
+AGL1L	agamous-like MADS-box protein AGL1-like	glyma.Wm82.gnm2.ann1.Glyma.08g310100
+PAP01	purple acid phosphatase 18-like	glyma.Wm82.gnm2.ann1.Glyma.08g314800
+CDPK-GAMMA	calmodulin-like domain protein kinase isoenzyme gamma	glyma.Wm82.gnm2.ann1.Glyma.08g316500
+PPR86	Psudo-Response Regulator gene 86	glyma.Wm82.gnm2.ann1.Glyma.08G318700
+WRKY87	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.08G320200
+ERF67	Ethylene-responsive factor gene 67	glyma.Wm82.gnm2.ann1.Glyma.08G320700
+C2-86	C2 domain containing protein gene 86	glyma.Wm82.gnm2.ann1.Glyma.08G325300
+WRKY35, WRKY88	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.08G325800
+F6H3	flavonoid 6-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.08g326900
+HSP90-2	heat shock cognate protein 80-like	glyma.Wm82.gnm2.ann1.Glyma.08g332900
+LBD36	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g334200
+NF-YA07	nuclear transcription factor Y subunit A-7	glyma.Wm82.gnm2.ann1.Glyma.08g335900
+KTI-1, KTI-S, KTi2	Kunitz trypsin inhibitor gene 2	glyma.Wm82.gnm2.ann1.Glyma.08g341400
+KTi3	Kunitz trypsin inhibitor gene 3	glyma.Wm82.gnm2.ann1.Glyma.08g341500
 Lac29	Laccase 29	glyma.Wm82.gnm2.ann1.Glyma.08G343500
-Lac3	Laccase 3	glyma.Wm82.gnm2.ann1.Glyma.01G173500
+PGMPM19	type 4 metallothionein MT4	glyma.Wm82.gnm2.ann1.Glyma.08g346600
+CycC-1	Cyclin C gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g347600
+RIN4d	RIN4d protein	glyma.Wm82.gnm2.ann1.Glyma.08g349500
+CYP93E1	beta-amyrin and sophoradiol 24-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.08g350800
 Lac30	Laccase 30	glyma.Wm82.gnm2.ann1.Glyma.08G353500
 Lac31	Laccase 31	glyma.Wm82.gnm2.ann1.Glyma.08G359100
 Lac32	Laccase 32	glyma.Wm82.gnm2.ann1.Glyma.08G359200
 Lac33	Laccase 33	glyma.Wm82.gnm2.ann1.Glyma.08G359300
 Lac34	Laccase 34	glyma.Wm82.gnm2.ann1.Glyma.08G359400
-Lac35	Laccase 35	glyma.Wm82.gnm2.ann1.Glyma.09G132400
-Lac36	Laccase 36	glyma.Wm82.gnm2.ann1.Glyma.10G197300
-Lac37	Laccase 37	glyma.Wm82.gnm2.ann1.Glyma.10G219100
-Lac38	Laccase 38	glyma.Wm82.gnm2.ann1.Glyma.10G219200
-Lac39	Laccase 39	glyma.Wm82.gnm2.ann1.Glyma.10G263800
-Lac4	Laccase 4	glyma.Wm82.gnm2.ann1.Glyma.01G173600
-Lac40	Laccase 40	glyma.Wm82.gnm2.ann1.Glyma.11G059200
-Lac41	Laccase 41	glyma.Wm82.gnm2.ann1.Glyma.11G069500
-Lac42	Laccase 42	glyma.Wm82.gnm2.ann1.Glyma.11G069600
-Lac43	Laccase 43	glyma.Wm82.gnm2.ann1.Glyma.11G097300
-Lac44	Laccase 44	glyma.Wm82.gnm2.ann1.Glyma.11G137500
-Lac45	Laccase 45	glyma.Wm82.gnm2.ann1.Glyma.11G164000
-Lac46	Laccase 46	glyma.Wm82.gnm2.ann1.Glyma.11G233400
-Lac47	Laccase 47	glyma.Wm82.gnm2.ann1.Glyma.11G236800
-Lac48	Laccase 48	glyma.Wm82.gnm2.ann1.Glyma.11G256700
-Lac49	Laccase 49	glyma.Wm82.gnm2.ann1.Glyma.12G023300
-Lac5	Laccase 5	glyma.Wm82.gnm2.ann1.Glyma.01G183100
-Lac50	Laccase 50	glyma.Wm82.gnm2.ann1.Glyma.12G060900
-Lac51	Laccase 51	glyma.Wm82.gnm2.ann1.Glyma.12G097700
-Lac52	Laccase 52	glyma.Wm82.gnm2.ann1.Glyma.12G121700
-Lac53	Laccase 53	glyma.Wm82.gnm2.ann1.Glyma.12G192800
-Lac54	Laccase 54	glyma.Wm82.gnm2.ann1.Glyma.13G033600
-Lac55	Laccase 55	glyma.Wm82.gnm2.ann1.Glyma.13G076900
-Lac56	Laccase 56	glyma.Wm82.gnm2.ann1.Glyma.13G338100
-Lac57	Laccase 57	glyma.Wm82.gnm2.ann1.Glyma.14G041300
-Lac58	Laccase 58	glyma.Wm82.gnm2.ann1.Glyma.14G056100
-Lac59	Laccase 59	glyma.Wm82.gnm2.ann1.Glyma.14G062300
-Lac6	Laccase 6	glyma.Wm82.gnm2.ann1.Glyma.02G224800
-Lac60	Laccase 60	glyma.Wm82.gnm2.ann1.Glyma.14G191500
-Lac61	Laccase 61	glyma.Wm82.gnm2.ann1.Glyma.14G198900
-Lac62	Laccase 62	glyma.Wm82.gnm2.ann1.Glyma.14G223000
-Lac63	Laccase 63	glyma.Wm82.gnm2.ann1.Glyma.15G109000
-Lac64	Laccase 64	glyma.Wm82.gnm2.ann1.Glyma.16G158400
-Lac65	Laccase 65	glyma.Wm82.gnm2.ann1.Glyma.17G012300
-Lac66	Laccase 66	glyma.Wm82.gnm2.ann1.Glyma.17G138300
-Lac67	Laccase 67	glyma.Wm82.gnm2.ann1.Glyma.17G180400
-Lac68	Laccase 68	glyma.Wm82.gnm2.ann1.Glyma.17G180500
-Lac69	Laccase 69	glyma.Wm82.gnm2.ann1.Glyma.17G261500
-Lac7	Laccase 7	glyma.Wm82.gnm2.ann1.Glyma.02G231600
-Lac70	Laccase 70	glyma.Wm82.gnm2.ann1.Glyma.18G023600
-Lac71	Laccase 71	glyma.Wm82.gnm2.ann1.Glyma.18G057200
-Lac72	Laccase 72	glyma.Wm82.gnm2.ann1.Glyma.18G065100
-Lac73	Laccase 73	glyma.Wm82.gnm2.ann1.Glyma.18G177200
-Lac74	Laccase 74	glyma.Wm82.gnm2.ann1.Glyma.18G177300
-Lac75	Laccase 75	glyma.Wm82.gnm2.ann1.Glyma.18G177400
-Lac76	Laccase 76	glyma.Wm82.gnm2.ann1.Glyma.18G183500
-Lac77	Laccase 77	glyma.Wm82.gnm2.ann1.Glyma.18G183700
-Lac78	Laccase 78	glyma.Wm82.gnm2.ann1.Glyma.18G193200
-Lac79	Laccase 79	glyma.Wm82.gnm2.ann1.Glyma.18G193300
-Lac8	Laccase 8	glyma.Wm82.gnm2.ann1.Glyma.02G261600
-Lac80	Laccase 80	glyma.Wm82.gnm2.ann1.Glyma.18G193400
-Lac81	Laccase 81	glyma.Wm82.gnm2.ann1.Glyma.18G197400
-Lac82	Laccase 82	glyma.Wm82.gnm2.ann1.Glyma.20G025200
-Lac83	Laccase 83	glyma.Wm82.gnm2.ann1.Glyma.20G051600
-Lac85	Laccase 85	glyma.Wm82.gnm2.ann1.Glyma.20G051900
-Lac86	Laccase 86	glyma.Wm82.gnm2.ann1.Glyma.20G126500
-Lac87	Laccase 87	glyma.Wm82.gnm2.ann1.Glyma.20G172600
-Lac88	Laccase 88	glyma.Wm82.gnm2.ann1.Glyma.20G172700
-Lac89	Laccase 89	glyma.Wm82.gnm2.ann1.Glyma.20G192800
-Lac9	Laccase 9	glyma.Wm82.gnm2.ann1.Glyma.03G077900
-Lac90	Laccase 90	glyma.Wm82.gnm2.ann1.Glyma.20G192900
-Lac91	Laccase 91	glyma.Wm82.gnm2.ann1.Glyma.U027300
-Lac92	Laccase 92	glyma.Wm82.gnm2.ann1.Glyma.U027400
-Lbc2A	Leghemoglobin C2 gene A	glyma.Wm82.gnm1.ann1.Glyma20g33290
-Le4-2	lectin DB58-like	glyma.Wm82.gnm2.ann1.Glyma.10g108900
-Le5	Lectin gene 5	glyma.Wm82.gnm1.ann1.Glyma10g15480
-Lx1	lipoxygenase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.13g347600
-Lx2	Lipoxygenase 2 gene	glyma.Wm82.gnm2.ann1.Glyma.13g347500
-Lx3	Lipoxygenase 3 gene	glyma.Wm82.gnm2.ann1.Glyma.15g026300
-MADS28	MADS transcription factor	glyma.Wm82.gnm2.ann1.Glyma.18g0047001
-MAF1	MFP1 attachment factor 1	glyma.Wm82.gnm2.ann1.Glyma.17g237500
-MAGL	Monoacylglycerol lipase	glyma.Wm82.gnm1.ann1.Glyma08G19060
-MAKKK13-2	mitogen-activated protein kinase kinase 13 gene 2 	glyma.Wm82.gnm2.ann1.Glyma.14G195300
-MAN	endo-1, 4-beta-mannosidase	glyma.Wm82.gnm2.ann1.Glyma.19G223000
-MAN1	mannosyl-oligosaccharide 1,2-alpha-mannosidase	glyma.Wm82.gnm2.ann1.Glyma.08g221900
-MAPK1	mitogen-activated protein kinase 1	glyma.Wm82.gnm2.ann1.Glyma.u021800
-MAPK11-2	mitogen-activated protein kinase 11 gene 2	glyma.Wm82.gnm2.ann1.Glyma.09G256000
-MAPK16-4	mitogen-activated protein kinase 16	glyma.Wm82.gnm2.ann1.Glyma.07g255400
-MAPK2	mitogen-activated protein kinase 2	glyma.Wm82.gnm2.ann1.Glyma.02g138800
-MAPK22-2	mitogen-activated protein kinase 22 gene 2	glyma.Wm82.gnm2.ann1.Glyma.16G088700
-MAPK3-2	mitogen-activated protein kinase kinase gene 3 gene 2 	glyma.Wm82.gnm2.ann1.Glyma.12G073000
-MAPKK2	mitogen-activated protein kinase kinase MAPKK2	glyma.Wm82.gnm2.ann1.Glyma.17g052400
-MAPKKK14-1	mitogen-activated protein kinase kinase kinase 14 gene 1	glyma.Wm82.gnm2.ann1.Glyma.18G060900
-MAPKKK18-1	mitogen-activated protein kinase kinase 18 gene 1	glyma.Wm82.gnm2.ann1.Glyma.12G097200
-MAPKKK24-3	mitogen-activated protein kinase kinase kinase 24 gene 3	glyma.Wm82.gnm2.ann1.Glyma.14G080100
-MAT1	maturation-associated protein 1 gene	glyma.Wm82.gnm2.ann1.Glyma.07g090400
-MATE	aluminum-activated citrate transporter	glyma.Wm82.gnm2.ann1.Glyma.13g339800
-MATE13	citrate-proton symporter	glyma.Wm82.gnm2.ann1.Glyma.02g181800
-MCCA	3-methylcrotonyl-CoA carboxylase 1	glyma.Wm82.gnm2.ann1.Glyma.02g145300
-MDH-1, Mdh1	malate dehydrogenase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.12g159300
-MDHAR-4a	Peroximal monodehydroascorbate reductase 4 gene a	glyma.Wm82.gnm2.ann1.Glyma.16g073100
-MDHAR-4b	Peroximal monodehydroascorbate reductase 4 gene b	glyma.Wm82.gnm2.ann1.Glyma.19g061200
-MDHAR-6	Monodehydroascorbate reductase 6, cytosolic	glyma.Wm82.gnm2.ann1.Glyma.08g017800
-MED10-1	Mediator Complex 10 gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g296500
-MED10-2	Mediator Complex 10 gene 2	glyma.Wm82.gnm2.ann1.Glyma.18g125700
-MED11-1	Mediator Complex 11 gene 1	glyma.Wm82.gnm2.ann1.Glyma.03g168300
-MED11-2	Mediator Complex 11 gene 2	glyma.Wm82.gnm2.ann1.Glyma.19g169600
-MED12-1	Mediator Complex 12 gene 1	glyma.Wm82.gnm2.ann1.Glyma.03g009200
-MED12-2	Mediator Complex 12 gene 2	glyma.Wm82.gnm2.ann1.Glyma.07g070700
-MED12-3	Mediator Complex 12 gene 3	glyma.Wm82.gnm2.ann1.Glyma.09g259400
-MED12-4	Mediator Complex 12 gene 4	glyma.Wm82.gnm2.ann1.Glyma.18g232900
-MED13-1	Mediator Complex 13 gene 1	glyma.Wm82.gnm2.ann1.Glyma.18g000100
-MED13-2	Mediator Complex 13 gene 2	glyma.Wm82.gnm2.ann1.Glyma.11G256800
-MED14-1	Mediator Complex 14 gene 1	glyma.Wm82.gnm2.ann1.Glyma.03g247300
-MED14-2	Mediator Complex 14 gene 2	glyma.Wm82.gnm2.ann1.Glyma.19g245100
-MED14-3	Mediator Complex 14 gene 3	glyma.Wm82.gnm2.ann1.Glyma.01G083100
-MED15-1	Mediator Complex 15 gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g214900
-MED15-2	Mediator Complex 15 gene 2	glyma.Wm82.gnm2.ann1.Glyma.13g367700
-MED15-3	Mediator Complex 15 gene 3	glyma.Wm82.gnm2.ann1.Glyma.15g005500
-MED16-1	Mediator Complex 16 gene 1	glyma.Wm82.gnm2.ann1.Glyma.13g181200
-MED16-2	Mediator Complex 16 gene 2	glyma.Wm82.gnm2.ann1.Glyma.13g241100
-MED16-3	Mediator Complex 15 gene 3	glyma.Wm82.gnm2.ann1.Glyma.15g072300
-MED17-1	Mediator Complex 17 gene 1	glyma.Wm82.gnm2.ann1.Glyma.05g009700
-MED17-2	Mediator Complex 17 gene 2	glyma.Wm82.gnm2.ann1.Glyma.14g007400
-MED17-3	Mediator Complex 17 gene 3	glyma.Wm82.gnm2.ann1.Glyma.17g117600
-MED18-1	Mediator Complex 18 gene 1	glyma.Wm82.gnm2.ann1.Glyma.09g054300
-MED18-2	Mediator Complex 18 gene 2	glyma.Wm82.gnm2.ann1.Glyma.15g160500
-MED18-3	Mediator Complex 18 gene 3	glyma.Wm82.gnm2.ann1.Glyma.18g135700
-MED19-1	Mediator Complex 19 gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g001800
-MED19-2	Mediator Complex 19 gene 2	glyma.Wm82.gnm2.ann1.Glyma.06g001300
-MED19-3	Mediator Complex 19 gene 3	glyma.Wm82.gnm2.ann1.Glyma.07g058600
-MED19-4	Mediator Complex 19 gene 4	glyma.Wm82.gnm2.ann1.Glyma.16g027500
-MED2-1	Mediator Complex 2 gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g123300
-MED2-2	Mediator Complex 2 gene 2	glyma.Wm82.gnm2.ann1.Glyma.09g214900
-MED20-1	Mediator Complex 20 gene 1	glyma.Wm82.gnm2.ann1.Glyma.13g109300
-MED20-2	Mediator Complex 20 gene 2	glyma.Wm82.gnm2.ann1.Glyma.17g050300
-MED21-1	Mediator Complex 21 gene 1	glyma.Wm82.gnm2.ann1.Glyma.10g264300
-MED22-1	Mediator Complex 22 gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g160100
-MED22-2	Mediator Complex 22 gene 2	glyma.Wm82.gnm2.ann1.Glyma.15g204300
-MED23-1	Mediator Complex 23 gene 1	glyma.Wm82.gnm2.ann1.Glyma.09g123500
-MED25-1	Mediator Complex 25 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02g098300
-MED25-2	Mediator Complex 25 gene 2	glyma.Wm82.gnm2.ann1.Glyma.01G086600
-MED25-3	Mediator Complex 25 gene 3	glyma.Wm82.gnm2.ann1.Glyma.02G098500
-MED25-4	Mediator Complex 25 gene 4	glyma.Wm82.gnm2.ann1.Glyma.20G031800
-MED26-1	Mediator Complex 26 gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g216700
-MED26-2	Mediator Complex 26 gene 2	glyma.Wm82.gnm2.ann1.Glyma.05g187800
-MED26-3	Mediator Complex 26 gene 3	glyma.Wm82.gnm2.ann1.Glyma.06g149200
-MED26-4	Mediator Complex 26 gene 4	glyma.Wm82.gnm2.ann1.Glyma.08g146000
-MED28-1	Mediator Complex 28 gene 1	glyma.Wm82.gnm2.ann1.Glyma.05g185600
-MED28-2	Mediator Complex 28 gene 2	glyma.Wm82.gnm2.ann1.Glyma.08g143600
-MED3-1	Mediator Complex 3 gene 1	glyma.Wm82.gnm2.ann1.Glyma.03g201900
-MED3-2	Mediator Complex 3 gene 2	glyma.Wm82.gnm2.ann1.Glyma.19g026300
-MED30-1	Mediator Complex 30 gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g196600
-MED30-2	Mediator Complex 30 gene 2	glyma.Wm82.gnm2.ann1.Glyma.06g169200
-MED31-1	Mediator Complex 31 gene 1	glyma.Wm82.gnm2.ann1.Glyma.10g242500
-MED31-2	Mediator Complex 31 gene 2	glyma.Wm82.gnm2.ann1.Glyma.20g151600
-MED34-1	Mediator Complex 34 gene 1	glyma.Wm82.gnm2.ann1.Glyma.09g215200
-MED35-1	Mediator Complex 35 gene 1	glyma.Wm82.gnm2.ann1.Glyma.11g102600
-MED35-3	Mediator Complex 35 gene 3	glyma.Wm82.gnm2.ann1.Glyma.12g028100
-MED35-4	Mediator Complex 35 gene 4	glyma.Wm82.gnm2.ann1.Glyma.17g233000
-MED35-5	Mediator Complex 35 gene 5	glyma.Wm82.gnm2.ann1.Glyma.20g135800
-MED36-1	Mediator Complex 36 gene 1	glyma.Wm82.gnm2.ann1.Glyma.04g200700
-MED36-2	Mediator Complex 36 gene 2	glyma.Wm82.gnm2.ann1.Glyma.06g164800
-MED36-3	Mediator Complex 36 gene 3	glyma.Wm82.gnm2.ann1.Glyma.18g020000
-MED37-1	Mediator Complex 37 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02g093200
-MED37-10	Mediator Complex 37 gene 10	glyma.Wm82.gnm2.ann1.Glyma.18g289100
-MED37-11	Mediator Complex 37 gene 11	glyma.Wm82.gnm2.ann1.Glyma.18g289600
-MED37-12	Mediator Complex 37 gene 12	glyma.Wm82.gnm2.ann1.Glyma.19g172200
-MED37-2	Mediator Complex 37 gene 2	glyma.Wm82.gnm2.ann1.Glyma.03g171100
-MED37-3	Mediator Complex 37 gene 3	glyma.Wm82.gnm2.ann1.Glyma.05g219600
-MED37-4	Mediator Complex 37 gene 4 	glyma.Wm82.gnm2.ann1.Glyma.05g219400
-MED37-5	Mediator Complex 37 gene 5	glyma.Wm82.gnm2.ann1.Glyma.07g170800
-MED37-6	Mediator Complex 37 gene 6	glyma.Wm82.gnm2.ann1.Glyma.08g025700
-MED37-8	Mediator Complex 37 gene 8	glyma.Wm82.gnm2.ann1.Glyma.11g140500
-MED37-9	Mediator Complex 37 gene 9	glyma.Wm82.gnm2.ann1.Glyma.12g064000
-MED4-1	Mediator Complex 4 gene 1	glyma.Wm82.gnm2.ann1.Glyma.06g188800
-MED4-2	Mediator Complex 4 gene 2	glyma.Wm82.gnm2.ann1.Glyma.08g287300
-MED4-3	Mediator Complex 4 gene 3	glyma.Wm82.gnm2.ann1.Glyma.13g067700
-MED5-1	Mediator Complex 5 gene 1	glyma.Wm82.gnm2.ann1.Glyma.03g151100
-MED5-2	Mediator Complex 5 gene 2	glyma.Wm82.gnm2.ann1.Glyma.05g001600
-MED5-3	Mediator Complex 5 gene 3	glyma.Wm82.gnm2.ann1.Glyma.13g209800
-MED5-4	Mediator Complex 5 gene 4	glyma.Wm82.gnm2.ann1.Glyma.15g102800
-MED5-5	Mediator Complex 5 gene 5	glyma.Wm82.gnm2.ann1.Glyma.18g218900
-MED5-6	Mediator Complex 5 gene 6	glyma.Wm82.gnm2.ann1.Glyma.19g001500
-MED6-1	Mediator Complex 6 gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g199200
-MED7-1	Mediator Complex 7 gene 1	glyma.Wm82.gnm2.ann1.Glyma.07g029300
-MED7-2	Mediator Complex 7 gene 2	glyma.Wm82.gnm2.ann1.Glyma.08g213500
-MED8-1	Mediator Complex 8 gene 1	glyma.Wm82.gnm2.ann1.Glyma.13g372700
-MED9-1	Mediator Complex 9 gene 1	glyma.Wm82.gnm2.ann1.Glyma.07g009300
-MED9-2	Mediator Complex 9 gene 2	glyma.Wm82.gnm2.ann1.Glyma.08g192500
-MEKK	MAPK/ERK kinase kinase family protein	glyma.Wm82.gnm2.ann1.Glyma.13g084100
-MEKK2	mitogen-activated protein kinase	glyma.Wm82.gnm2.ann1.Glyma.17G173000
-MER3	ATP-dependent DNA helicase	glyma.Wm82.gnm2.ann1.Glyma.16g072300
-MET2	metallothionein type 2	glyma.Wm82.gnm2.ann1.Glyma.07g132000
-MGD1	monogalactosyldiacylglycerol synthase 1	glyma.Wm82.gnm2.ann1.Glyma.14g104100
-MIPS	myo-inositol-3-phosphate synthase	glyma.Wm82.gnm2.ann1.Glyma.11g238800
-MIPS4	inositol-3-phosphate synthase	glyma.Wm82.gnm2.ann1.Glyma.08g138200
-MKK1a	Mitogen-activated protein kinase kinase 1 gene a	glyma.Wm82.gnm1.ann1.Glyma15g18860
-MKK1b	Mitogen-activated protein kinase kinase 1 gene b	glyma.Wm82.gnm1.ann1.Glyma09g07660
-MKK2a	Mitogen-activated protein kinase kinase 2 gene a	glyma.Wm82.gnm1.ann1.Glyma17g06020
-MKK2b	Mitogen-activated protein kinase kinase 2 gene b	glyma.Wm82.gnm1.ann1.Glyma13g16650
-MKK4	mitogen-activated protein kinase kinase 4	glyma.Wm82.gnm2.ann1.Glyma.07g003200
-MKS2	methylketone synthase 2	glyma.Wm82.gnm2.ann1.Glyma.01g080400
-MLH3	MutL Homolog 3	glyma.Wm82.gnm2.ann1.Glyma.11G086300
-MLP34	MLP-like protein	glyma.Wm82.gnm2.ann1.Glyma.09G102400
-MMP2	Matrix metalloproteinase 2 gene	glyma.Wm82.gnm2.ann1.Glyma.01g036900
-MMT1	methionine S-methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.12g163700
-MMT2	methionine S-methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.16g000200
-MP2, PM2	maturation polypeptide 2 gene	glyma.Wm82.gnm2.ann1.Glyma.13g149000
-MPK4	mitogen-activated protein kinase 4	glyma.Wm82.gnm2.ann1.Glyma.01G222000
-MPK4c	Mitogen-activated protein kinase kinase 4 gene c	glyma.Wm82.gnm1.ann1.Glyma09g39190
-MPK4d	Mitogen-activated protein kinase kinase 4 gene d	glyma.Wm82.gnm1.ann1.Glyma18g47140
-MS	malate synthase	glyma.Wm82.gnm2.ann1.Glyma.17g128000
-MSG	MLP-like protein 28-like	glyma.Wm82.gnm2.ann1.Glyma.20g017900
-MSH1	DNA mismatch repair protein	glyma.Wm82.gnm2.ann1.Glyma.10g130700
-MST1	monosaccharide transporter	glyma.Wm82.gnm2.ann1.Glyma.08g035300
-MT2	malonyltransferase	glyma.Wm82.gnm2.ann1.Glyma.18g057700
-MT3	type 3 metallothionein MT3	glyma.Wm82.gnm2.ann1.Glyma.06g242900
-MTO3	METHIONINE OVER-ACCUMULATOR 3	glyma.Wm82.gnm1.ann1.Glyma17g04340
-MYB047	transcription factor MYB047	glyma.Wm82.gnm2.ann1.Glyma.04g004100
-MYB091	MYB transcription factor 91	glyma.Wm82.gnm1.ann1.Glyma03g19030
-MYB101	transcription factor MYB101	glyma.Wm82.gnm2.ann1.Glyma.12g017000
-MYB107	MYB transcription factor MYB107	glyma.Wm82.gnm2.ann1.Glyma.08g189900
-MYB109	MYB transcription factor MYB109	glyma.Wm82.gnm2.ann1.Glyma.17g121000
-MYB11	MYB11 protein	glyma.Wm82.gnm2.ann1.Glyma.19g024700
-MYB112	MYB transcription factor MYB112	glyma.Wm82.gnm2.ann1.Glyma.01g190100
-MYB118	MYB transcription factor MYB118	glyma.Wm82.gnm2.ann1.Glyma.10g048500
-MYB121	transcription factor MYBZ1	glyma.Wm82.gnm2.ann1.Glyma.15g176000
-MYB124	MYB transcription factor MYB124	glyma.Wm82.gnm2.ann1.Glyma.06g036800
-MYB127	MYB transcription factor MYB127	glyma.Wm82.gnm2.ann1.Glyma.08g029400
-MYB128	MYB transcription factor MYB128	glyma.Wm82.gnm2.ann1.Glyma.01g003000
-MYB12A	R2R3-type MYB transcription factor MYB12a	glyma.Wm82.gnm2.ann1.Glyma.03g221700
-MYB13	transcription factor MYB13	glyma.Wm82.gnm2.ann1.Glyma.20g184200
-MYB133	MYB transcription factor MYB133	glyma.Wm82.gnm2.ann1.Glyma.07g066100
-MYB136	MYB transcription factor MYB136	glyma.Wm82.gnm2.ann1.Glyma.09g131400
-MYB138	MYB transcription factor MYB138	glyma.Wm82.gnm2.ann1.Glyma.02g026300
-MYB139	MYB transcription factor MYB139	glyma.Wm82.gnm2.ann1.Glyma.13g333200
-MYB14	MYB14 protein	glyma.Wm82.gnm2.ann1.Glyma.15g259400
-MYB142	MYB transcription factor MYB142	glyma.Wm82.gnm2.ann1.Glyma.19g127900
-MYB143	MYB transcription factor MYB143	glyma.Wm82.gnm2.ann1.Glyma.04g177300
-MYB145	MYB transcription factor MYB145	glyma.Wm82.gnm2.ann1.Glyma.12g066000
-MYB149	MYB transcription factor MYB149	glyma.Wm82.gnm2.ann1.Glyma.08g293300
-MYB150	MYB transcription factor MYB150	glyma.Wm82.gnm2.ann1.Glyma.06g201500
-MYB158	transcription factor MYB1R1	glyma.Wm82.gnm2.ann1.Glyma.01g0386002
-MYB159	R2R3 MYB transcription factor MYB100	glyma.Wm82.gnm2.ann1.Glyma.07g216000
-MYB164	MYB transcription factor MYB164	glyma.Wm82.gnm2.ann1.Glyma.14g074500
-MYB172	MYB transcription factor MYB172	glyma.Wm82.gnm2.ann1.Glyma.13g307300
-MYB175	MYB transcription factor MYB173	glyma.Wm82.gnm2.ann1.Glyma.17g094400
-MYB177	MYB transcription factor MYB177	glyma.Wm82.gnm2.ann1.Glyma.14g210600
-MYB178	MYB transcription factor MYB178	glyma.Wm82.gnm2.ann1.Glyma.17g1671001
-MYB180	MYB transcription factor MYB180	glyma.Wm82.gnm2.ann1.Glyma.17g144100
-MYB181	MYB transcription factor MYB181	glyma.Wm82.gnm2.ann1.Glyma.16g073000
-MYB182	MYB transcription factor MYB182	glyma.Wm82.gnm2.ann1.Glyma.19g061300
-MYB184	MYB transcription factor MYB184	glyma.Wm82.gnm2.ann1.Glyma.08g042100
-MYB185	MYB transcription factor MYB185	glyma.Wm82.gnm2.ann1.Glyma.19g257400
-MYB205	transcription factor MYB205	glyma.Wm82.gnm2.ann1.Glyma.17g050500
-MYB29	MYB29 protein	glyma.Wm82.gnm2.ann1.Glyma.10g180800
-MYB29B2	MYB/HD-like transcription factor	glyma.Wm82.gnm2.ann1.Glyma.20g209700
-MYB3A	transcription factor MYB3a	glyma.Wm82.gnm2.ann1.Glyma.20g013000
-MYB48	MYB transcription factor MYB48	glyma.Wm82.gnm2.ann1.Glyma.06g003800
-MYB50	MYB transcription factor MYB50	glyma.Wm82.gnm2.ann1.Glyma.11g052100
-MYB51	MYB transcription factor MYB51	glyma.Wm82.gnm2.ann1.Glyma.03g078000
-MYB52	MYB transcription factor MYB52	glyma.Wm82.gnm2.ann1.Glyma.15g019400
-MYB53	MYB transcription factor MYB53	glyma.Wm82.gnm2.ann1.Glyma.13g063200
-MYB54	MYB transcription factor MYB54	glyma.Wm82.gnm2.ann1.Glyma.12g032200
-MYB55	MYB transcription factor	glyma.Wm82.gnm2.ann1.Glyma.09g029300
-MYB56	MYB transcription factor MYB56	glyma.Wm82.gnm2.ann1.Glyma.06g160500
-MYB57	MYB transcription factor MYB57	glyma.Wm82.gnm2.ann1.Glyma.14g191700
-MYB58	transcription factor MYB58	glyma.Wm82.gnm2.ann1.Glyma.05g0619001
-MYB59	DNA binding / transcription factor  	glyma.Wm82.gnm1.ann1.Glyma11g15180
-MYB60	MYB transcription factor MYB60	glyma.Wm82.gnm2.ann1.Glyma.18g259100
-MYB62	MYB transcription factor MYB62	glyma.Wm82.gnm2.ann1.Glyma.13g354800
-MYB62;L1	MYB62;L1 transcription factor	glyma.Wm82.gnm2.ann1.Glyma.10G010400
-MYB64	MYB transcription factor MYB64	glyma.Wm82.gnm2.ann1.Glyma.19g222200
-MYB68	MYB transcription factor MYB68	glyma.Wm82.gnm2.ann1.Glyma.04g042300
-MYB73	MYB transcription factor MYB73	glyma.Wm82.gnm2.ann1.Glyma.06g303100
-MYB75	MYB transcription factor MYB75	glyma.Wm82.gnm2.ann1.Glyma.14g062200
-MYB76	MYB transcription factor MYB76	glyma.Wm82.gnm2.ann1.Glyma.02g009800
-MYB81	MYB transcription factor MYB81	glyma.Wm82.gnm2.ann1.Glyma.14g086500
-MYB82	MYB transcription factor MYB82	glyma.Wm82.gnm2.ann1.Glyma.15g034500
-MYB83	MYB transcription factor MYB83	glyma.Wm82.gnm2.ann1.Glyma.02g254200
-MYB85	MYB transcription factor MYB85	glyma.Wm82.gnm2.ann1.Glyma.17g160500
-MYB92	MYB transcription factor MYB92	glyma.Wm82.gnm2.ann1.Glyma.16g023000
-MYB93	MYB transcription factor MYB93	glyma.Wm82.gnm2.ann1.Glyma.05g062300
-MYB98	MYB transcription factor MYB98	glyma.Wm82.gnm2.ann1.Glyma.19g061600
-MYB99	transcription factor MYB99	glyma.Wm82.gnm2.ann1.Glyma.05g006100
-MYBJ1	protein ODORANT1-like	glyma.Wm82.gnm2.ann1.Glyma.05g051700
-MYBJ2	myb-related protein 306-like	glyma.Wm82.gnm2.ann1.Glyma.04g170100
-MYBZ2	transcription factor MYBZ2	glyma.Wm82.gnm2.ann1.Glyma.11g107100
-Mdh2	malate dehydrogenase 2 gene, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.05g026300
-Ms1	Male Sterile 1	glyma.Wm82.gnm2.ann1.Glyma.13G114200
-N-21, VTL1a	vacuole iron transporter like	glyma.Wm82.gnm2.ann1.Glyma.05G121600
-N-22	nodulin-22	glyma.Wm82.gnm2.ann1.Glyma.15g045000
-N-23	nodulin-23	glyma.Wm82.gnm2.ann1.Glyma.20g024200
-N-26	nodulin-26	glyma.Wm82.gnm2.ann1.Glyma.08g120100
-N-26B	nodulin-26b (AA 1-213)	glyma.Wm82.gnm2.ann1.Glyma.19g074000
-N-36A	early nodulin-36A	glyma.Wm82.gnm2.ann1.Glyma.01g028500
-N-44	nodulin-44	glyma.Wm82.gnm2.ann1.Glyma.13g364400
-N-56	probable 2-isopropylmalate synthase	glyma.Wm82.gnm2.ann1.Glyma.13g024700
-N-70	early nodulin-70	glyma.Wm82.gnm2.ann1.Glyma.18g018900
-N479	C2H2 zinc finger protein	glyma.Wm82.gnm2.ann1.Glyma.07g135800
-N6L	nodulin 6l	glyma.Wm82.gnm2.ann1.Glyma.10g060100
-N:IFR	Isoflavone Reductase	glyma.Wm82.gnm1.ann1.Glyma01g37810
-NAB	Nucleic Acids Binding protein	glyma.Wm82.gnm1.ann1.Glyma18G40360
-NAC001	NAC Transcription Factor gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G005500
-NAC002	NAC Transcription Factor gene 2	glyma.Wm82.gnm2.ann1.Glyma.01G046800
-NAC003, NAC1	NAC domain protein NAC1	glyma.Wm82.gnm2.ann1.Glyma.01g051300
-NAC004	NAC Transcription Factor gene 4	glyma.Wm82.gnm2.ann1.Glyma.01G088200
-NAC005	NAC Transcription Factor gene 5	glyma.Wm82.gnm2.ann1.Glyma.01G167900
-NAC006	NAC Transcription Factor gene 6	glyma.Wm82.gnm1.ann1.Glyma02g07700
-NAC007	NAC Transcription Factor gene 7	glyma.Wm82.gnm2.ann1.Glyma.02G070600.
-NAC008	NAC Transcription Factor gene 8	glyma.Wm82.gnm2.ann1.Glyma.02G100200
-NAC009	NAC Transcription Factor gene 9	glyma.Wm82.gnm2.ann1.Glyma.02G107000
-NAC010, NAC26, NAC29	NAC domain-containing protein	glyma.Wm82.gnm2.ann1.Glyma.02G109800
-NAC011, NAC193	NAC Transcription Factor gene 193	glyma.Wm82.gnm1.ann1.Glyma02g26480
-NAC012, NAC22	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.02g222300
-NAC013	NAC Transcription Factor gene 13	glyma.Wm82.gnm2.ann1.Glyma.02G240500
-NAC014	NAC Transcription Factor gene 14	glyma.Wm82.gnm2.ann1.Glyma.03G197900
-NAC015	NAC Transcription Factor gene 15	glyma.Wm82.gnm2.ann1.Glyma.04G078600
-NAC016	NAC Transcription Factor gene 16	glyma.Wm82.gnm2.ann1.Glyma.04G119500
-NAC017	NAC Transcription Factor gene 17	glyma.Wm82.gnm1.ann1.Glyma04g33270
-NAC019	NAC Transcription Factor gene 19	glyma.Wm82.gnm2.ann1.Glyma.04G212000
-NAC020	NAC Transcription Factor gene 20	glyma.Wm82.gnm2.ann1.Glyma.04G213300
-NAC023	NAC Transcription Factor gene 23	glyma.Wm82.gnm2.ann1.Glyma.05G025500
-NAC024	NAC Transcription Factor gene 24	glyma.Wm82.gnm2.ann1.Glyma.05G055900
-NAC025	NAC Transcription Factor gene 25	glyma.Wm82.gnm2.ann1.Glyma.05G002700
-NAC026	NAC Transcription Factor gene 26	glyma.Wm82.gnm2.ann1.Glyma.05G113000
-NAC027	NAC Transcription Factor gene 27	glyma.Wm82.gnm1.ann1.Glyma05g24910
-NAC028	NAC Transcription Factor gene 28	glyma.Wm82.gnm2.ann1.Glyma.05G191300
-NAC029	NAC Transcription Factor gene 29	glyma.Wm82.gnm2.ann1.Glyma.05G192500
-NAC030	NAC Transcription Factor gene 30	glyma.Wm82.gnm2.ann1.Glyma.05G195000
-NAC031	NAC Transcription Factor gene 31	glyma.Wm82.gnm2.ann1.Glyma.05G234200
-NAC032	NAC Transcription Factor gene 32	glyma.Wm82.gnm2.ann1.Glyma.05G225100
-NAC033	NAC Transcription Factor gene 33	glyma.Wm82.gnm2.ann1.Glyma.05G202300
-NAC034	NAC Transcription Factor gene 34	glyma.Wm82.gnm2.ann1.Glyma.06G080200
-NAC035, NAC2	NAC domain protein NAC2	glyma.Wm82.gnm2.ann1.Glyma.06g114000
-NAC036	NAC Transcription Factor gene 36	glyma.Wm82.gnm2.ann1.Glyma.06G138100
-NAC037	NAC Transcription Factor gene 37	glyma.Wm82.gnm2.ann1.Glyma.06G152900
-NAC038	NAC Transcription Factor gene 38	glyma.Wm82.gnm1.ann1.Glyma04g38990
-NAC039	NAC Transcription Factor gene 39	glyma.Wm82.gnm2.ann1.Glyma.06G157400
-NAC040	NAC Transcription Factor gene 40	glyma.Wm82.gnm2.ann1.Glyma.06G166500
-NAC041, NAC5	NAC domain protein NAC5	glyma.Wm82.gnm2.ann1.Glyma.06g195500
-NAC042	NAC Transcription Factor gene 42	glyma.Wm82.gnm2.ann1.Glyma.06G236000
-NAC043	NAC Transcription Factor gene 43	glyma.Wm82.gnm1.ann1.Glyma06g38410
-NAC044	NAC Transcription Factor gene 44	glyma.Wm82.gnm1.ann1.Glyma06g38440
-NAC045	NAC Transcription Factor gene 45	glyma.Wm82.gnm2.ann1.Glyma.06G318900
-NAC046	NAC Transcription Factor gene 46	glyma.Wm82.gnm2.ann1.Glyma.07G048000
-NAC047	NAC Transcription Factor gene 47	glyma.Wm82.gnm2.ann1.Glyma.07G048100
-NAC048, NST1A	NAC family transcription factor	glyma.Wm82.gnm2.ann1.Glyma.07g050600
-NAC049	NAC Transcription Factor gene 49	glyma.Wm82.gnm2.ann1.Glyma.07G092000
-NAC050	NAC Transcription Factor gene 50	glyma.Wm82.gnm2.ann1.Glyma.07G126500
-NAC051	NAC Transcription Factor gene 51	glyma.Wm82.gnm2.ann1.Glyma.07G201800
-NAC052	NAC Transcription Factor gene 52	glyma.Wm82.gnm1.ann1.Glyma07g35630
-NAC053	NAC Transcription Factor gene 53	glyma.Wm82.gnm2.ann1.Glyma.07G271100
-NAC054	NAC Transcription Factor gene 54	glyma.Wm82.gnm2.ann1.Glyma.08G009700
-NAC055	NAC Transcription Factor gene 55	glyma.Wm82.gnm2.ann1.Glyma.08G031900
-NAC056	NAC Transcription Factor gene 56	glyma.Wm82.gnm2.ann1.Glyma.08G041500
-NAC057	NAC Transcription Factor gene 57	glyma.Wm82.gnm2.ann1.Glyma.08G075300
-NAC058	NAC Transcription Factor gene 58	glyma.Wm82.gnm2.ann1.Glyma.08G156500
-NAC059	NAC Transcription Factor gene 59	glyma.Wm82.gnm2.ann1.Glyma.08G161300
-NAC060	NAC Transcription Factor gene 60	glyma.Wm82.gnm2.ann1.Glyma.08G169400
-NAC061, NAC34	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.08g173400
-NAC062	NAC Transcription Factor gene 62	glyma.Wm82.gnm1.ann1.Glyma08g19300
-NAC063	NAC Transcription Factor gene 63	glyma.Wm82.gnm2.ann1.Glyma.08G301100
-NAC064	NAC Transcription Factor gene 64	glyma.Wm82.gnm2.ann1.Glyma.08G307100
 NAC065, NAC15	NAC domain-containing protein	glyma.Wm82.gnm2.ann1.Glyma.08g360200
-NAC066	NAC Transcription Factor gene 66	glyma.Wm82.gnm2.ann1.Glyma.09G167400
-NAC067	NAC Transcription Factor gene 67	glyma.Wm82.gnm2.ann1.Glyma.09G184100
-NAC068	NAC Transcription Factor gene 68	glyma.Wm82.gnm2.ann1.Glyma.09G231700
-NAC069	NAC Transcription Factor gene 69	glyma.Wm82.gnm2.ann1.Glyma.09G233600
-NAC070, NLP2	NAC domain-containing protein 100-like	glyma.Wm82.gnm2.ann1.Glyma.09g235700
-NAC071	NAC Transcription Factor gene 71	glyma.Wm82.gnm1.ann1.Glyma10g04350
-NAC072	NAC Transcription Factor gene 72	glyma.Wm82.gnm2.ann1.Glyma.10G197500
-NAC073	NAC Transcription Factor gene 73	glyma.Wm82.gnm2.ann1.Glyma.10G216400
-NAC074, SNAC38	NAC transcription factor	glyma.Wm82.gnm2.ann1.Glyma.10g219600
-NAC075	NAC Transcription Factor gene 75	glyma.Wm82.gnm2.ann1.Glyma.11G030600
-NAC076	NAC Transcription Factor gene 76	glyma.Wm82.gnm2.ann1.Glyma.11G075400
-NAC077	NAC Transcription Factor gene 77	glyma.Wm82.gnm2.ann1.Glyma.11G096600
-NAC078, NAC90	PREDICTED: NAC domain-containing protein 90-like	glyma.Wm82.gnm2.ann1.Glyma.11G182000
-NAC079	NAC Transcription Factor gene 79	glyma.Wm82.gnm2.ann1.Glyma.11G212400
-NAC080	NAC Transcription Factor gene 80	glyma.Wm82.gnm2.ann1.Glyma.12G004900
-NAC081, NAC6	NAC domain protein NAC6	glyma.Wm82.gnm2.ann1.Glyma.12g022700
-NAC082	NAC Transcription Factor gene 82	glyma.Wm82.gnm2.ann1.Glyma.12G091200
-NAC083	NAC Transcription Factor gene 83	glyma.Wm82.gnm1.ann1.Glyma12g13710
-NAC084	NAC Transcription Factor gene 84	glyma.Wm82.gnm1.ann1.Glyma12g22790
-NAC085	NAC Transcription Factor gene 85	glyma.Wm82.gnm1.ann1.Glyma12g22880
-NAC086	NAC Transcription Factor gene 86	glyma.Wm82.gnm2.ann1.Glyma.12G161700
-NAC087	NAC Transcription Factor gene 87	glyma.Wm82.gnm2.ann1.Glyma.12G171600
-NAC088	NAC Transcription Factor gene 88	glyma.Wm82.gnm2.ann1.Glyma.12G186200
-NAC090	NAC Transcription Factor gene 90	glyma.Wm82.gnm2.ann1.Glyma.12G206900
-NAC091, NAC113	NAC Transcription Factor gene 113	glyma.Wm82.gnm1.ann1.Glyma15g07620
-NAC092	NAC Transcription Factor gene 92	glyma.Wm82.gnm1.ann1.Glyma12g35000
-NAC093, NLP4	protein CUP-SHAPED COTYLEDON 2-like	glyma.Wm82.gnm2.ann1.Glyma.12g226500
-NAC094	NAC Transcription Factor gene 94	glyma.Wm82.gnm2.ann1.Glyma.13G063300
-NAC095	NAC Transcription Factor gene 95	glyma.Wm82.gnm1.ann1.Glyma13g05540
-NAC097	NAC Transcription Factor gene 97	glyma.Wm82.gnm2.ann1.Glyma.13G174700
-NAC098	NAC Transcription Factor gene 98	glyma.Wm82.gnm2.ann1.Glyma.13G234700
-NAC099	NAC Transcription Factor gene 99	glyma.Wm82.gnm1.ann1.Glyma13g31660
-NAC100	NAC Transcription Factor gene 100	glyma.Wm82.gnm2.ann1.Glyma.13G274300
-NAC101	NAC Transcription Factor gene 101	glyma.Wm82.gnm1.ann1.Glyma13g35550
-NAC102	NAC Transcription Factor gene 102	glyma.Wm82.gnm1.ann1.Glyma13g35560
-NAC103	NAC Transcription Factor gene 103	glyma.Wm82.gnm2.ann1.Glyma.13G314600
-NAC104	NAC Transcription Factor gene 104	glyma.Wm82.gnm2.ann1.Glyma.13G315300
-NAC105	NAC Transcription Factor gene 105	glyma.Wm82.gnm2.ann1.Glyma.13G327600
-NAC106, NAC42-2	NAC domain-containing protein 42-like	glyma.Wm82.gnm2.ann1.Glyma.14g030700
-NAC107	NAC Transcription Factor gene 107	glyma.Wm82.gnm2.ann1.Glyma.14G084300
-NAC109	NAC Transcription Factor gene 109	glyma.Wm82.gnm1.ann1.Glyma14g24220
-NAC11, NAC181	NAC Transcription Factor gene 181	glyma.Wm82.gnm2.ann1.Glyma.19G108800
-NAC110	NAC Transcription Factor gene 110	glyma.Wm82.gnm2.ann1.Glyma.14G189300
-NAC111	NAC Transcription Factor gene 111	glyma.Wm82.gnm2.ann1.Glyma.14G210000
-NAC112	NAC Transcription Factor gene 112	glyma.Wm82.gnm2.ann1.Glyma.15G051200
-NAC114	NAC Transcription Factor gene 114	glyma.Wm82.gnm2.ann1.Glyma.15G078300
-NAC115, NAC35	transcriptional factor NAC35	glyma.Wm82.gnm2.ann1.Glyma.15g254000
-NAC116	NAC Transcription Factor gene 116	glyma.Wm82.gnm2.ann1.Glyma.15G257700
-NAC117	NAC Transcription Factor gene 117	glyma.Wm82.gnm2.ann1.Glyma.15G264100
-NAC118	NAC Transcription Factor gene 118	glyma.Wm82.gnm2.ann1.Glyma.15G266500
-NAC12, NAC124	NAC Transcription Factor gene 124	glyma.Wm82.gnm2.ann1.Glyma.16G043200
-NAC120	NAC Transcription Factor gene 120	glyma.Wm82.gnm2.ann1.Glyma.16G016600
-NAC121	NAC Transcription Factor gene 121	glyma.Wm82.gnm2.ann1.Glyma.16G016700
-NAC122, SHAT1-5	NAC domain-containing protein 43-like	glyma.Wm82.gnm2.ann1.Glyma.16g019400
-NAC123	NAC Transcription Factor gene 123	glyma.Wm82.gnm2.ann1.Glyma.16G042900
-NAC125	NAC Transcription Factor gene 125	glyma.Wm82.gnm2.ann1.Glyma.16G051800
-NAC126	NAC Transcription Factor gene 126	glyma.Wm82.gnm2.ann1.Glyma.16G130200
-NAC127	NAC Transcription Factor gene 127	glyma.Wm82.gnm2.ann1.Glyma.16G151500
-NAC128, NAC23	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.16g152100
-NAC129	NAC Transcription Factor gene 129	glyma.Wm82.gnm2.ann1.Glyma.16G217400
-NAC130	NAC Transcription Factor gene 130	glyma.Wm82.gnm2.ann1.Glyma.17G002800
-NAC131	NAC Transcription Factor gene 131	glyma.Wm82.gnm2.ann1.Glyma.17G101500
-NAC132	NAC Transcription Factor gene 132	glyma.Wm82.gnm2.ann1.Glyma.17G138100
-NAC133	NAC Transcription Factor gene 133	glyma.Wm82.gnm2.ann1.Glyma.17G154100
-NAC134	NAC Transcription Factor gene 134	glyma.Wm82.gnm2.ann1.Glyma.17G185000
-NAC135	NAC Transcription Factor gene 135	glyma.Wm82.gnm2.ann1.Glyma.17G240700
-NAC136	NAC Transcription Factor gene 136	glyma.Wm82.gnm2.ann1.Glyma.18G043900
-NAC137	NAC Transcription Factor gene 137	glyma.Wm82.gnm2.ann1.Glyma.18G110700
-NAC138	NAC Transcription Factor gene 138	glyma.Wm82.gnm2.ann1.Glyma.18G119300
-NAC139, NLP1	NAC domain-containing protein 100-like	glyma.Wm82.gnm2.ann1.Glyma.18g261300
-NAC14, NAC179	NAC Transcription Factor gene 179	glyma.Wm82.gnm2.ann1.Glyma.18G301500
-NAC140	NAC Transcription Factor gene 140	glyma.Wm82.gnm2.ann1.Glyma.19G021900
-NAC141	NAC Transcription Factor gene 141	glyma.Wm82.gnm2.ann1.Glyma.19G024500
-NAC142	NAC Transcription Factor gene 142	glyma.Wm82.gnm2.ann1.Glyma.19G056400
-NAC143	NAC Transcription Factor gene 143	glyma.Wm82.gnm2.ann1.Glyma.19G097700
-NAC144	NAC Transcription Factor gene 144	glyma.Wm82.gnm2.ann1.Glyma.19G109100
-NAC145	NAC Transcription Factor gene 145	glyma.Wm82.gnm2.ann1.Glyma.19G180300
-NAC146	NAC Transcription Factor gene 146	glyma.Wm82.gnm2.ann1.Glyma.19G259500
-NAC147	NAC Transcription Factor gene 147	glyma.Wm82.gnm2.ann1.Glyma.19G259700
-NAC148	NAC Transcription Factor gene 148	glyma.Wm82.gnm1.ann1.Glyma20g04400
-NAC149	NAC Transcription Factor gene 149	glyma.Wm82.gnm2.ann1.Glyma.20G172100
-NAC150	NAC Transcription Factor gene 150	glyma.Wm82.gnm2.ann1.Glyma.20G185800
-NAC151	NAC Transcription Factor gene 151	glyma.Wm82.gnm2.ann1.Glyma.20G192300
-NAC152	NAC Transcription Factor gene 152	glyma.Wm82.gnm2.ann1.Glyma.20G192500
-NAC154, NAC42-1	transcription factor JUNGBRUNNEN 1	glyma.Wm82.gnm2.ann1.Glyma.02g284300
-NAC156	NAC Transcription Factor gene 156	glyma.Wm82.gnm2.ann1.Glyma.03G179600
-NAC161	NAC Transcription Factor gene 161	glyma.Wm82.gnm2.ann1.Glyma.05G108700
-NAC164	NAC Transcription Factor gene 164	glyma.Wm82.gnm2.ann1.Glyma.07G047900
-NAC169	NAC Transcription Factor gene 169	glyma.Wm82.gnm2.ann1.Glyma.10G197600
-NAC172	NAC domain-containing protein 172	glyma.Wm82.gnm2.ann1.Glyma.12g145100
-NAC174	NAC Transcription Factor gene 174	glyma.Wm82.gnm2.ann1.Glyma.12G186900
-NAC176	NAC domain-containing protein 176	glyma.Wm82.gnm2.ann1.Glyma.14g140100
-NAC178	NAC Transcription Factor gene 178	glyma.Wm82.gnm2.ann1.Glyma.16G069300
-NAC183	NAC Transcription Factor gene 183	glyma.Wm82.gnm2.ann1.Glyma.19G195800
-NAC19	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.13g030900
-NAC21	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.14g152700
-NAC27	NAC transcription factor NAC27	glyma.Wm82.gnm2.ann1.Glyma.13g279900
-NAC3	NAC domain protein NAC3	glyma.Wm82.gnm2.ann1.Glyma.06g248900
-NAC4	NAC domain protein NAC4	glyma.Wm82.gnm2.ann1.Glyma.12g221500
-NAC51	transcription factor NAC51	glyma.Wm82.gnm2.ann1.Glyma.07g229100
-NARK	nodule autoregulation receptor kinase	glyma.Wm82.gnm2.ann1.Glyma.12g040000
-NCED2	9-cis-epoxycarotenoid dioxygenase 2	glyma.Wm82.gnm2.ann1.Glyma.08g096200
-NCED3	NINE-CIS-EPOXYCAROTENOID DIOXYGENASE3	glyma.Wm82.gnm1.ann1.Glyma15g40070
-NDH	NAD(P)H dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.10G000900
-NDR1A	NDR1-like protein	glyma.Wm82.gnm2.ann1.Glyma.13g287500
-NDR1b	CC-NB-LRR resistance (R) protein	glyma.Wm82.gnm2.ann1.Glyma.12g214100
-NES	nerol synthase	glyma.Wm82.gnm2.ann1.Glyma.13g250400
-NF-YA	nuclear factor Y subunit A	glyma.Wm82.gnm2.ann1.Glyma.08g124200
-NF-YA01	nuclear transcription factor Y subunit A-1	glyma.Wm82.gnm2.ann1.Glyma.02g195000
-NF-YA02	nuclear transcription factor Y subunit A-2	glyma.Wm82.gnm2.ann1.Glyma.02g303800
-NF-YA03	nuclear transcription factor Y subunit A-3	glyma.Wm82.gnm2.ann1.Glyma.03g203000
-NF-YA05	nuclear transcription factor Y subunit A-5	glyma.Wm82.gnm2.ann1.Glyma.07g036200
-NF-YA07	nuclear transcription factor Y subunit A-7	glyma.Wm82.gnm2.ann1.Glyma.08g335900
-NF-YA08	nuclear transcription factor Y subunit A-8	glyma.Wm82.gnm2.ann1.Glyma.09g023800
-NF-YA09	nuclear transcription factor Y subunit A-9	glyma.Wm82.gnm2.ann1.Glyma.09g068400
-NF-YA10	nuclear transcription factor Y subunit A-10	glyma.Wm82.gnm2.ann1.Glyma.10g082800
-NF-YA11	nuclear transcription factor Y subunit A-11	glyma.Wm82.gnm2.ann1.Glyma.12g236800
-NF-YA12	nuclear transcription factor Y subunit A-12	glyma.Wm82.gnm2.ann1.Glyma.13g107900
-NF-YA13	nuclear transcription factor Y subunit A-13	glyma.Wm82.gnm2.ann1.Glyma.13g202300
-NF-YA14	nuclear transcription factor Y subunit A-14	glyma.Wm82.gnm2.ann1.Glyma.14g010000
-NF-YA15	nuclear transcription factor Y subunit A-15	glyma.Wm82.gnm2.ann1.Glyma.15g027400
-NF-YA16	nuclear transcription factor Y subunit A-16	glyma.Wm82.gnm2.ann1.Glyma.15g129900
-NF-YA18	nuclear transcription factor Y subunit A-18	glyma.Wm82.gnm2.ann1.Glyma.16g005500
-NF-YA19	nuclear transcription factor Y subunit A-19	glyma.Wm82.gnm2.ann1.Glyma.17g051400
-NF-YA1B	putative CCAAT-binding transcription factor GmNF-YA1b	glyma.Wm82.gnm2.ann1.Glyma.19g200800
-NF-YA20	nuclear transcription factor Y subunit A-20	glyma.Wm82.gnm2.ann1.Glyma.18g071000
+SWEET25	sugar efflux transporter SWEET25	glyma.Wm82.gnm2.ann1.Glyma.08g360400
+SWEET26	sugar efflux transporter SWEET26	glyma.Wm82.gnm2.ann1.Glyma.08g360500
+GMR2	ras-related protein RABA5d-like	glyma.Wm82.gnm2.ann1.Glyma.08g361000
+FT4, FT4 (E10)	Flowering Locus T gene 4	glyma.Wm82.gnm2.ann1.Glyma.08G363100
+FT6, FTL7	Flowering locus T-like gene 7	glyma.Wm82.gnm2.ann1.Glyma.08g363200
+GF14m, SGF14M	14-3-3 protein SGF14m	glyma.Wm82.gnm2.ann1.Glyma.08g363800
+LBD37	LBD domain-containing transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g365100
+PPR87	Psudo-Response Regulator gene 87	glyma.Wm82.gnm2.ann1.Glyma.09G000400
+ABA3	molybdenum cofactor sulfurtransferase 3	glyma.Wm82.gnm2.ann1.Glyma.09G002300
+C2-87	C2 domain containing protein gene 87	glyma.Wm82.gnm2.ann1.Glyma.09G003400
+GLYI-10	Glyoxylase 1 gene 10	glyma.Wm82.gnm2.ann1.Glyma.09g004300
+WRKY23, WRKY89	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.09G005700
+H1	homeobox protein SBH1	glyma.Wm82.gnm2.ann1.Glyma.09g007500
+PTOX	plastid terminal oxidase	glyma.Wm82.gnm2.ann1.Glyma.09g008500
 NF-YB3a	Nuclear Transcripiton Factor Y Subunit Beta 3 gene a	glyma.Wm82.gnm2.ann1.Glyma.09G014100
-NF-YB3b	Nuclear Transcripiton Factor Y Subunit Beta 3 gene b	glyma.Wm82.gnm2.ann1.Glyma.15G118800
-NF-YC02	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.03g239400
-NF-YC03, NF-YC4-2	NF-Y subunit C 4 gene 2	glyma.Wm82.gnm2.ann1.Glyma.04g196200
-NF-YC04, NF-YC4-1	NF-Y subunit C 4 gene 1	glyma.Wm82.gnm2.ann1.Glyma.06g169600
-NF-YC05	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.08g148200
-NF-YC06	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.08g165700
-NF-YC07	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.10g155900
-NF-YC08	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.12g217200
-NF-YC09	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.13g207500
-NF-YC10	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.13g207600
-NF-YC11	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.13g207700
-NF-YC12	nuclear factor Y transcription factor	glyma.Wm82.gnm2.ann1.Glyma.13g284000
-NF-YC13	nuclear factor Y transcription factor	glyma.Wm82.gnm2.ann1.Glyma.15g261300
-NF-YC14	nuclear factor Y transcription factor	glyma.Wm82.gnm2.ann1.Glyma.19g236400
-NF-YC15	nuclear factor Y transcription factor	glyma.Wm82.gnm2.ann1.Glyma.20g232400
-NFR1B	LysM-type receptor kinase NFR1B	glyma.Wm82.gnm2.ann1.Glyma.14g046200
-NFR5A	Nod factor receptor protein 5A	glyma.Wm82.gnm2.ann1.Glyma.11g063100
-NFR5B	Nod-factor receptor 5B	glyma.Wm82.gnm2.ann1.Glyma.01g179100
-NFYA	Nuclear Factor Y subunit A	glyma.Wm82.gnm1.ann1.Glyma02g47380
-NGM-16	nodulin-16	glyma.Wm82.gnm2.ann1.Glyma.02g265200
-NHX1	sodium/hydrogen exchanger 1	glyma.Wm82.gnm2.ann1.Glyma.20g229900
-NINA	protein NODULE INCEPTION 1a	glyma.Wm82.gnm2.ann1.Glyma.04g000600
-NIP1-1	aquaporin NIP1-1	glyma.Wm82.gnm2.ann1.Glyma.05g162600
-NIP1-2	aquaporin NIP1-2	glyma.Wm82.gnm2.ann1.Glyma.08g120200
-NIP1-4	aquaporin NIP1-4	glyma.Wm82.gnm2.ann1.Glyma.15g087300
-NIP1-6	aquaporin NIP1-6	glyma.Wm82.gnm2.ann1.Glyma.05g162500
-NIP1-8	aquaporin NIP1-8	glyma.Wm82.gnm2.ann1.Glyma.13g224900
-NIP2-1	putative Si transporter NIP2-1	glyma.Wm82.gnm2.ann1.Glyma.09g238200
-NIP2-2	putative Si transporter NIP2-2	glyma.Wm82.gnm2.ann1.Glyma.18g259500
-NIP3-1	aquaporin NIP3-1	glyma.Wm82.gnm2.ann1.Glyma.14g174300
-NIP30	NEFA interacting protein 30	glyma.Wm82.gnm1.ann1.Glyma19G40910
-NIP4-1	aquaporin NIP4-1	glyma.Wm82.gnm2.ann1.Glyma.02g246700
-NIP4-2	aquaporin NIP4-2	glyma.Wm82.gnm2.ann1.Glyma.14g069500
-NIP5-2	aquaporin NIP5-2	glyma.Wm82.gnm2.ann1.Glyma.10g221100
-NIP6-2	aquaporin NIP6-2	glyma.Wm82.gnm2.ann1.Glyma.08g217400
-NIP6-3	aquaporin NIP6-3	glyma.Wm82.gnm2.ann1.Glyma.15g003900
-NIP7-1	aquaporin NIP7-1	glyma.Wm82.gnm2.ann1.Glyma.02g140500
-NIP7-2	aquaporin NIP7-2	glyma.Wm82.gnm2.ann1.Glyma.10g033600
-NIR, NIR1-1	nitrate reductase 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02g132100
-NLP	NAC domain-containing protein	glyma.Wm82.gnm2.ann1.Glyma.04g167200
-NMHC5	MADS-box transcription factor NMHC5	glyma.Wm82.gnm2.ann1.Glyma.13g2552001
-NOD33	putative nod33	glyma.Wm82.gnm2.ann1.Glyma.10g248900
-NPR1-2 	nonexpressor of PR1	glyma.Wm82.gnm1.ann1.Glyma09g02430
-NPR1.09	Non-induced pathogenesis-related gene	glyma.Wm82.gnm2.ann1.Glyma.09G064700
-NPR1.2.15	Non-induced pathogenesis-related gene	glyma.Wm82.gnm2.ann1.Glyma.15G127200
-NR	Nitrate reductase	glyma.Wm82.gnm2.ann1.Glyma.14g165000
-NR1-2	nitrate reductase 1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.13g084000
-NRAMP1A	divalent metal ion transporter NRAMP1a	glyma.Wm82.gnm2.ann1.Glyma.01g190700
-NRAMP1B	metal transporter Nramp1b	glyma.Wm82.gnm2.ann1.Glyma.11g051500
-NRAMP2A	metal transporter Nramp2a	glyma.Wm82.gnm2.ann1.Glyma.05g101700
-NRAMP3A	metal transporter Nramp3a	glyma.Wm82.gnm2.ann1.Glyma.04g044000
-NRAMP3B	metal transporter Nramp3b	glyma.Wm82.gnm2.ann1.Glyma.06g044200
-NRAMP4A	metal transporter Nramp4a	glyma.Wm82.gnm2.ann1.Glyma.07g058900
-NRAMP4B	metal transporter Nramp4b	glyma.Wm82.gnm2.ann1.Glyma.16g027800
-NRAMP5A	metal transporter Nramp5a	glyma.Wm82.gnm2.ann1.Glyma.07g023600
-NRAMP5B	metal transporter Nramp5b	glyma.Wm82.gnm2.ann1.Glyma.08g218200
-NRAMP6A	metal transporter Nramp6a	glyma.Wm82.gnm2.ann1.Glyma.13g369900
-NRAMP6B	metal transporter Nramp6b	glyma.Wm82.gnm2.ann1.Glyma.15g003500
-NRAMP7	metal transporter Nramp7	glyma.Wm82.gnm2.ann1.Glyma.06g115800
-NRP-A	N-rich protein	glyma.Wm82.gnm2.ann1.Glyma.20g066100
-NRPB1-1	DNA-directed RNA polymerase II subunit 1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.01g162200
-NRPB1-2	DNA-directed RNA polymerase II subunit 1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.11g081200
-NRT1-2	nitrate transporter NRT1-2	glyma.Wm82.gnm2.ann1.Glyma.17g096400
-NRT1-3	putative nitrate transporter NRT1-3	glyma.Wm82.gnm2.ann1.Glyma.10g183900
-NRT2	NRT2 protein	glyma.Wm82.gnm2.ann1.Glyma.13g323800
-NSP1	nodulation-signaling pathway 1 protein	glyma.Wm82.gnm2.ann1.Glyma.07g039400
-NSP2	nodulation-signaling pathway 2 protein	glyma.Wm82.gnm2.ann1.Glyma.04g251900
-NTF2B-1	nucleus transporter2B gene 1	glyma.Wm82.gnm2.ann1.Glyma.08G105100
-NTF2B-2	nucleus transporter 2B gene 2	glyma.Wm82.gnm2.ann1.Glyma.05g148200
-NTF2B-3	nucleus transporter 2B gene 3	glyma.Wm82.gnm2.ann1.Glyma.11g251700
-NTF2B-4	nucleus transporter 2B gene 4	glyma.Wm82.gnm2.ann1.Glyma.18g005300
-NTF2B-5, NTF2B-6	nucleus transporter 2B gene 6	glyma.Wm82.gnm2.ann1.Glyma.02g156200
-NYC1_1	protein NON-YELLOW COLORING 1	glyma.Wm82.gnm2.ann1.Glyma.07g085700
-NYC1_2	protein NON-YELLOW COLORING 1	glyma.Wm82.gnm2.ann1.Glyma.09g191200
-O-MT	O-methyltransferase	glyma.Wm82.gnm1.ann1.Glyma07g05480
-OAS-TL1	cysteine synthase	glyma.Wm82.gnm2.ann1.Glyma.03g244800
-OAS-TL2	cysteine synthase	glyma.Wm82.gnm2.ann1.Glyma.20g148100
-OAS-TL3	OAS-TL3 cysteine synthase	glyma.Wm82.gnm2.ann1.Glyma.18g234600
-OAS-TL4	OAS-TL4 cysteine synthase	glyma.Wm82.gnm2.ann1.Glyma.07g206800
-OAS-TL6	cysteine synthase	glyma.Wm82.gnm2.ann1.Glyma.10g159700
-OAS-TL7	cysteine synthase	glyma.Wm82.gnm2.ann1.Glyma.20g228900
-ODC2	ornithine decarboxylase	glyma.Wm82.gnm2.ann1.Glyma.06g020300
-OLEO1	oleosin 1	glyma.Wm82.gnm2.ann1.Glyma.20g196600
-OLPa	osmotin-like protein, acidic	glyma.Wm82.gnm2.ann1.Glyma.11g025600
-OLPb	PR-5b protein	glyma.Wm82.gnm2.ann1.Glyma.01g217700
-OSBP	oxysterol-binding protein	glyma.Wm82.gnm2.ann1.Glyma.06g109500
-OXR17	Oxidoreductase 17	glyma.Wm82.gnm2.ann1.Glyma.17G021200
-P34	P34 probable thiol protease	glyma.Wm82.gnm2.ann1.Glyma.08g116300
-P42-1	conversion of hydroxypyruvate to glycerate	glyma.Wm82.gnm2.ann1.Glyma.20g107800
-P5CR	pyrroline-5-carboxylate reductase	glyma.Wm82.gnm2.ann1.Glyma.19g131500
-P5CS1	DELTA1-PYRROLINE-5-CARBOXYLATE SYNTHASE 1	glyma.Wm82.gnm1.ann1.Glyma01g24530
-P89	P24 oleosin isoform A	glyma.Wm82.gnm2.ann1.Glyma.19g063400
-P91	P24 oleosin isoform B	glyma.Wm82.gnm2.ann1.Glyma.16g071800
-PAA1	proteasome subunit alpha type-6	glyma.Wm82.gnm2.ann1.Glyma.06g254200
-PAE1	20S proteasome subunit	glyma.Wm82.gnm2.ann1.Glyma.10g014300
-PAL1	phenylalanine ammonia-lyase 1	glyma.Wm82.gnm1.ann1.Glyma02g47940
-PAL1.1	phenylalanine ammonia-lyase 1.1	glyma.Wm82.gnm2.ann1.Glyma.19g182300
-PAL1.2	phenylalanine ammonia-lyase 1	glyma.Wm82.gnm2.ann1.Glyma.03g181700
-PAL1.3	phenylalanine ammonia-lyase 1	glyma.Wm82.gnm2.ann1.Glyma.03g181600
-PAL2.1	phenylalanine ammonia-lyase 2.1	glyma.Wm82.gnm2.ann1.Glyma.10g058200
-PAL2.2	phenylalanine ammonia-lyase 2.2	glyma.Wm82.gnm2.ann1.Glyma.20g180800
-PAL2.3	phenylalanine ammonia-lyase 2.3	glyma.Wm82.gnm2.ann1.Glyma.13g145000
-PAL2.4	phenylalanine ammonia-lyase 2.4	glyma.Wm82.gnm2.ann1.Glyma.10g209800
-PAL3.1	phenylalanine ammonia-lyase 3.1	glyma.Wm82.gnm2.ann1.Glyma.02g309300
-PAO1	peroxisomal copper-containing amine oxidase	glyma.Wm82.gnm2.ann1.Glyma.08g282800
-PAP01	purple acid phosphatase 18-like	glyma.Wm82.gnm2.ann1.Glyma.08g314800
-PAP02	multiple inositol polyphosphate phosphatase 1-like	glyma.Wm82.gnm2.ann1.Glyma.18g024700
-PAP10	Purple acid phosphatase gene 10	glyma.Wm82.gnm1.ann1.Glyma05g33640
-PAP11	Purple acid phosphatase 11 gene	glyma.Wm82.gnm1.ann1.Glyma06g03100
-PAP13, PAP13 	Purple acid phosphatase gene 12	glyma.Wm82.gnm1.ann1.Glyma08g06090
-PAP16	Purple acid phosphatase 16 gene	glyma.Wm82.gnm1.ann1.Glyma08g09910
-PAP18	Purple acid phosphatase 18 gene	glyma.Wm82.gnm1.ann1.Glyma08g42670
-PAP19	Purple acid phosphatase 19 gene	glyma.Wm82.gnm1.ann1.Glyma08g46550
-PAP2	Purple acid phosphatase gene 2	glyma.Wm82.gnm1.ann1.Glyma02g45950
-PAP20	Purple acid phosphatase gene 20	glyma.Wm82.gnm1.ann1.Glyma09g36360
-PAP23	Purple acid phosphatase gene 23	glyma.Wm82.gnm1.ann1.Glyma12g01000
-PAP24	Purple acid phosphatase 24 gene	glyma.Wm82.gnm1.ann1.Glyma12g34960
-PAP27	Purple acid phosphatase gene 27	glyma.Wm82.gnm1.ann1.Glyma14g02790
-PAP28	Purple acid phosphatase 28 gene	glyma.Wm82.gnm1.ann1.Glyma17g11790
-PAP29	Purple acid phosphatase 29 gene	glyma.Wm82.gnm1.ann1.Glyma18g00410
-PAP32	Purple acid phosphatase 32 gene	glyma.Wm82.gnm1.ann1.Glyma19g37850
-PAP33	Purple acid phosphatase 33 gene	glyma.Wm82.gnm1.ann1.Glyma19g37860
-PAP34	Purple acid phosphatase 34 gene	glyma.Wm82.gnm1.ann1.Glyma20g01470
-PAP35	Purple acid phosphatase 35 gene	glyma.Wm82.gnm1.ann1.Glyma20g03260
-PAP36	purple acid phosphatase 36	glyma.Wm82.gnm2.ann1.Glyma.12g007500
-PAP4	Purple acid phosphatase gene 4	glyma.Wm82.gnm1.ann1.Glyma03g35200
-PAP5	Purple acid phosphatase 5 gene	glyma.Wm82.gnm1.ann1.Glyma04g37180
-PAP6	Purple acid phosphatase 6 gene	glyma.Wm82.gnm1.ann1.Glyma05g03320
-PAP7	Purple acid phosphatase gene 7	glyma.Wm82.gnm1.ann1.Glyma05g26920
-PAP8	Purple acid phosphatase gene 8	glyma.Wm82.gnm1.ann1.Glyma05g26930
-PARP3	seed maturation protein PM38	glyma.Wm82.gnm2.ann1.Glyma.12g088300
-PB1	octicosapeptide/Phox/Bem1p (PB1) domain-containing protein  	glyma.Wm82.gnm1.ann1.Glyma13g32730
-PBS3	avrPphB susceptible 3	glyma.Wm82.gnm1.ann1.Glyma03g30590
-PC7	peroxidase	glyma.Wm82.gnm2.ann1.Glyma.06g302600
-PCS1	homo-phytochelatin synthase	glyma.Wm82.gnm2.ann1.Glyma.03g165000
-PDF	serine/threonine-protein phosphatase 2A regulatory subunit A gene	glyma.Wm82.gnm2.ann1.Glyma.20G114000
-PDH1	prephenate dehydrogenase 1	glyma.Wm82.gnm2.ann1.Glyma.18g023100
-PDH2	prephenate dehydrogenase 2	glyma.Wm82.gnm2.ann1.Glyma.11g233900
-PDIL	protein disulfide isomerase	glyma.Wm82.gnm2.ann1.Glyma.06G114800
-PDIL-2	protein disulfide isomerase-like protein	glyma.Wm82.gnm2.ann1.Glyma.12g172800
-PDIM-1	protein disulfide isomerse like protein	glyma.Wm82.gnm2.ann1.Glyma.14g050600
-PDIQ-1A	protein disulfide family pdiq-1a	glyma.Wm82.gnm2.ann1.Glyma.20g124700
-PDIS-2	protein disulfide isomerase-like protein	glyma.Wm82.gnm2.ann1.Glyma.19g229000
-PDK3	mitochondrial pyruvate dehydrogenase E1alpha-kinase 3	glyma.Wm82.gnm2.ann1.Glyma.17g040500
-PDR12	PDR-like ABC-transporter	glyma.Wm82.gnm2.ann1.Glyma.03g168000
-PDS1	phytoene desaturase	glyma.Wm82.gnm2.ann1.Glyma.18g003900
-PEAMT1	Phosphoethanolamine methyltransferase 1	glyma.Wm82.gnm1.ann1.Glyma05g33790
-PEAMT2	Phosphoethanolamine methyltransferase 2	glyma.Wm82.gnm1.ann1.Glyma07g11580
-PEPC, PEPC15, PEPCase	phosphoenolpyruvate carboxylase	glyma.Wm82.gnm2.ann1.Glyma.12g229400
-PEPC16	phosphoenolpyruvate carboxylase	glyma.Wm82.gnm2.ann1.Glyma.12G161300
-PEPC17, ppc17	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.10G205500
-PER1	peroxidase	glyma.Wm82.gnm2.ann1.Glyma.18g055300
-PERK1	putative receptor protein kinase PERK1	glyma.Wm82.gnm2.ann1.Glyma.09g191300
-PETC	Rieske iron-sulphur protein precursor	glyma.Wm82.gnm2.ann1.Glyma.12g199400
-PEX14	peroxisomal membrane protein PEX14	glyma.Wm82.gnm2.ann1.Glyma.06g182600
-PG11	polygalacturonase precursor	glyma.Wm82.gnm2.ann1.Glyma.12g012200
-PG7	polygalacturonase precursor	glyma.Wm82.gnm2.ann1.Glyma.05g133400
-PGIP1	polygalacturonase inhibitor 1 gene	glyma.Wm82.gnm2.ann1.Glyma.05g124000
-PGIP2	polygalacturonase inhibitor 2 gene	glyma.Wm82.gnm2.ann1.Glyma.05g123900
-PGIP3	polygalacturonase inhibitor 3 gene	glyma.Wm82.gnm2.ann1.Glyma.08g079100
-PGIP4	polygalacturonase inhibitor 4 gene	glyma.Wm82.gnm2.ann1.Glyma.08g079200
-PGLCAT8	glycosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.11g053000
-PGM	phosphoglycerate mutase-like protein	glyma.Wm82.gnm2.ann1.Glyma.04g090300
-PGM1	phosphoglucomutase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.03g042000
-PGM2, PGMb	beta-phosphoglucomutase-like	glyma.Wm82.gnm2.ann1.Glyma.08g044100
-PGM3	phosphoglucomutase 3 gene	glyma.Wm82.gnm2.ann1.Glyma.10g241000
-PGM4	Phosphoglucomutase 4 gene	glyma.Wm82.gnm2.ann1.Glyma.20g153600
-PGM5	phosphoglucomutase 5 gene	glyma.Wm82.gnm2.ann1.Glyma.20g179900
-PGMPM10	51 kDa seed maturation protein	glyma.Wm82.gnm2.ann1.Glyma.13g119400
-PGMPM18	35 kDa seed maturation protein	glyma.Wm82.gnm2.ann1.Glyma.03g189200
-PGMPM19	type 4 metallothionein MT4	glyma.Wm82.gnm2.ann1.Glyma.08g346600
-PGN	polygalacturonase	glyma.Wm82.gnm2.ann1.Glyma.u016300
-PGYRP7	proline/glycine/tyrosine-rich protein	glyma.Wm82.gnm2.ann1.Glyma.15g060400
-PHA1	plasma membrane H+-ATPase gene 1	glyma.Wm82.gnm1.ann1.Glyma19g35930
-PHAN3	MYB/HD-like transcription factor	glyma.Wm82.gnm2.ann1.Glyma.18g181300
-PHANa	phantastica transcription factor a	glyma.Wm82.gnm2.ann1.Glyma.07g132400
-PHANb	phantastica transcription factor b	glyma.Wm82.gnm2.ann1.Glyma.03g081900
-PHD4	PHD finger superfamily protein	glyma.Wm82.gnm2.ann1.Glyma.14g099700
-PHD6	PHD finger protein GmPHD6	glyma.Wm82.gnm2.ann1.Glyma.09g068500
-PHO1-H1	phosphate transporter PHO1-like	glyma.Wm82.gnm2.ann1.Glyma.02g003700
-PHO1-H10, PHO1;H10	Phosphate responsive 1 gene H10	glyma.Wm82.gnm2.ann1.Glyma.20G032500
-PHO1-H11	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.20g032600
-PHO1-H12	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.01g091800
-PHO1-H13	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.02g110600
-PHO1-H14	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.02g130200
-PHO1-H2	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.07g228400
-PHO1-H3	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.09g235200
-PHO1-H4	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.10g004800
-PHO1-H5	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.10g183300
-PHO1-H6	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.18g261900
-PHO1-H7	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.20g031700
-PHO1-H8	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.20g206900
-PHO1-H9, PHO1;H9	phosphate responsive 1 gene H9	glyma.Wm82.gnm2.ann1.Glyma.20G032400
-PHP1	Ubiquitous, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma07g03390
-PHP2	Root Preferential, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma08g22720
-PHP3	Root Specific, Phosphotransfer Protein	glyma.Wm82.gnm1.ann1.Glyma15g01010
-PHR	CPD photolyase	glyma.Wm82.gnm2.ann1.Glyma.11g029500
-PHR1	MYB-CC domain-containing transcription factor PHR1	glyma.Wm82.gnm2.ann1.Glyma.01g009600
-PHR10	MYB-CC domain-containing transcription factor PHR10	glyma.Wm82.gnm2.ann1.Glyma.03g250000
-PHR11	MYB-CC domain-containing transcription factor PHR11	glyma.Wm82.gnm2.ann1.Glyma.07g229800
-PHR12	MYB-CC domain-containing transcription factor PHR12	glyma.Wm82.gnm2.ann1.Glyma.08g163500
+C2-88	C2 domain containing protein gene 88	glyma.Wm82.gnm2.ann1.Glyma.09G014700
+C2-89	C2 domain containing protein gene 89	glyma.Wm82.gnm2.ann1.Glyma.09G015700
+RAB2	guanine nucleotide regulatory protein	glyma.Wm82.gnm2.ann1.Glyma.09g016700
 PHR13	MYB-CC domain-containing transcription factor PHR13	glyma.Wm82.gnm2.ann1.Glyma.09g017300
 PHR14	MYB-CC domain-containing transcription factor PHR14	glyma.Wm82.gnm2.ann1.Glyma.09g017400
-PHR15	MYB-CC domain-containing transcription factor PHR15	glyma.Wm82.gnm2.ann1.Glyma.09g113000
-PHR16	MYB-CC domain-containing transcription factor PHR16	glyma.Wm82.gnm2.ann1.Glyma.09g211400
-PHR17	MYB-CC domain-containing transcription factor PHR17	glyma.Wm82.gnm2.ann1.Glyma.10g039700
-PHR18	MYB-CC domain-containing transcription factor PHR18	glyma.Wm82.gnm2.ann1.Glyma.10g196600
-PHR19	MYB-CC domain-containing transcription factor PHR19	glyma.Wm82.gnm2.ann1.Glyma.11g1834001
-PHR2	MYB-CC domain-containing transcription factor PHR2	glyma.Wm82.gnm2.ann1.Glyma.01g049100
-PHR20	MYB-CC domain-containing transcription factor PHR20	glyma.Wm82.gnm2.ann1.Glyma.12g089100
-PHR21	MYB-CC domain-containing transcription factor PHR21	glyma.Wm82.gnm2.ann1.Glyma.12g184700
-PHR22	MYB-CC domain-containing transcription factor PHR22	glyma.Wm82.gnm2.ann1.Glyma.13g126200
-PHR23	MYB-CC domain-containing transcription factor PHR23	glyma.Wm82.gnm2.ann1.Glyma.13g316600
-PHR24	MYB-CC domain-containing transcription factor PHR24	glyma.Wm82.gnm2.ann1.Glyma.15g123000
-PHR25	MYB-CC domain-containing transcription factor PHR25	glyma.Wm82.gnm2.ann1.Glyma.15g123100
-PHR26	MYB-CC domain-containing transcription factor PHR26	glyma.Wm82.gnm2.ann1.Glyma.15g215000
-PHR27	MYB-CC domain-containing transcription factor PHR27	glyma.Wm82.gnm2.ann1.Glyma.15g263700
-PHR28	MYB-CC domain-containing transcription factor PHR28	glyma.Wm82.gnm2.ann1.Glyma.16g152200
-PHR29	MYB-CC domain-containing transcription factor PHR29	glyma.Wm82.gnm2.ann1.Glyma.18g201800
-PHR3	MYB-CC domain-containing transcription factor PHR3	glyma.Wm82.gnm2.ann1.Glyma.02g070900
-PHR30	MYB-CC domain-containing transcription factor PHR30	glyma.Wm82.gnm2.ann1.Glyma.19g122700
-PHR31	MYB-CC domain-containing transcription factor PHR31	glyma.Wm82.gnm2.ann1.Glyma.19g146600
-PHR32	MYB-CC domain-containing transcription factor PHR32	glyma.Wm82.gnm2.ann1.Glyma.19g167500
-PHR33	MYB-CC domain-containing transcription factor PHR33	glyma.Wm82.gnm2.ann1.Glyma.19g247600
-PHR34	MYB-CC domain-containing transcription factor PHR34	glyma.Wm82.gnm2.ann1.Glyma.20g035300
-PHR35	MYB-CC domain-containing transcription factor PHR35	glyma.Wm82.gnm2.ann1.Glyma.20g193600
-PHR4	MYB-CC domain-containing transcription factor PHR4	glyma.Wm82.gnm2.ann1.Glyma.02g108500
-PHR5	MYB-CC domain-containing transcription factor PHR5	glyma.Wm82.gnm2.ann1.Glyma.02g177800
-PHR6	MYB-CC domain-containing transcription factor PHR6	glyma.Wm82.gnm2.ann1.Glyma.02g178100
-PHR7	MYB-CC domain-containing transcription factor PHR7	glyma.Wm82.gnm2.ann1.Glyma.03g003500
-PHR8	MYB-CC domain-containing transcription factor PHR8	glyma.Wm82.gnm2.ann1.Glyma.03g143600
-PHR9	MYB-CC domain-containing transcription factor PHR9	glyma.Wm82.gnm2.ann1.Glyma.03g166400
-PHT1-1	inorganic phosphate transporter 1-1	glyma.Wm82.gnm2.ann1.Glyma.10g186500
-PHT1-10	inorganic phosphate transporter 1-10	glyma.Wm82.gnm2.ann1.Glyma.20g204100
-PHT1-11	inorganic phosphate transporter 1-11	glyma.Wm82.gnm2.ann1.Glyma.14g188000
-PHT1-12	inorganic phosphate transporter 1-12	glyma.Wm82.gnm2.ann1.Glyma.14g123500
-PHT1-13	inorganic phosphate transporter 1-13	glyma.Wm82.gnm2.ann1.Glyma.13g040200
-PHT1-14	inorganic phosphate transporter 1-14	glyma.Wm82.gnm2.ann1.Glyma.02g005800
-PHT1-2	inorganic phosphate transporter 1-2	glyma.Wm82.gnm2.ann1.Glyma.03g162800
-PHT1-3	inorganic phosphate transporter 1-3	glyma.Wm82.gnm2.ann1.Glyma.10g006700
-PHT1-4	inorganic phosphate transporter 1-4	glyma.Wm82.gnm2.ann1.Glyma.10g036800
-PHT1-5	inorganic phosphate transporter 1-5	glyma.Wm82.gnm2.ann1.Glyma.20g204000
-PHT1-6	inorganic phosphate transporter 1-6	glyma.Wm82.gnm2.ann1.Glyma.10g186400
-PHT1-7	inorganic phosphate transporter 1-7	glyma.Wm82.gnm2.ann1.Glyma.19g164300
-PHT1-8	inorganic phosphate transporter 1-8	glyma.Wm82.gnm2.ann1.Glyma.20g021600
-PHT1-9	inorganic phosphate transporter 1-9	glyma.Wm82.gnm2.ann1.Glyma.07g222700
-PHYA, PHYA1	Phytochrome A gene 1	glyma.Wm82.gnm2.ann1.Glyma.10g141400
-PHYA2	Phytochrome A gene 2	glyma.Wm82.gnm2.ann1.Glyma.20g090000
-PHYA3	Phytochrome A gene 3	glyma.Wm82.gnm2.ann1.Glyma.19g224200
-PHYA4	Phytochrome A gene 4	glyma.Wm82.gnm1.ann1.Glyma03g38620
+CEL12	endo-1,4-beta-glucancase	glyma.Wm82.gnm2.ann1.Glyma.09g018500
+VAMP721D	vesicle-associated membrane protein 721d	glyma.Wm82.gnm2.ann1.Glyma.09g019800
+RTRP3	reverse transcriptase-like domain-containing RBR protein	glyma.Wm82.gnm2.ann1.Glyma.09g020000
+Ep, PRX1, SPOD4.1	Ep, peroxidase	glyma.Wm82.gnm2.ann1.Glyma.09g022300
+bZIP70	Basic leucine zipper transcription factor-like protein gene 70	glyma.Wm82.gnm2.ann1.Glyma.09G023600
+NF-YA08	nuclear transcription factor Y subunit A-8	glyma.Wm82.gnm2.ann1.Glyma.09g023800
+C2-90	C2 domain containing protein gene 90	glyma.Wm82.gnm2.ann1.Glyma.09G024400
+CrRI,k1l,08	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.09G024700
+DCL2, DCL2B	endoribonuclease dicer-like 2b	glyma.Wm82.gnm2.ann1.Glyma.09g025300
+DCL2A	endoribonuclease dicer-like 2a	glyma.Wm82.gnm2.ann1.Glyma.09g025400
+MYB55	MYB transcription factor	glyma.Wm82.gnm2.ann1.Glyma.09g029300
+WRKY90	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.09G029800
+COPE2	epsilon2-COP	glyma.Wm82.gnm2.ann1.Glyma.09g030400
+WRKY26, WRKY91	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.09G034300
 PHYB, PHYB1	Phytochrome B gene 1	glyma.Wm82.gnm2.ann1.Glyma.09g035500
-PHYB2	Phytochrome B gene 2	glyma.Wm82.gnm2.ann1.Glyma.15g140000
-PHYE1	Phytochrome E gene 1	glyma.Wm82.gnm2.ann1.Glyma.09g088500
-PHYE2	Phytochrome E gene 2	glyma.Wm82.gnm2.ann1.Glyma.15g196500
-PHYTASE	purple acid phosphatase 18-like	glyma.Wm82.gnm2.ann1.Glyma.14g024700
-PIF3	bHLH transcription factor PIF3	glyma.Wm82.gnm2.ann1.Glyma.19g222000
-PIN1d	PIN-formed 1 gene d	glyma.Wm82.gnm2.ann1.Glyma.03G126000
-PIN1e	PIN-formed 1 gene e	glyma.Wm82.gnm2.ann1.Glyma.19G128800
-PIN5b	PIN-formed 5 gene b	glyma.Wm82.gnm2.ann1.Glyma.18G241000
-PIN8a	PIN-formed 8 gene a	glyma.Wm82.gnm2.ann1.Glyma.05G109800
-PIN8b	PIN-formed 8 gene b	glyma.Wm82.gnm2.ann1.Glyma.17G157300
-PIN8c	PIN-formed 8 gene c	glyma.Wm82.gnm2.ann1.Glyma.09G240500
-PIN8d	PIN-formed 8 gene d	glyma.Wm82.gnm2.ann1.Glyma.18G255800
-PIN9a	PIN-formed 9 gene a	glyma.Wm82.gnm2.ann1.Glyma.09G061800
-PIN9b	PIN-formed 9 gene b	glyma.Wm82.gnm2.ann1.Glyma.15G168100
-PIN9d	PIN-formed 9 gene d	glyma.Wm82.gnm2.ann1.Glyma.15G208600
-PIP1-1	aquaporin PIP1-1	glyma.Wm82.gnm2.ann1.Glyma.03g078700
-PIP1-10	aquaporin PIP1-10	glyma.Wm82.gnm2.ann1.Glyma.02g255000
-PIP1-2	aquaporin PIP1-2	glyma.Wm82.gnm2.ann1.Glyma.18g198300
-PIP1-3	aquaporin PIP1-3	glyma.Wm82.gnm2.ann1.Glyma.01g220600
-PIP1-4	aquaporin PIP1-4	glyma.Wm82.gnm2.ann1.Glyma.11g023200
-PIP1-6	aquaporin PIP1-6	glyma.Wm82.gnm2.ann1.Glyma.08g015300
-PIP1-7	aquaporin PIP1-7	glyma.Wm82.gnm2.ann1.Glyma.14g061500
-PIP1-8	aquaporin PIP1-8	glyma.Wm82.gnm2.ann1.Glyma.11g228000
-PIP1-9	aquaporin PIP1-9	glyma.Wm82.gnm2.ann1.Glyma.01g113400
-PIP1:6	Plasma membrane intrinsic protein 1 gene 6	glyma.Wm82.gnm1.ann1.Glyma08g08160
-PIP2-1	aquaporin PIP2-1	glyma.Wm82.gnm2.ann1.Glyma.04g003200
-PIP2-10	aquaporin PIP2-10	glyma.Wm82.gnm2.ann1.Glyma.16g155000
-PIP2-11	aquaporin PIP2-11	glyma.Wm82.gnm2.ann1.Glyma.16g155100
-PIP2-12	aquaporin PIP2-12	glyma.Wm82.gnm2.ann1.Glyma.02g073700
-PIP2-13	aquaporin PIP2-13	glyma.Wm82.gnm2.ann1.Glyma.10g211000
-PIP2-14	aquaporin PIP2-14	glyma.Wm82.gnm2.ann1.Glyma.20g179700
-PIP2-2	aquaporin PIP2-2	glyma.Wm82.gnm2.ann1.Glyma.06g003200
-PIP2-3	aquaporin PIP2-3	glyma.Wm82.gnm2.ann1.Glyma.11g146500
-PIP2-4	aquaporin PIP2-4	glyma.Wm82.gnm2.ann1.Glyma.12g075400
-PIP2-5	aquaporin PIP2-5	glyma.Wm82.gnm2.ann1.Glyma.12g172500
-PIP2-6	aquaporin PIP2-6	glyma.Wm82.gnm2.ann1.Glyma.13g325900
-PIP2-7	aquaporin PIP2-7	glyma.Wm82.gnm2.ann1.Glyma.03g180900
-PIP2-8	aquaporin PIP2-8	glyma.Wm82.gnm2.ann1.Glyma.19g181300
-PIP2-9	aquaporin PIP2-9	glyma.Wm82.gnm2.ann1.Glyma.02g073600
-PIa	Pistillata gene a	glyma.Wm82.gnm2.ann1.Glyma.13G034100
-PIb	Pistillata gene b	glyma.Wm82.gnm2.ann1.Glyma.04G245500
-PIc	Pistillata gene c	glyma.Wm82.gnm2.ann1.Glyma.14G155100
-PK3	pyruvate kinase	glyma.Wm82.gnm2.ann1.Glyma.20g024800
-PK6	protein kinase	glyma.Wm82.gnm2.ann1.Glyma.15g074900
-PKR19	protein kinase R	glyma.Wm82.gnm2.ann1.Glyma.19G193100
-PLA1-IId	Phospholipase A1-Iid	glyma.Wm82.gnm1.ann1.Glyma12G15430
-PLD-gamma	Phospholipase D gamma	glyma.Wm82.gnm1.ann1.Glyma01g42420
-PLDZ	phospholipase D p1-like	glyma.Wm82.gnm2.ann1.Glyma.20g238000
-PLDZ1	PHOSPHOLIPASE D ZETA1	glyma.Wm82.gnm1.ann1.Glyma20g38200
-PLM	putative sphingomyelin synthase family protein	glyma.Wm82.gnm2.ann1.Glyma.20g167800
-PLMT	phospholipid N-methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.08g218900
-PLP1	PAS/LOV protein 1	glyma.Wm82.gnm2.ann1.Glyma.02g022000
-PLP2	proteolipid protein 2 (colonic epithelium-enriched)	glyma.Wm82.gnm2.ann1.Glyma.01g042300
-PM1	Late embryogenesis abundant protein 1 gene	glyma.Wm82.gnm2.ann1.Glyma.19g147200
-PM12	dehydrin	glyma.Wm82.gnm2.ann1.Glyma.04g009900
-PM13	Ca+2-binding EF hand protein	glyma.Wm82.gnm2.ann1.Glyma.10g189900
-PM16	Late embryogenesis abundant protein 16 gene	glyma.Wm82.gnm2.ann1.Glyma.17g155000
-PM23	seed maturation protein PM23	glyma.Wm82.gnm2.ann1.Glyma.10g260200
-PM24	seed maturation protein PM24	glyma.Wm82.gnm2.ann1.Glyma.10g247500
-PM25	seed maturation protein PM25	glyma.Wm82.gnm2.ann1.Glyma.20g147600
-PM27	seed maturation protein PM27	glyma.Wm82.gnm2.ann1.Glyma.12g001600
-PM28	seed maturation protein PM28	glyma.Wm82.gnm2.ann1.Glyma.08g172800
-PM29	seed maturation protein	glyma.Wm82.gnm2.ann1.Glyma.05g112000
-PM3	maturation protein PM3	glyma.Wm82.gnm2.ann1.Glyma.10g205900
-PM30	Seed maturation protein 30 gene	glyma.Wm82.gnm2.ann1.Glyma.13g363300
-PM31	seed maturation protein PM31	glyma.Wm82.gnm2.ann1.Glyma.02g076600
-PM32	maturation protein pPM32	glyma.Wm82.gnm2.ann1.Glyma.13g237700
-PM34	seed maturation protein PM34	glyma.Wm82.gnm2.ann1.Glyma.20g233000
-PM35	seed maturation protein PM35	glyma.Wm82.gnm2.ann1.Glyma.17g164200
-PM37	seed maturation protein PM37	glyma.Wm82.gnm2.ann1.Glyma.12g095700
-PM39	seed maturation protein PM39	glyma.Wm82.gnm2.ann1.Glyma.09g139600
-PM40	seed maturation protein PM40	glyma.Wm82.gnm2.ann1.Glyma.05g055700
-PM41	seed maturation protein PM41	glyma.Wm82.gnm2.ann1.Glyma.08g160800
-PM9	late embryogenesis abundant group 4 protein PM9	glyma.Wm82.gnm2.ann1.Glyma.03g144400
-POD	peroxidase	glyma.Wm82.gnm2.ann1.Glyma.02g171600
-POLD1	DNA polymerase delta	glyma.Wm82.gnm2.ann1.Glyma.04g210700
-POT	proton-dependent oligopeptide transport  family protein  	glyma.Wm82.gnm1.ann1.Glyma17g25390
-PP2C	protein phosphatase 2C	glyma.Wm82.gnm1.ann1.Glyma14g32430
-PP2C;L1	phloem-specific pumpkin2C gene L1	glyma.Wm82.gnm2.ann1.Glyma.20G207600
-PP2C;L2	phloem-specific pumpkin2C gene L2	glyma.Wm82.gnm2.ann1.Glyma.06G059700
-PPR1	Psudo-Response Regulator gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G003400
-PPR10	Psudo-Response Regulator gene 10	glyma.Wm82.gnm2.ann1.Glyma.01G237100
-PPR100	Psudo-Response Regulator gene 100	glyma.Wm82.gnm2.ann1.Glyma.09G286300
-PPR101	Psudo-Response Regulator gene 101	glyma.Wm82.gnm2.ann1.Glyma.10G018100
-PPR102	Psudo-Response Regulator gene 102	glyma.Wm82.gnm2.ann1.Glyma.10G074100
-PPR103	Psudo-Response Regulator gene 103	glyma.Wm82.gnm2.ann1.Glyma.10G093800
-PPR104	Psudo-Response Regulator gene 104	glyma.Wm82.gnm2.ann1.Glyma.10G190600
-PPR105	Psudo-Response Regulator gene 105	glyma.Wm82.gnm2.ann1.Glyma.10G230100
-PPR106	Psudo-Response Regulator gene 106	glyma.Wm82.gnm2.ann1.Glyma.10G247700
-PPR107	Psudo-Response Regulator gene 107	glyma.Wm82.gnm2.ann1.Glyma.10G258200
-PPR108	Psudo-Response Regulator gene 108	glyma.Wm82.gnm2.ann1.Glyma.10G277600
-PPR109	Psudo-Response Regulator gene 109	glyma.Wm82.gnm2.ann1.Glyma.11G006200
-PPR11	Psudo-Response Regulator gene 11	glyma.Wm82.gnm2.ann1.Glyma.02G071600
-PPR110	Psudo-Response Regulator gene 110	glyma.Wm82.gnm2.ann1.Glyma.11G007200
-PPR111	Psudo-Response Regulator gene 111	glyma.Wm82.gnm2.ann1.Glyma.11G008800
-PPR112	Psudo-Response Regulator gene 112	glyma.Wm82.gnm2.ann1.Glyma.11G013400
-PPR113	Psudo-Response Regulator gene 113	glyma.Wm82.gnm2.ann1.Glyma.11G213300
-PPR114	Psudo-Response Regulator gene 114	glyma.Wm82.gnm2.ann1.Glyma.11G254200
-PPR115	Psudo-Response Regulator gene 115	glyma.Wm82.gnm2.ann1.Glyma.12G009800
-PPR116	Psudo-Response Regulator gene 116	glyma.Wm82.gnm2.ann1.Glyma.12G102800
-PPR117	Psudo-Response Regulator gene 117	glyma.Wm82.gnm2.ann1.Glyma.12G115500
-PPR118	Psudo-Response Regulator gene 118	glyma.Wm82.gnm2.ann1.Glyma.12G118200
-PPR119	Psudo-Response Regulator gene 119	glyma.Wm82.gnm2.ann1.Glyma.12G146900
-PPR12	Psudo-Response Regulator gene 12	glyma.Wm82.gnm2.ann1.Glyma.02G102000
-PPR120	Psudo-Response Regulator gene 120	glyma.Wm82.gnm2.ann1.Glyma.12G183600
-PPR121	Psudo-Response Regulator gene 121	glyma.Wm82.gnm2.ann1.Glyma.12G184200
-PPR122	Psudo-Response Regulator gene 122	glyma.Wm82.gnm2.ann1.Glyma.12G239300
-PPR123	Psudo-Response Regulator gene 123	glyma.Wm82.gnm2.ann1.Glyma.13G060800
-PPR125	Psudo-Response Regulator gene 125	glyma.Wm82.gnm2.ann1.Glyma.13G119700
-PPR126	Psudo-Response Regulator gene 126	glyma.Wm82.gnm2.ann1.Glyma.13G121800
-PPR127	Psudo-Response Regulator gene 127	glyma.Wm82.gnm2.ann1.Glyma.13G179700
-PPR128	Psudo-Response Regulator gene 128	glyma.Wm82.gnm2.ann1.Glyma.13G220400
-PPR129	Psudo-Response Regulator gene 129	glyma.Wm82.gnm2.ann1.Glyma.13G332400
-PPR13	Psudo-Response Regulator gene 13	glyma.Wm82.gnm2.ann1.Glyma.02G118600
-PPR130	Psudo-Response Regulator gene 130	glyma.Wm82.gnm2.ann1.Glyma.13G345000
-PPR131	Psudo-Response Regulator gene 131	glyma.Wm82.gnm2.ann1.Glyma.14G003900
-PPR132	Psudo-Response Regulator gene 132	glyma.Wm82.gnm2.ann1.Glyma.14G184600
-PPR133	Psudo-Response Regulator gene 133	glyma.Wm82.gnm2.ann1.Glyma.14G194400
-PPR134	Psudo-Response Regulator gene 134	glyma.Wm82.gnm2.ann1.Glyma.14G224400
-PPR135	Psudo-Response Regulator gene 135	glyma.Wm82.gnm2.ann1.Glyma.15G016600
-PPR136	Psudo-Response Regulator gene 136	glyma.Wm82.gnm2.ann1.Glyma.15G041800
-PPR137	Psudo-Response Regulator gene 137	glyma.Wm82.gnm2.ann1.Glyma.15G084700
-PPR138	Psudo-Response Regulator gene 138	glyma.Wm82.gnm2.ann1.Glyma.15G092000
-PPR139	Psudo-Response Regulator gene 139	glyma.Wm82.gnm2.ann1.Glyma.15G156600
-PPR14	Psudo-Response Regulator gene 14	glyma.Wm82.gnm2.ann1.Glyma.02G133100
-PPR140	Psudo-Response Regulator gene 140	glyma.Wm82.gnm2.ann1.Glyma.15G254800
-PPR141	Psudo-Response Regulator gene 141	glyma.Wm82.gnm2.ann1.Glyma.15G272100
-PPR142	Psudo-Response Regulator gene 142	glyma.Wm82.gnm2.ann1.Glyma.15G273200
-PPR143	Psudo-Response Regulator gene 143	glyma.Wm82.gnm2.ann1.Glyma.15G277000
-PPR144	Psudo-Response Regulator gene 144	glyma.Wm82.gnm2.ann1.Glyma.16G026000
-PPR145	Psudo-Response Regulator gene 145	glyma.Wm82.gnm2.ann1.Glyma.16G049100
-PPR146	Psudo-Response Regulator gene 146	glyma.Wm82.gnm2.ann1.Glyma.16G049800
-PPR147	Psudo-Response Regulator gene 147	glyma.Wm82.gnm2.ann1.Glyma.16G152800
-PPR148	Psudo-Response Regulator gene 148	glyma.Wm82.gnm2.ann1.Glyma.16G161800
-PPR149	Psudo-Response Regulator gene 149	glyma.Wm82.gnm2.ann1.Glyma.16G172800
-PPR15	Psudo-Response Regulator gene 15	glyma.Wm82.gnm2.ann1.Glyma.02G144100
-PPR150	Psudo-Response Regulator gene 150	glyma.Wm82.gnm2.ann1.Glyma.16G218400
-PPR151	Psudo-Response Regulator gene 151	glyma.Wm82.gnm2.ann1.Glyma.17G024900
-PPR152	Psudo-Response Regulator gene 152	glyma.Wm82.gnm2.ann1.Glyma.17G072100
-PPR153	Psudo-Response Regulator gene 153	glyma.Wm82.gnm2.ann1.Glyma.17G099500
-PPR154	Psudo-Response Regulator gene 154	glyma.Wm82.gnm2.ann1.Glyma.17G100500
-PPR155	Psudo-Response Regulator gene 155	glyma.Wm82.gnm2.ann1.Glyma.17G117000
-PPR156	Psudo-Response Regulator gene 156	glyma.Wm82.gnm2.ann1.Glyma.17G146000
-PPR157	Psudo-Response Regulator gene 157	glyma.Wm82.gnm2.ann1.Glyma.17G165800
-PPR158	Psudo-Response Regulator gene 158	glyma.Wm82.gnm2.ann1.Glyma.17G209700
-PPR159	Psudo-Response Regulator gene 159	glyma.Wm82.gnm2.ann1.Glyma.17G220100
-PPR16	Psudo-Response Regulator gene 16	glyma.Wm82.gnm2.ann1.Glyma.02G160400
-PPR160	Psudo-Response Regulator gene 160	glyma.Wm82.gnm2.ann1.Glyma.17G262700
-PPR161	Psudo-Response Regulator gene 161	glyma.Wm82.gnm2.ann1.Glyma.18G085900
-PPR162	Psudo-Response Regulator gene 162	glyma.Wm82.gnm2.ann1.Glyma.18G094700
-PPR163	Psudo-Response Regulator gene 163	glyma.Wm82.gnm2.ann1.Glyma.18G126700
-PPR164	Psudo-Response Regulator gene 164	glyma.Wm82.gnm2.ann1.Glyma.18G128100
-PPR165	Psudo-Response Regulator gene 165	glyma.Wm82.gnm2.ann1.Glyma.18G225600
-PPR166	Psudo-Response Regulator gene 166	glyma.Wm82.gnm2.ann1.Glyma.18G241500
-PPR167	Psudo-Response Regulator gene 167	glyma.Wm82.gnm2.ann1.Glyma.18G260300
-PPR168	Psudo-Response Regulator gene 168	glyma.Wm82.gnm2.ann1.Glyma.18G275000
-PPR169	Psudo-Response Regulator gene 169	glyma.Wm82.gnm2.ann1.Glyma.18G277000
-PPR17	Psudo-Response Regulator gene 17	glyma.Wm82.gnm2.ann1.Glyma.02G164800
-PPR170	Psudo-Response Regulator gene 170	glyma.Wm82.gnm2.ann1.Glyma.18G287500
-PPR171	Psudo-Response Regulator gene 171	glyma.Wm82.gnm2.ann1.Glyma.19G025700
-PPR172	Psudo-Response Regulator gene 172	glyma.Wm82.gnm2.ann1.Glyma.19G102300
-PPR173	Psudo-Response Regulator gene 173	glyma.Wm82.gnm2.ann1.Glyma.19G141800
-PPR174	Psudo-Response Regulator gene 174	glyma.Wm82.gnm2.ann1.Glyma.19G202500
-PPR175	Psudo-Response Regulator gene 175	glyma.Wm82.gnm2.ann1.Glyma.20G013300
-PPR176	Psudo-Response Regulator gene 176	glyma.Wm82.gnm2.ann1.Glyma.20G112100
-PPR177	Psudo-Response Regulator gene 177	glyma.Wm82.gnm2.ann1.Glyma.20G132900
-PPR178	Psudo-Response Regulator gene 178	glyma.Wm82.gnm2.ann1.Glyma.20G155800
-PPR179	Psudo-Response Regulator gene 179	glyma.Wm82.gnm2.ann1.Glyma.20G200100
-PPR18	Psudo-Response Regulator gene 18	glyma.Wm82.gnm2.ann1.Glyma.02G174500
-PPR19	Psudo-Response Regulator gene 19	glyma.Wm82.gnm2.ann1.Glyma.02G201800
-PPR2	Psudo-Response Regulator gene 2	glyma.Wm82.gnm2.ann1.Glyma.01G004400
-PPR20	Psudo-Response Regulator gene 20	glyma.Wm82.gnm2.ann1.Glyma.02G205900
-PPR21	Psudo-Response Regulator gene 21	glyma.Wm82.gnm2.ann1.Glyma.02G217200
-PPR22	Psudo-Response Regulator gene 22	glyma.Wm82.gnm2.ann1.Glyma.02G227300
-PPR23	Psudo-Response Regulator gene 23	glyma.Wm82.gnm2.ann1.Glyma.03G093000
-PPR24	Psudo-Response Regulator gene 24	glyma.Wm82.gnm2.ann1.Glyma.03G108500
-PPR25	Psudo-Response Regulator gene 25	glyma.Wm82.gnm2.ann1.Glyma.03G189000
-PPR26	Psudo-Response Regulator gene 26	glyma.Wm82.gnm2.ann1.Glyma.03G205100
-PPR27	Psudo-Response Regulator gene 27	glyma.Wm82.gnm2.ann1.Glyma.03G227900
-PPR28	Psudo-Response Regulator gene 28	glyma.Wm82.gnm2.ann1.Glyma.03G238000
-PPR29	Psudo-Response Regulator gene 29	glyma.Wm82.gnm2.ann1.Glyma.03G264700
-PPR3	Psudo-Response Regulator gene 3	glyma.Wm82.gnm2.ann1.Glyma.01G011300
-PPR30	Psudo-Response Regulator gene 30	glyma.Wm82.gnm2.ann1.Glyma.04G010200
-PPR31	Psudo-Response Regulator gene 31	glyma.Wm82.gnm2.ann1.Glyma.04G057300
-PPR32	Psudo-Response Regulator gene 32	glyma.Wm82.gnm2.ann1.Glyma.04G078800
-PPR33	Psudo-Response Regulator gene 33	glyma.Wm82.gnm2.ann1.Glyma.04G127500
-PPR34	Psudo-Response Regulator gene 34	glyma.Wm82.gnm2.ann1.Glyma.04G158200
-PPR35	Psudo-Response Regulator gene 35	glyma.Wm82.gnm2.ann1.Glyma.04G183600
-PPR36	Psudo-Response Regulator gene 36	glyma.Wm82.gnm2.ann1.Glyma.05G008800
-PPR37	Psudo-Response Regulator gene 37	glyma.Wm82.gnm2.ann1.Glyma.05G026400
-PPR38	Psudo-Response Regulator gene 38	glyma.Wm82.gnm2.ann1.Glyma.05G125500
-PPR39	Psudo-Response Regulator gene 39	glyma.Wm82.gnm2.ann1.Glyma.05G131900
-PPR4	Psudo-Response Regulator gene 4	glyma.Wm82.gnm2.ann1.Glyma.01G011700
-PPR40	Psudo-Response Regulator gene 40	glyma.Wm82.gnm2.ann1.Glyma.05G137900
-PPR41	Psudo-Response Regulator gene 41	glyma.Wm82.gnm2.ann1.Glyma.05G155200
-PPR42	Psudo-Response Regulator gene 42	glyma.Wm82.gnm2.ann1.Glyma.05G157500
-PPR43	Psudo-Response Regulator gene 43	glyma.Wm82.gnm2.ann1.Glyma.05G159700
-PPR44	Psudo-Response Regulator gene 44	glyma.Wm82.gnm2.ann1.Glyma.05G228000
-PPR45	Psudo-Response Regulator gene 45	glyma.Wm82.gnm2.ann1.Glyma.05G240300
-PPR46	Psudo-Response Regulator gene 46	glyma.Wm82.gnm2.ann1.Glyma.05G244300
-PPR47	Psudo-Response Regulator gene 47	glyma.Wm82.gnm2.ann1.Glyma.05G244400
-PPR48	Psudo-Response Regulator gene 48	glyma.Wm82.gnm2.ann1.Glyma.06G057900
-PPR49	Psudo-Response Regulator gene 49	glyma.Wm82.gnm2.ann1.Glyma.06G080500
-PPR5	Psudo-Response Regulator gene 5	glyma.Wm82.gnm2.ann1.Glyma.01G048100
-PPR50	Psudo-Response Regulator gene 50	glyma.Wm82.gnm2.ann1.Glyma.06G161900
-PPR51	Psudo-Response Regulator gene 51	glyma.Wm82.gnm2.ann1.Glyma.06G206900
-PPR52	Psudo-Response Regulator gene 52	glyma.Wm82.gnm2.ann1.Glyma.06G254600
-PPR53	Psudo-Response Regulator gene 53	glyma.Wm82.gnm2.ann1.Glyma.06G301600
-PPR54	Psudo-Response Regulator gene 54	glyma.Wm82.gnm2.ann1.Glyma.06G311600
-PPR55	Psudo-Response Regulator gene 55	glyma.Wm82.gnm2.ann1.Glyma.06G311700
-PPR56	Psudo-Response Regulator gene 56	glyma.Wm82.gnm2.ann1.Glyma.06G322500
-PPR57	Psudo-Response Regulator gene 57	glyma.Wm82.gnm2.ann1.Glyma.07G029000
-PPR58	Psudo-Response Regulator gene 58	glyma.Wm82.gnm2.ann1.Glyma.07G033300
-PPR59	Psudo-Response Regulator gene 59	glyma.Wm82.gnm2.ann1.Glyma.07G057000
-PPR6	Psudo-Response Regulator gene 6	glyma.Wm82.gnm2.ann1.Glyma.01G060400
-PPR60	Psudo-Response Regulator gene 60	glyma.Wm82.gnm2.ann1.Glyma.07G127400
-PPR61	Psudo-Response Regulator gene 61	glyma.Wm82.gnm2.ann1.Glyma.07G128600
-PPR62	Psudo-Response Regulator gene 62	glyma.Wm82.gnm2.ann1.Glyma.07G159200
-PPR63	Psudo-Response Regulator gene 63	glyma.Wm82.gnm2.ann1.Glyma.07G196400
-PPR64	Psudo-Response Regulator gene 64	glyma.Wm82.gnm2.ann1.Glyma.07G211900
-PPR65	Psudo-Response Regulator gene 65	glyma.Wm82.gnm2.ann1.Glyma.07G216300
-PPR66	Psudo-Response Regulator gene 66	glyma.Wm82.gnm2.ann1.Glyma.07G245500
-PPR67	Psudo-Response Regulator gene 67	glyma.Wm82.gnm2.ann1.Glyma.07G249400
-PPR68	Psudo-Response Regulator gene 68	glyma.Wm82.gnm2.ann1.Glyma.08G080300
-PPR69	Psudo-Response Regulator gene 69	glyma.Wm82.gnm2.ann1.Glyma.08G086500
-PPR7	Psudo-Response Regulator gene 7	glyma.Wm82.gnm2.ann1.Glyma.01G230500
-PPR70	Psudo-Response Regulator gene 70	glyma.Wm82.gnm2.ann1.Glyma.08G092900
-PPR71	Psudo-Response Regulator gene 71	glyma.Wm82.gnm2.ann1.Glyma.08G113100
-PPR72	Psudo-Response Regulator gene 72	glyma.Wm82.gnm2.ann1.Glyma.08G117400
-PPR73	Psudo-Response Regulator gene 73	glyma.Wm82.gnm2.ann1.Glyma.08G123700
-PPR74	Psudo-Response Regulator gene 74	glyma.Wm82.gnm2.ann1.Glyma.08G152900
-PPR75	Psudo-Response Regulator gene 75	glyma.Wm82.gnm2.ann1.Glyma.08G160200
-PPR76	Psudo-Response Regulator gene 76	glyma.Wm82.gnm2.ann1.Glyma.08G172500
-PPR77	Psudo-Response Regulator gene 77	glyma.Wm82.gnm2.ann1.Glyma.08G208900
-PPR78	Psudo-Response Regulator gene 78	glyma.Wm82.gnm2.ann1.Glyma.08G213800
-PPR79	Psudo-Response Regulator gene 79	glyma.Wm82.gnm2.ann1.Glyma.08G252400
-PPR8	Psudo-Response Regulator gene 8	glyma.Wm82.gnm2.ann1.Glyma.01G234100
-PPR80	Psudo-Response Regulator gene 80	glyma.Wm82.gnm2.ann1.Glyma.08G254300
-PPR81	Psudo-Response Regulator gene 81	glyma.Wm82.gnm2.ann1.Glyma.08G291700
-PPR82	Psudo-Response Regulator gene 82	glyma.Wm82.gnm2.ann1.Glyma.08G291800
-PPR83	Psudo-Response Regulator gene 83	glyma.Wm82.gnm2.ann1.Glyma.08G294900
-PPR84	Psudo-Response Regulator gene 84	glyma.Wm82.gnm2.ann1.Glyma.08G295900
-PPR85	Psudo-Response Regulator gene 85	glyma.Wm82.gnm2.ann1.Glyma.08G302300
-PPR86	Psudo-Response Regulator gene 86	glyma.Wm82.gnm2.ann1.Glyma.08G318700
-PPR87	Psudo-Response Regulator gene 87	glyma.Wm82.gnm2.ann1.Glyma.09G000400
+ALDH22A2	aldehyde dehydrogenase 22A2	glyma.Wm82.gnm2.ann1.Glyma.09g036000
+CAMTA9	Calmodulin binding transcription activator 9	glyma.Wm82.gnm2.ann1.Glyma.09G038300
+COBL13	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.09G039900
+cox2	Cytochrome C oxidase subunit 2	glyma.Wm82.gnm2.ann1.Glyma.09g040100
+PR10	pathogenesis-related protein 10	glyma.Wm82.gnm2.ann1.Glyma.09g040500
+ERF5, ERF68	Ethylene-responsive factor gene 68	glyma.Wm82.gnm2.ann1.Glyma.09G041500
+SWEET28	sugar efflux transporter SWEET28	glyma.Wm82.gnm2.ann1.Glyma.09g043200
 PPR88	Psudo-Response Regulator gene 88	glyma.Wm82.gnm2.ann1.Glyma.09G043600
+C2-91, COR2	cold-regulated protein	glyma.Wm82.gnm2.ann1.Glyma.09g045700
+CYP81E11	isoflavone 2'-hydroxylase-like	glyma.Wm82.gnm2.ann1.Glyma.09g049100
+I2'H	isoflavone 2'-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.09g049300
+AAH2	allantoate deiminase 2	glyma.Wm82.gnm2.ann1.Glyma.09g050800
+ERF69	Ethylene-responsive factor gene 69	glyma.Wm82.gnm2.ann1.Glyma.09G052800
+ERF70	Ethylene-responsive factor gene 70	glyma.Wm82.gnm2.ann1.Glyma.09G052900
+ERF71	Ethylene-responsive factor gene 71	glyma.Wm82.gnm2.ann1.Glyma.09G053000
+MED18-1	Mediator Complex 18 gene 1	glyma.Wm82.gnm2.ann1.Glyma.09g054300
+PIN9a	PIN-formed 9 gene a	glyma.Wm82.gnm2.ann1.Glyma.09G061800
+WRKY47, WRKY92	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.09G061900
+NPR1.09	Non-induced pathogenesis-related gene	glyma.Wm82.gnm2.ann1.Glyma.09G064700
+NF-YA09	nuclear transcription factor Y subunit A-9	glyma.Wm82.gnm2.ann1.Glyma.09g068400
+PHD6	PHD finger protein GmPHD6	glyma.Wm82.gnm2.ann1.Glyma.09g068500
+GRF7	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.09g068700
+ALDH7B1	aldehyde dehydrogenase family 7 member B1	glyma.Wm82.gnm2.ann1.Glyma.09g070300
+LEA2-45	late embryogenesis abundant 2 gene 45	glyma.Wm82.gnm2.ann1.Glyma.09G071900
+RTRP5	RING/U-box superfamily protein	glyma.Wm82.gnm2.ann1.Glyma.09g074200
+chs6, CHS6b	Chalcone and stilbene synthases, C-terminal domain; Chalcone and stilbene synthases, N-terminal domain 6 gene b	glyma.Wm82.gnm2.ann1.Glyma.09G075200
+WRKY93	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.09G080000
+PHYE1	Phytochrome E gene 1	glyma.Wm82.gnm2.ann1.Glyma.09g088500
+CYP21	peptidyl-prolyl cis-trans isomerase CYP21	glyma.Wm82.gnm2.ann1.Glyma.09g090900
+PRP1	repetitive proline-rich cell wall protein 1	glyma.Wm82.gnm2.ann1.Glyma.09g092700
+GASA13	gibberellin-regulated protein 13	glyma.Wm82.gnm2.ann1.Glyma.09g095200
+CYP50	peptidyl-prolyl cis-trans isomerase CYP50	glyma.Wm82.gnm2.ann1.Glyma.09g095400
+PIN9C	auxin efflux carrier component	glyma.Wm82.gnm2.ann1.Glyma.09g097300
 PPR89	Psudo-Response Regulator gene 89	glyma.Wm82.gnm2.ann1.Glyma.09G097800
-PPR9	Psudo-Response Regulator gene 9	glyma.Wm82.gnm2.ann1.Glyma.01G236000
+TIL	temperature-induced lipocalin	glyma.Wm82.gnm2.ann1.Glyma.09g098900
+MLP34	MLP-like protein	glyma.Wm82.gnm2.ann1.Glyma.09G102400
+FRD3b	ferric reductase defective 3b	glyma.Wm82.gnm2.ann1.Glyma.09g102800
+JOX1	jasnonate-induced oxygenase 1	glyma.Wm82.gnm2.ann1.Glyma.09G107100
+FAD2-2D	fatty acid desaturase-2	glyma.Wm82.gnm2.ann1.Glyma.09g111900
+PHR15	MYB-CC domain-containing transcription factor PHR15	glyma.Wm82.gnm2.ann1.Glyma.09g113000
+SPL9B	squamosa promoter-binding-like protein 9b	glyma.Wm82.gnm2.ann1.Glyma.09g113800
+C2-92	C2 domain containing protein gene 92	glyma.Wm82.gnm2.ann1.Glyma.09G117100
+PIN3D	auxin efflux carrier component 3d	glyma.Wm82.gnm2.ann1.Glyma.09g117900
+TPS8	terpene synthase 8	glyma.Wm82.gnm2.ann1.Glyma.09g122500
+MED23-1	Mediator Complex 23 gene 1	glyma.Wm82.gnm2.ann1.Glyma.09g123500
 PPR90	Psudo-Response Regulator gene 90	glyma.Wm82.gnm2.ann1.Glyma.09G126100
+WRKY94	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.09G127100
+SGT1-2	Suppressor of the G2 allele of SKP1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.09g128800
+WRKY95	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.09G129100
+MYB136	MYB transcription factor MYB136	glyma.Wm82.gnm2.ann1.Glyma.09g131400
+HSP90A1	heat shock protein 90-A1	glyma.Wm82.gnm2.ann1.Glyma.09g131500
+BCH5	beta-carotene hydroxylase 5	glyma.Wm82.gnm2.ann1.Glyma.09g132200
+Lac35	Laccase 35	glyma.Wm82.gnm2.ann1.Glyma.09G132400
+CrRI,k1l,09	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.09G133000
+C2-93	C2 domain containing protein gene 93	glyma.Wm82.gnm2.ann1.Glyma.09G134500
+PM39	seed maturation protein PM39	glyma.Wm82.gnm2.ann1.Glyma.09g139600
+HSF-18	heat stress transcription factor 18	glyma.Wm82.gnm2.ann1.Glyma.09g143200
+TFL1.4	terminal flowering 1-like protein 4	glyma.Wm82.gnm2.ann1.Glyma.09g143500
+IQD31	protein IQ-DOMAIN 31	glyma.Wm82.gnm2.ann1.Glyma.09g143900
+DREB1-like	CRT binding factor 1	glyma.Wm82.gnm2.ann1.Glyma.09g147200
+GA1, GA20OX3	gibberellin 20-oxidase	glyma.Wm82.gnm2.ann1.Glyma.09g149200
+CRK12	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.09g150500
+CRK13	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.09g151400
+CRK14	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.09g151700
 PPR91	Psudo-Response Regulator gene 91	glyma.Wm82.gnm2.ann1.Glyma.09G154200
+KTI-2	kunitz trypsin protease inhibitor	glyma.Wm82.gnm2.ann1.Glyma.09g155500
+BBI-CII	Bowman-Birk type proteinase inhibitor C-II	glyma.Wm82.gnm2.ann1.Glyma.09g158800
+BBI	Bowman-Birk proteinase inhibitor	glyma.Wm82.gnm2.ann1.Glyma.09g158900
+UGT708D1	UDP-glucose:2-hydroxyflavanone C-glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.09g162400
+NAC066	NAC Transcription Factor gene 66	glyma.Wm82.gnm2.ann1.Glyma.09G167400
 PPR92	Psudo-Response Regulator gene 92	glyma.Wm82.gnm2.ann1.Glyma.09G168800
+GBP	GAGA-binding protein	glyma.Wm82.gnm2.ann1.Glyma.09g170400
+FCL2	homeobox protein knotted-1-like	glyma.Wm82.gnm2.ann1.Glyma.09g172800
+GS1alpha	Glutamine synthase 1 alpha gene	glyma.Wm82.gnm2.ann1.Glyma.09g173200
+PIN1C	auxin efflux carrier component 1c	glyma.Wm82.gnm2.ann1.Glyma.09g176300
+C2-94	C2 domain containing protein gene 94	glyma.Wm82.gnm2.ann1.Glyma.09G176900
+IQD32	protein IQ-DOMAIN 32	glyma.Wm82.gnm2.ann1.Glyma.09g177200
+LEA2-46	late embryogenesis abundant 2 gene 46	glyma.Wm82.gnm2.ann1.Glyma.09G179400
+C2-95	C2 domain containing protein gene 95	glyma.Wm82.gnm2.ann1.Glyma.09G182700
+NAC067	NAC Transcription Factor gene 67	glyma.Wm82.gnm2.ann1.Glyma.09G184100
+bZIP71	Basic leucine zipper transcription factor-like protein gene 71	glyma.Wm82.gnm2.ann1.Glyma.09G184300
+DEHYDRIN, MAT9	Maturation-associated protein 9 gene	glyma.Wm82.gnm2.ann1.Glyma.09g185500
+ALMT14	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.09g185600
+C2-96	C2 domain containing protein gene 96	glyma.Wm82.gnm2.ann1.Glyma.09G187900
+ALDH2C7	aldehyde dehydrogenase family 2 member C7	glyma.Wm82.gnm2.ann1.Glyma.09g189200
+ALDH2C8	aldehyde dehydrogenase family 2 member C8	glyma.Wm82.gnm2.ann1.Glyma.09g189300
+ALDH2C9	aldehyde dehydrogenase family 2 member C9	glyma.Wm82.gnm2.ann1.Glyma.09g189500
+LEA2-47	late embryogenesis abundant 2 gene 47	glyma.Wm82.gnm2.ann1.Glyma.09G189900
+HSF-16	heat stress transcription factor 16	glyma.Wm82.gnm2.ann1.Glyma.09g190600
+NYC1_2	protein NON-YELLOW COLORING 1	glyma.Wm82.gnm2.ann1.Glyma.09g191200
+PERK1	putative receptor protein kinase PERK1	glyma.Wm82.gnm2.ann1.Glyma.09g191300
+LEA2-48	late embryogenesis abundant 2 gene 48	glyma.Wm82.gnm2.ann1.Glyma.09G192300
+IAA29	Indole-3-Acetic Acid Responsive Gene 29	glyma.Wm82.gnm2.ann1.Glyma.09G193000
+GLYI-11	Glyoxylase 1 gene 11	glyma.Wm82.gnm2.ann1.Glyma.09g193800
+VPS-like	Vacuolar protein sorting -like 	glyma.Wm82.gnm2.ann1.Glyma.09G196600
 PPR93	Psudo-Response Regulator gene 93	glyma.Wm82.gnm2.ann1.Glyma.09G200600
+SYMRK-BETA	symbiosis receptor kinase SymRK-beta	glyma.Wm82.gnm2.ann1.Glyma.09g202300
+IAA30	Indole-3-Acetic Acid Responsive Gene 30	glyma.Wm82.gnm2.ann1.Glyma.09G203300
+HSF-17	heat stress transcription factor 17	glyma.Wm82.gnm2.ann1.Glyma.09g206600
+bZIP72	Basic leucine zipper transcription factor-like protein gene 72	glyma.Wm82.gnm2.ann1.Glyma.09G208500
 PPR94	Psudo-Response Regulator gene 94	glyma.Wm82.gnm2.ann1.Glyma.09G209700
+PHR16	MYB-CC domain-containing transcription factor PHR16	glyma.Wm82.gnm2.ann1.Glyma.09g211400
+GRF8	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.09g212500
+MED2-2	Mediator Complex 2 gene 2	glyma.Wm82.gnm2.ann1.Glyma.09g214900
+MED34-1	Mediator Complex 34 gene 1	glyma.Wm82.gnm2.ann1.Glyma.09g215200
+LEA2-49	late embryogenesis abundant 2 gene 49	glyma.Wm82.gnm2.ann1.Glyma.09G217800
+CYP707A1A	abscisic acid 8'-hydroxylase 1	glyma.Wm82.gnm2.ann1.Glyma.09g218600
+GAMMA-TMT	gamma-tocopherol methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.09g222800
+TIP5-1	aquaporin TIP5-1	glyma.Wm82.gnm2.ann1.Glyma.09g224700
+IQD33	protein IQ-DOMAIN 33	glyma.Wm82.gnm2.ann1.Glyma.09g225300
+GLYI-12	Glyoxylase 1 gene 12	glyma.Wm82.gnm2.ann1.Glyma.09g226500
 PPR95	Psudo-Response Regulator gene 95	glyma.Wm82.gnm2.ann1.Glyma.09G227000
+PAP14	purple acid phosphatase-like	glyma.Wm82.gnm2.ann1.Glyma.09g229200
+CBP	putative calmodulin-binding protein	glyma.Wm82.gnm2.ann1.Glyma.09g231200
+NAC068	NAC Transcription Factor gene 68	glyma.Wm82.gnm2.ann1.Glyma.09G231700
+NAC069	NAC Transcription Factor gene 69	glyma.Wm82.gnm2.ann1.Glyma.09G233600
+PHO1-H3	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.09g235200
+CGS2	cystathionine-gamma-synthase	glyma.Wm82.gnm2.ann1.Glyma.09g235400
+NAC070, NLP2	NAC domain-containing protein 100-like	glyma.Wm82.gnm2.ann1.Glyma.09g235700
 PPR96	Psudo-Response Regulator gene 96	glyma.Wm82.gnm2.ann1.Glyma.09G236700
 PPR97	Psudo-Response Regulator gene 97	glyma.Wm82.gnm2.ann1.Glyma.09G237200
+NIP2-1	putative Si transporter NIP2-1	glyma.Wm82.gnm2.ann1.Glyma.09g238200
+GASA14	gibberellin-regulated protein 14	glyma.Wm82.gnm2.ann1.Glyma.09g238300
+WRKY96	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.09G240000
+PIN8c	PIN-formed 8 gene c	glyma.Wm82.gnm2.ann1.Glyma.09G240500
+ERF72	Ethylene-responsive factor gene 72	glyma.Wm82.gnm2.ann1.Glyma.09G242600
+SRA2	GTP binding protein	glyma.Wm82.gnm2.ann1.Glyma.09g243300
+WRKY97	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.09G244000
+CYP30	peptidyl-prolyl cis-trans isomerase CYP30	glyma.Wm82.gnm2.ann1.Glyma.09g245200
+WRKY98	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.09G250500
 PPR98	Psudo-Response Regulator gene 98	glyma.Wm82.gnm2.ann1.Glyma.09G251000
+PIN5A	auxin efflux carrier component 5a	glyma.Wm82.gnm2.ann1.Glyma.09g251600
+WRKY99	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.09G254400
+WRKY100	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.09G254800
+MAPK11-2	mitogen-activated protein kinase 11 gene 2	glyma.Wm82.gnm2.ann1.Glyma.09G256000
+MED12-3	Mediator Complex 12 gene 3	glyma.Wm82.gnm2.ann1.Glyma.09g259400
+C2-97	C2 domain containing protein gene 97	glyma.Wm82.gnm2.ann1.Glyma.09G261200
+C2-98	C2 domain containing protein gene 98	glyma.Wm82.gnm2.ann1.Glyma.09G266600
+ZPR1A	protein LITTLE ZIPPER 2-like	glyma.Wm82.gnm2.ann1.Glyma.09g268100
 PPR99	Psudo-Response Regulator gene 99	glyma.Wm82.gnm2.ann1.Glyma.09G272000
-PR-10	stress-induced protein SAM22	glyma.Wm82.gnm2.ann1.Glyma.07g243700
-PR08-Bet VI	pathogenesis-related protein	glyma.Wm82.gnm2.ann1.Glyma.08G230500
-PR1, PR1-1	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.13g251600
-PR1-2	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.13g251700
-PR1-3	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.13g252300
-PR1-4	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.13g252000
-PR1-5	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.13g252400
-PR1-6	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.15g062400
-PR1-7	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.15g062500
-PR1-8	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.15g062700
-PR10	pathogenesis-related protein 10	glyma.Wm82.gnm2.ann1.Glyma.09g040500
-PRD3	Putative recombination initiation defects 3	glyma.Wm82.gnm2.ann1.Glyma.07G070400
-PRI1-9	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.15g062800
-PRP1	repetitive proline-rich cell wall protein 1	glyma.Wm82.gnm2.ann1.Glyma.09g092700
-PRP3	repetitive proline-rich cell wall protein 3	glyma.Wm82.gnm2.ann1.Glyma.11g154900
-PRR124	Psudo-Response Regulator gene 124	glyma.Wm82.gnm2.ann1.Glyma.13G062300
-PRR37	Root Preferential, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma04g33110
-PRR38	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma05g00880
-PRR39	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma06g14150
-PRR3B	Psudo-Response Regulator 3 gene B	glyma.Wm82.gnm1.ann1.Glyma12g07861
-PRR40	Root Preferential, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma19g44970
-PRR41	Root Preferential, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma13g19870
-PRR42, PRR7	Pseudo-response regulator gene 7	glyma.Wm82.gnm1.ann1.Glyma12g07860
-PRR43, PRR5	Pseudo-response regulator gene 5	glyma.Wm82.gnm1.ann1.Glyma04g40640
-PRR44	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma16g02050
-PRR45	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma07g05530
-PRR46	Shoot preferential, Pseudo Response Regulator	glyma.Wm82.gnm1.ann1.Glyma05g06070
-PRR47	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma17g16360
-PRR48	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma01g40900
-PRR49	Ubiquitous, Pseudo response regulator	glyma.Wm82.gnm1.ann1.Glyma11g04440
-PRR5a	Pseudo Response Regultor 5 gene a	glyma.Wm82.gnm2.ann1.Glyma.06G136600
-PRR5b	Pseudo Response Regultor 5 gene b	glyma.Wm82.gnm2.ann1.Glyma.04G228300
-PRR7a	Pseudo Response Regultor 7 gene a	glyma.Wm82.gnm2.ann1.Glyma.U034500
-PRR7b	Pseudo Response Regultor 7 gene b	glyma.Wm82.gnm2.ann1.Glyma.12G073900
-PRR7c	Pseudo Response Regultor 7 gene c	glyma.Wm82.gnm2.ann1.Glyma.13G135900
+CrRRk1R10	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.09G273300
+S6K1A	S6 Kinase 1	glyma.Wm82.gnm2.ann1.Glyma.09g273600
+WRKY101	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.09G274000
+WNK10	with no lysine kinase 10	glyma.Wm82.gnm2.ann1.Glyma.09g276300
+KASIII-1	beta-ketoacyl-ACP synthetase 3 gene 1	glyma.Wm82.gnm2.ann1.Glyma.09g277400
+SNAP09	soluble NSF attachment protein 9	glyma.Wm82.gnm2.ann1.Glyma.09g279400
+WRKY102	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.09G280200
+AMT4.1	ammonium transporter 4.1	glyma.Wm82.gnm2.ann1.Glyma.09g281600
+DIM1	DIM 1-like protein	glyma.Wm82.gnm2.ann1.Glyma.09g283300
+TCP11	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 11	glyma.Wm82.gnm2.ann1.Glyma.09G284300
+TCP12	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 12	glyma.Wm82.gnm2.ann1.Glyma.09G284500
+PPR100	Psudo-Response Regulator gene 100	glyma.Wm82.gnm2.ann1.Glyma.09G286300
+SEO-F3	sieve element occlusion by forisomes 3	glyma.Wm82.gnm2.ann1.Glyma.10g000400
+SEOF	sieve element occlusion f	glyma.Wm82.gnm2.ann1.Glyma.10g000500
+IAA31	Indole-3-Acetic Acid Responsive Gene 31	glyma.Wm82.gnm2.ann1.Glyma.10G000700
+NDH	NAD(P)H dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.10G000900
+HSF-22	heat stress transcription factor 22	glyma.Wm82.gnm2.ann1.Glyma.10g003100
+IQD34	protein IQ-DOMAIN 34	glyma.Wm82.gnm2.ann1.Glyma.10g003700
+PHO1-H4	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.10g004800
+CYN	Cyanate hydratase	glyma.Wm82.gnm2.ann1.Glyma.10g005200
+PHT1-3	inorganic phosphate transporter 1-3	glyma.Wm82.gnm2.ann1.Glyma.10g006700
+TOPP8	TOPP-type protein phosphatase gene 8	glyma.Wm82.gnm2.ann1.Glyma.10G006800
+ERF73	Ethylene-responsive factor gene 73	glyma.Wm82.gnm2.ann1.Glyma.10G007000
+ERF74	Ethylene-responsive factor gene 74	glyma.Wm82.gnm2.ann1.Glyma.10G007100
+MYB62;L1	MYB62;L1 transcription factor	glyma.Wm82.gnm2.ann1.Glyma.10G010400
+GA2OX2	gibberellin 2-beta-dioxygenase 2	glyma.Wm82.gnm2.ann1.Glyma.10g010700
+WRKY103	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.10G011300
+BZIP59, bZIP73	Basic leucine zipper transcription factor-like protein gene 73	glyma.Wm82.gnm2.ann1.Glyma.10G013300
+PAE1	20S proteasome subunit	glyma.Wm82.gnm2.ann1.Glyma.10g014300
+ERF75	Ethylene-responsive factor gene 75	glyma.Wm82.gnm2.ann1.Glyma.10G016500
+PPR101	Psudo-Response Regulator gene 101	glyma.Wm82.gnm2.ann1.Glyma.10G018100
+GSTF7	glutathione S-transferase GST 21	glyma.Wm82.gnm2.ann1.Glyma.10g019900
+TIR1B	protein TRANSPORT INHIBITOR RESPONSE 1B	glyma.Wm82.gnm2.ann1.Glyma.10g021500
+HSF-21	heat stress transcription factor 21	glyma.Wm82.gnm2.ann1.Glyma.10g029600
+IAA32	Indole-3-Acetic Acid Responsive Gene 32	glyma.Wm82.gnm2.ann1.Glyma.10G031800
+IAA33	Indole-3-Acetic Acid Responsive Gene 33	glyma.Wm82.gnm2.ann1.Glyma.10G031900
+GR-2a	Chloroplastic glutathione reductase 2 gene a	glyma.Wm82.gnm2.ann1.Glyma.10G032100
+WRKY104	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.10G032900
+NIP7-2	aquaporin NIP7-2	glyma.Wm82.gnm2.ann1.Glyma.10g033600
+ERF76	Ethylene-responsive factor gene 76	glyma.Wm82.gnm2.ann1.Glyma.10G036200
+ERF77	Ethylene-responsive factor gene 77	glyma.Wm82.gnm2.ann1.Glyma.10G036300
+ERF78	Ethylene-responsive factor gene 78	glyma.Wm82.gnm2.ann1.Glyma.10G036600
+ERF79	Ethylene-responsive factor gene 79	glyma.Wm82.gnm2.ann1.Glyma.10G036700
+PHT1-4	inorganic phosphate transporter 1-4	glyma.Wm82.gnm2.ann1.Glyma.10g036800
+glycinin A5A4B3, GY4	glycinin G4	glyma.Wm82.gnm2.ann1.Glyma.10g037100
+PHR17	MYB-CC domain-containing transcription factor PHR17	glyma.Wm82.gnm2.ann1.Glyma.10g039700
+IAA34	Indole-3-Acetic Acid Responsive Gene 34	glyma.Wm82.gnm2.ann1.Glyma.10G040400
+GSTL2	glutathione S-transferase L2	glyma.Wm82.gnm2.ann1.Glyma.10g047700
 PRR7d	Pseudo Response Regultor 7 gene d	glyma.Wm82.gnm2.ann1.Glyma.10G048100
-PRX2	Cationic peroxidase 2 gene	glyma.Wm82.gnm2.ann1.Glyma.17g013600
-PRX2B	peroxidase	glyma.Wm82.gnm2.ann1.Glyma.07g260300
-PRX3	peroxidase 43	glyma.Wm82.gnm2.ann1.Glyma.15g050800
-PRX4	peroxidase	glyma.Wm82.gnm2.ann1.Glyma.16g164200
-PRXD16	Peroxiredoxin 6	glyma.Wm82.gnm2.ann1.Glyma.16G164400
-PSAD	photosystem I subunit PsaD	glyma.Wm82.gnm2.ann1.Glyma.10g249000
-PSK-GAMMA1	phytosulfokine-gamma1	glyma.Wm82.gnm2.ann1.Glyma.02g126200
-PSK1	putative phytosulfokines 6-like	glyma.Wm82.gnm2.ann1.Glyma.12g181700
+MYB118	MYB transcription factor MYB118	glyma.Wm82.gnm2.ann1.Glyma.10g048500
+IQD35	protein IQ-DOMAIN 35	glyma.Wm82.gnm2.ann1.Glyma.10g050000
+TCP13	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 13	glyma.Wm82.gnm2.ann1.Glyma.10G057400
+PAL2.1	phenylalanine ammonia-lyase 2.1	glyma.Wm82.gnm2.ann1.Glyma.10g058200
+N6L	nodulin 6l	glyma.Wm82.gnm2.ann1.Glyma.10g060100
+ERF80	Ethylene-responsive factor gene 80	glyma.Wm82.gnm2.ann1.Glyma.10G061400
+Raf1-2	Raf1 proto-oncogene serine/threonine protein kinase gene 2	glyma.Wm82.gnm2.ann1.Glyma.10G066000
+HSF-20	heat stress transcription factor 20	glyma.Wm82.gnm2.ann1.Glyma.10g066100
 PSK3	putative phytosulfokine peptide	glyma.Wm82.gnm2.ann1.Glyma.10g066400
-PSK5	phytosulfokines 3-like	glyma.Wm82.gnm2.ann1.Glyma.u029600
-PT01	glycinol 2-dimethylallyl transferase	glyma.Wm82.gnm2.ann1.Glyma.01g134600
-PT03	prenyltransferase family protein PT03	glyma.Wm82.gnm2.ann1.Glyma.03g0331001
+GRF9	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.10g067200
 PT10B	prenyltransferase family protein PT10b	glyma.Wm82.gnm2.ann1.Glyma.10g0701001
 PT10D	prenyltransferase family protein PT10d	glyma.Wm82.gnm2.ann1.Glyma.10g070300
+CEN2	CEN-like protein 2-like	glyma.Wm82.gnm2.ann1.Glyma.10g071400
+ABI5, bZIP74	Basic leucine zipper transcription factor-like protein gene 74	glyma.Wm82.gnm2.ann1.Glyma.10G071700
+PPR102	Psudo-Response Regulator gene 102	glyma.Wm82.gnm2.ann1.Glyma.10G074100
+CASP2	casparian strip membrane protein 2	glyma.Wm82.gnm2.ann1.Glyma.10g075400
+B3	B3 domain protein	glyma.Wm82.gnm2.ann1.Glyma.10g076100
+NAC167	NAC transcription factor 167	glyma.Wm82.gnm2.ann1.Glyma.10g077000
+NAC168	NAC domain-containing protein 168	glyma.Wm82.gnm2.ann1.Glyma.10g077400
+LEA2-50	late embryogenesis abundant 2 gene 50	glyma.Wm82.gnm2.ann1.Glyma.10G079400
+LEA2-51	late embryogenesis abundant 2 gene 51	glyma.Wm82.gnm2.ann1.Glyma.10G079900
+LEA2-52	late embryogenesis abundant 2 gene 52	glyma.Wm82.gnm2.ann1.Glyma.10G080000
+NF-YA10	nuclear transcription factor Y subunit A-10	glyma.Wm82.gnm2.ann1.Glyma.10g082800
+C2-99	C2 domain containing protein gene 99	glyma.Wm82.gnm2.ann1.Glyma.10G091800
+bZIP75, TGA11	bZIP transcription factor 11	glyma.Wm82.gnm2.ann1.Glyma.10g092100
+C2-100	C2 domain containing protein gene 100	glyma.Wm82.gnm2.ann1.Glyma.10G092200
+PPR103	Psudo-Response Regulator gene 103	glyma.Wm82.gnm2.ann1.Glyma.10G093800
+SG-3, UGT91H4	Plant uridine 5' -diphosphate glycosyltransferase 91H4	glyma.Wm82.gnm2.ann1.Glyma.10g104700
+SDP1	triacylglycerol lipase SDP1	glyma.Wm82.gnm2.ann1.Glyma.10g105200
+TFIIB1	transcription factor TFIIB	glyma.Wm82.gnm2.ann1.Glyma.10g108600
+Le4-2	lectin DB58-like	glyma.Wm82.gnm2.ann1.Glyma.10g108900
+CRK15	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10g109200
+WRKY105	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.10G111400
+Le2-1	Lectin 4 gene 1	glyma.Wm82.gnm2.ann1.Glyma.10g113600
+WRKY106	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.10G113800
+ERF81	Ethylene-responsive factor gene 81	glyma.Wm82.gnm2.ann1.Glyma.10G118900
+EXPB2	beta-expansin	glyma.Wm82.gnm2.ann1.Glyma.10g122300
+EXPB5	expansin B protein	glyma.Wm82.gnm2.ann1.Glyma.10g122600
+GA2OX3	gibberellin 2-beta-dioxygenase 3	glyma.Wm82.gnm2.ann1.Glyma.10g123000
+C2-101	C2 domain containing protein gene 101	glyma.Wm82.gnm2.ann1.Glyma.10G130100
+MSH1	DNA mismatch repair protein	glyma.Wm82.gnm2.ann1.Glyma.10g130700
+C2-102	C2 domain containing protein gene 102	glyma.Wm82.gnm2.ann1.Glyma.10G130800
+AMT1.2	ammonium transporter AMT1.2	glyma.Wm82.gnm2.ann1.Glyma.10g132300
+HAD1, HAD3-1	acid phosphatase	glyma.Wm82.gnm2.ann1.Glyma.10G134700
+WRKY1, WRKY107	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.10G138300
+IAA35	Indole-3-Acetic Acid Responsive Gene 35	glyma.Wm82.gnm2.ann1.Glyma.10G138500
+CYP28	peptidyl-prolyl cis-trans isomerase CYP28	glyma.Wm82.gnm2.ann1.Glyma.10g139500
+GER16	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.10g139700
+GER17	germin-like protein 17	glyma.Wm82.gnm2.ann1.Glyma.10g139800
+PHYA, PHYA1	Phytochrome A gene 1	glyma.Wm82.gnm2.ann1.Glyma.10g141400
+GSK-3	glycogen synthase kinase-3	glyma.Wm82.gnm2.ann1.Glyma.10g144600
+NF-YC07	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.10g155900
+PURD	phosphoribosylamine--glycine ligase	glyma.Wm82.gnm2.ann1.Glyma.10g156900
+EDR1	serine/threonine-protein kinase EDR1	glyma.Wm82.gnm2.ann1.Glyma.10g159200
+OAS-TL6	cysteine synthase	glyma.Wm82.gnm2.ann1.Glyma.10g159700
+GT-2B	trihelix transcription factor	glyma.Wm82.gnm2.ann1.Glyma.10g161200
+bZIP76, SBZ1	bZIP transcription factor protein SBZ1	glyma.Wm82.gnm2.ann1.Glyma.10g162100
+IAA36	Indole-3-Acetic Acid Responsive Gene 36	glyma.Wm82.gnm2.ann1.Glyma.10G162400
+CrRRk1R1 1	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10G163200
+C2-103	C2 domain containing protein gene 103	glyma.Wm82.gnm2.ann1.Glyma.10G165300
+PPCK3	phosphoenolpyruvate-carboxylase kinase	glyma.Wm82.gnm2.ann1.Glyma.10g166600
+TOPP9	TOPP-type protein phosphatase gene 9	glyma.Wm82.gnm2.ann1.Glyma.10G166700
+EIN4	GAF/HisKA/CheY-like REC domain-containing protein	glyma.Wm82.gnm2.ann1.Glyma.10g167300
+AMT1.3	ammonium transporter AMT1.3	glyma.Wm82.gnm2.ann1.Glyma.10g167800
+AMT1.4	ammonium transporter AMT1.4	glyma.Wm82.gnm2.ann1.Glyma.10g168100
+AMT1.5	ammonium transporter AMT1.5	glyma.Wm82.gnm2.ann1.Glyma.10g168200
+GER6	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.10g168900
+WRKY108	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.10G171000
+WRKY109	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.10G171100
+WRKY110	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.10G171200
+GBSSIa	granule bound starch synthase Ia	glyma.Wm82.gnm2.ann1.Glyma.10g172200
+ALMT16	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.10g173400
+LEA2-53	late embryogenesis abundant 2 gene 53	glyma.Wm82.gnm2.ann1.Glyma.10G174100
+SCAM-4	calmodulin	glyma.Wm82.gnm2.ann1.Glyma.10g178400
+IAA37	Indole-3-Acetic Acid Responsive Gene 37	glyma.Wm82.gnm2.ann1.Glyma.10G180000
+IAA38, SLR1	auxin-induced protein ali50	glyma.Wm82.gnm2.ann1.Glyma.10g180100
+CRY2a1	Cryptochrome 2a1	glyma.Wm82.gnm2.ann1.Glyma.10g180600
+MYB29	MYB29 protein	glyma.Wm82.gnm2.ann1.Glyma.10g180800
+PHO1-H5	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.10g183300
+NRT1-3	putative nitrate transporter NRT1-3	glyma.Wm82.gnm2.ann1.Glyma.10g183900
+SEO-F1	sieve element occlusion by forisomes 1	glyma.Wm82.gnm2.ann1.Glyma.10g185500
+SEO-F2	sieve element occlusion by forisomes 2	glyma.Wm82.gnm2.ann1.Glyma.10g185600
+SEO-F4	sieve element occlusion by forisomes 4	glyma.Wm82.gnm2.ann1.Glyma.10g185700
+SEOG	sieve element occlusion g	glyma.Wm82.gnm2.ann1.Glyma.10g185800
+PPCK4	phosphoenolpyruvate-carboxylase kinase	glyma.Wm82.gnm2.ann1.Glyma.10g186000
+PHT1-6	inorganic phosphate transporter 1-6	glyma.Wm82.gnm2.ann1.Glyma.10g186400
+PHT1-1	inorganic phosphate transporter 1-1	glyma.Wm82.gnm2.ann1.Glyma.10g186500
+TOPP10	TOPP-type protein phosphatase gene 10	glyma.Wm82.gnm2.ann1.Glyma.10G186600
+ERF82	Ethylene-responsive factor gene 82	glyma.Wm82.gnm2.ann1.Glyma.10G186800
+ERF83	Ethylene-responsive factor gene 83	glyma.Wm82.gnm2.ann1.Glyma.10G186900
+ERF84	Ethylene-responsive factor gene 84	glyma.Wm82.gnm2.ann1.Glyma.10G187000
+ETR2	ethylene receptor	glyma.Wm82.gnm2.ann1.Glyma.10g188500
+PM13	Ca+2-binding EF hand protein	glyma.Wm82.gnm2.ann1.Glyma.10g189900
+PPR104	Psudo-Response Regulator gene 104	glyma.Wm82.gnm2.ann1.Glyma.10G190600
+GSTU42	glutathione S-transferase GST 15	glyma.Wm82.gnm2.ann1.Glyma.10g192900
+SODB2	iron-superoxide dismutase	glyma.Wm82.gnm2.ann1.Glyma.10g193500
+F3G6''Rt, Fg2, UGT79A6, UGT79A6-1	flavonol 3-O-glucoside (1->6) rhamnosyltransferase gene 1	glyma.Wm82.gnm2.ann1.Glyma.10g194000
+ERF85	Ethylene-responsive factor gene 85	glyma.Wm82.gnm2.ann1.Glyma.10G194200
+PHR18	MYB-CC domain-containing transcription factor PHR18	glyma.Wm82.gnm2.ann1.Glyma.10g196600
+Lac36	Laccase 36	glyma.Wm82.gnm2.ann1.Glyma.10G197300
+NAC072	NAC Transcription Factor gene 72	glyma.Wm82.gnm2.ann1.Glyma.10G197500
+NAC169	NAC Transcription Factor gene 169	glyma.Wm82.gnm2.ann1.Glyma.10G197600
+Lbc3	Leghemoglobin C3 gene	glyma.Wm82.gnm2.ann1.Glyma.10g198800
+LB	leghemoglobin	glyma.Wm82.gnm2.ann1.Glyma.10g198900
+LBC1	leghemoglobin C1	glyma.Wm82.gnm2.ann1.Glyma.10g199000
+LBA	Leghemoglobin A	glyma.Wm82.gnm2.ann1.Glyma.10g199100
+CYP76O2	7-ethoxycoumarin O-deethylase-like	glyma.Wm82.gnm2.ann1.Glyma.10g200800
+RAV	RAV-like DNA-binding protein	glyma.Wm82.gnm2.ann1.Glyma.10g204400
+NAC170	NAC domain-containing protein 170	glyma.Wm82.gnm2.ann1.Glyma.10g204700
+PEPC17, PEPC5, ppc17	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.10G205500
+PM3	maturation protein PM3	glyma.Wm82.gnm2.ann1.Glyma.10g205900
+CYP51	peptidyl-prolyl cis-trans isomerase CYP51	glyma.Wm82.gnm2.ann1.Glyma.10g206100
+CP3	cysteine proteinase	glyma.Wm82.gnm2.ann1.Glyma.10g207100
+PAL2.4	phenylalanine ammonia-lyase 2.4	glyma.Wm82.gnm2.ann1.Glyma.10g209800
+C2-104	C2 domain containing protein gene 104	glyma.Wm82.gnm2.ann1.Glyma.10G210000
+PIP2-13	aquaporin PIP2-13	glyma.Wm82.gnm2.ann1.Glyma.10g211000
+IQD36	protein IQ-DOMAIN 36	glyma.Wm82.gnm2.ann1.Glyma.10g213100
+STOP1	C2-H2 zinc finger protein	glyma.Wm82.gnm2.ann1.Glyma.10g215200
+GASA15	gibberellin-regulated protein 15	glyma.Wm82.gnm2.ann1.Glyma.10g216000
+GASA16	gibberellin-regulated protein 16	glyma.Wm82.gnm2.ann1.Glyma.10g216100
+NAC073	NAC Transcription Factor gene 73	glyma.Wm82.gnm2.ann1.Glyma.10G216400
+SUT1	sucrose transporter	glyma.Wm82.gnm2.ann1.Glyma.10g217900
+PTP1	Tyrosine phosphatase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.10g218100
+SERK1	somatic embryogenesis receptor kinase	glyma.Wm82.gnm2.ann1.Glyma.10g218800
+Lac37	Laccase 37	glyma.Wm82.gnm2.ann1.Glyma.10G219100
+Lac38	Laccase 38	glyma.Wm82.gnm2.ann1.Glyma.10G219200
+NAC074, SNAC38	NAC transcription factor	glyma.Wm82.gnm2.ann1.Glyma.10g219600
+NIP5-2	aquaporin NIP5-2	glyma.Wm82.gnm2.ann1.Glyma.10g221100
+GI3, GIa (E2)	Gigantea gene a	glyma.Wm82.gnm2.ann1.Glyma.10G221500
+ERF86	Ethylene-responsive factor gene 86	glyma.Wm82.gnm2.ann1.Glyma.10G223200
+bZIP77	Basic leucine zipper transcription factor-like protein gene 77	glyma.Wm82.gnm2.ann1.Glyma.10G223800
+bZIP78	Basic leucine zipper transcription factor-like protein gene 78	glyma.Wm82.gnm2.ann1.Glyma.10G226000
+RCC1	Regulator of chromosome condensation 1	glyma.Wm82.gnm2.ann1.Glyma.10G226900
+PPR105	Psudo-Response Regulator gene 105	glyma.Wm82.gnm2.ann1.Glyma.10G230100
+WRKY111, WRKY2	WRKY transcription factor 2	glyma.Wm82.gnm2.ann1.Glyma.10g230200
+BCH3	beta-carotene hydroxylase BCH3	glyma.Wm82.gnm2.ann1.Glyma.10g231200
+CrRLk1L12	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10G231500
+HSF-19	heat stress transcription factor 19	glyma.Wm82.gnm2.ann1.Glyma.10g237800
+IQD37	protein IQ-DOMAIN 37	glyma.Wm82.gnm2.ann1.Glyma.10g238300
+TCP14	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 14	glyma.Wm82.gnm2.ann1.Glyma.10G240200
+PGM3	phosphoglucomutase 3 gene	glyma.Wm82.gnm2.ann1.Glyma.10g241000
+RAR1-1	RAR1 protein	glyma.Wm82.gnm2.ann1.Glyma.10g242200
+MED31-1	Mediator Complex 31 gene 1	glyma.Wm82.gnm2.ann1.Glyma.10g242500
+HSF-23	heat stress transcription factor 23	glyma.Wm82.gnm2.ann1.Glyma.10g244000
+IQD38	protein IQ-DOMAIN 38	glyma.Wm82.gnm2.ann1.Glyma.10g245000
+TCP50	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 50	glyma.Wm82.gnm2.ann1.Glyma.10G246200
+CG-1, GM7S	beta-conglycinin alpha prime subunit 1	glyma.Wm82.gnm2.ann1.Glyma.10g246300
+Cgy1	beta-conglycinin 1, beta chain-like 	glyma.Wm82.gnm2.ann1.Glyma.10g246500
+PM24	seed maturation protein PM24	glyma.Wm82.gnm2.ann1.Glyma.10g247500
+PPR106	Psudo-Response Regulator gene 106	glyma.Wm82.gnm2.ann1.Glyma.10G247700
+WNK2	with no lysine kinase 2	glyma.Wm82.gnm2.ann1.Glyma.10g248400
+NOD33	putative nod33	glyma.Wm82.gnm2.ann1.Glyma.10g248900
+PSAD	photosystem I subunit PsaD	glyma.Wm82.gnm2.ann1.Glyma.10g249000
+LEA2-54	late embryogenesis abundant 2 gene 54	glyma.Wm82.gnm2.ann1.Glyma.10G252500
+CRK16	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10g252700
+CRK17	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10g252800
+CRK18	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10g253000
+CRK19	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10g253100
+CRK20	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10g253200
+CRK21	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10g253300
+CRK23	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10g253900
+CRK24	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.10g254300
+ITPK4	inositol phosphate kinase	glyma.Wm82.gnm2.ann1.Glyma.10g255000
+PPR107	Psudo-Response Regulator gene 107	glyma.Wm82.gnm2.ann1.Glyma.10G258200
+RNF12	RING-H2 finger protein	glyma.Wm82.gnm2.ann1.Glyma.10g259300
+GASA17	gibberellin-regulated protein 17	glyma.Wm82.gnm2.ann1.Glyma.10g259800
+PM23	seed maturation protein PM23	glyma.Wm82.gnm2.ann1.Glyma.10g260200
+SPX5	SPX domain-containing protein 5	glyma.Wm82.gnm2.ann1.Glyma.10g261900
+Lac39	Laccase 39	glyma.Wm82.gnm2.ann1.Glyma.10G263800
+MED21-1	Mediator Complex 21 gene 1	glyma.Wm82.gnm2.ann1.Glyma.10g264300
+IAA39	Indole-3-Acetic Acid Responsive Gene 39	glyma.Wm82.gnm2.ann1.Glyma.10G270500
+JAG2	JAGGED gene 2	glyma.Wm82.gnm2.ann1.Glyma.10g273800
+COL22	zinc finger protein CONSTANS-LIKE 16-like	glyma.Wm82.gnm2.ann1.Glyma.10g274300
+ERF87	Ethylene-responsive factor gene 87	glyma.Wm82.gnm2.ann1.Glyma.10G274600
+ALMT17	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.10g275700
+bZIP79, TGA12	bZIP transcription factor 12	glyma.Wm82.gnm2.ann1.Glyma.10g276100
+PPR108	Psudo-Response Regulator gene 108	glyma.Wm82.gnm2.ann1.Glyma.10G277600
+1-3-1A	syringolide-induced protein 1-3-1A	glyma.Wm82.gnm2.ann1.Glyma.10g277800
+FAD2-1A	fatty acid desaturase	glyma.Wm82.gnm2.ann1.Glyma.10g278000
+TCP15	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 15	glyma.Wm82.gnm2.ann1.Glyma.10G285900
+ALMT18	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.10g287700
+DHAR-1a, DHAR1, MDHAR-1a	DEHYDROASCORBATE REDUCTASE 1 gene a	glyma.Wm82.gnm2.ann1.Glyma.10G291100
+CHI1B2	chalcone isomerase 1B2	glyma.Wm82.gnm2.ann1.Glyma.10g292200
+G4DT	Glycinol 4-dimethylallyltransferase	glyma.Wm82.gnm2.ann1.Glyma.10g295300
+bZIP80	Basic leucine zipper transcription factor-like protein gene 80	glyma.Wm82.gnm2.ann1.Glyma.10G296200
+CYP23	peptidyl-prolyl cis-trans isomerase CYP23	glyma.Wm82.gnm2.ann1.Glyma.10g298200
+HDA11	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.11g000300
+C2-105	C2 domain containing protein gene 105	glyma.Wm82.gnm2.ann1.Glyma.11G000700
+CRK25	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g002800
+LEA2-55	late embryogenesis abundant 2 gene 55	glyma.Wm82.gnm2.ann1.Glyma.11G003000
+GA2OX4	gibberellin 2-beta-dioxygenase 4	glyma.Wm82.gnm2.ann1.Glyma.11g003200
+COBL14	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.11G003300
+TSB	tryptophan synthase beta subunit	glyma.Wm82.gnm2.ann1.Glyma.11g003500
+KAPP1	kinase-associated protein phosphatase 1	glyma.Wm82.gnm2.ann1.Glyma.11g004000
+PPR109	Psudo-Response Regulator gene 109	glyma.Wm82.gnm2.ann1.Glyma.11G006200
+PPR110	Psudo-Response Regulator gene 110	glyma.Wm82.gnm2.ann1.Glyma.11G007200
+GRF10	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.11g008500
+PPR111	Psudo-Response Regulator gene 111	glyma.Wm82.gnm2.ann1.Glyma.11G008800
+HSF-24	heat stress transcription factor 24	glyma.Wm82.gnm2.ann1.Glyma.11g009800
+4CL3	4-coumarate:coenzyme A ligase gene 3	glyma.Wm82.gnm2.ann1.Glyma.11g010500
+CHS8	chalcone synthase 8	glyma.Wm82.gnm2.ann1.Glyma.11g011500
+PPR112	Psudo-Response Regulator gene 112	glyma.Wm82.gnm2.ann1.Glyma.11G013400
+CYP97B2	Cytochrome P450 97B2	glyma.Wm82.gnm2.ann1.Glyma.11g016200
+AP2-9	AP2-EREBP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.11g018100
+ERF88	Ethylene-responsive factor gene 88	glyma.Wm82.gnm2.ann1.Glyma.11G019000
+LEA2-56	late embryogenesis abundant 2 gene 56	glyma.Wm82.gnm2.ann1.Glyma.11G020500
+LEA2-57	late embryogenesis abundant 2 gene 57	glyma.Wm82.gnm2.ann1.Glyma.11G020600
+WRKY112	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.11G021200
+PIP1-4	aquaporin PIP1-4	glyma.Wm82.gnm2.ann1.Glyma.11g023200
+C2-106	C2 domain containing protein gene 106	glyma.Wm82.gnm2.ann1.Glyma.11G024300
+OLPa	osmotin-like protein, acidic	glyma.Wm82.gnm2.ann1.Glyma.11g025600
+HSF-26	heat stress transcription factor 26	glyma.Wm82.gnm2.ann1.Glyma.11g025700
+ILPA1	anaphase-promoting complex subunit 8-like protein	glyma.Wm82.gnm2.ann1.Glyma.11g026400
+SGR1	Stay-green gene 1	glyma.Wm82.gnm2.ann1.Glyma.11g027400
+ANS3	Anthocyanidin synthase 3	glyma.Wm82.gnm2.ann1.Glyma.11g027700
+ACS10b	ACC Synthase 10 gene b	glyma.Wm82.gnm2.ann1.Glyma.11G028200
+PHR	CPD photolyase	glyma.Wm82.gnm2.ann1.Glyma.11g029500
+NAC075	NAC Transcription Factor gene 75	glyma.Wm82.gnm2.ann1.Glyma.11G030600
+ACX1;1	acyl-CoA oxidase	glyma.Wm82.gnm2.ann1.Glyma.11g035200
+ERF89	Ethylene-responsive factor gene 89	glyma.Wm82.gnm2.ann1.Glyma.11G036400
+ERF90	Ethylene-responsive factor gene 90	glyma.Wm82.gnm2.ann1.Glyma.11G036500
+CYP32	peptidyl-prolyl cis-trans isomerase CYP32	glyma.Wm82.gnm2.ann1.Glyma.11g038700
+SPK-2	protein kinase 2	glyma.Wm82.gnm2.ann1.Glyma.11g038800
+BMY3-3	Beta-amylase 3 gene 3	glyma.Wm82.gnm2.ann1.Glyma.11g039400
+C2-107	C2 domain containing protein gene 107	glyma.Wm82.gnm2.ann1.Glyma.11G040600
+ALMT21	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.11g042500
+RLK2	receptor-like protein kinase 2	glyma.Wm82.gnm2.ann1.Glyma.11g043800
+bZIP81	Basic leucine zipper transcription factor-like protein gene 81	glyma.Wm82.gnm2.ann1.Glyma.11G045900
+CYP18	peptidyl-prolyl cis-trans isomerase CYP18	glyma.Wm82.gnm2.ann1.Glyma.11g047800
+NRAMP1B	metal transporter Nramp1b	glyma.Wm82.gnm2.ann1.Glyma.11g051500
+MYB50	MYB transcription factor MYB50	glyma.Wm82.gnm2.ann1.Glyma.11g052100
+PGLCAT8	glycosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.11g053000
+WRKY113, WRKY14	WRKY transcription factor 14	glyma.Wm82.gnm2.ann1.Glyma.11g053100
+SGT2, UGT73P2	Plant uridine 5' -diphosphate glycosyltransferase 73P2	glyma.Wm82.gnm2.ann1.Glyma.11G053400
+ABA1	Abscisic acid 1	glyma.Wm82.gnm2.ann1.Glyma.11G055700
+HSF-25	heat stress transcription factor 25	glyma.Wm82.gnm2.ann1.Glyma.11g056200
+Lac40	Laccase 40	glyma.Wm82.gnm2.ann1.Glyma.11G059200
+CYP82C1	cytochrome P450 CYP82C1	glyma.Wm82.gnm2.ann1.Glyma.11g060100
+NFR5A	Nod factor receptor protein 5A	glyma.Wm82.gnm2.ann1.Glyma.11g063100
+BES1-6	protein BRI1-EMS-SUPPRESSOR 1	glyma.Wm82.gnm2.ann1.Glyma.11g064300
+SOYGBFA	G-box binding factor	glyma.Wm82.gnm2.ann1.Glyma.11g065000
+Lac41	Laccase 41	glyma.Wm82.gnm2.ann1.Glyma.11G069500
+Lac42	Laccase 42	glyma.Wm82.gnm2.ann1.Glyma.11G069600
+IFR1	isoflavone reductase homolog 1	glyma.Wm82.gnm2.ann1.Glyma.11g070300
+IFR	isoflavone reductase	glyma.Wm82.gnm2.ann1.Glyma.11g070500
+GLYI-13	Glyoxylase 1 gene 13	glyma.Wm82.gnm2.ann1.Glyma.11g075000
+NAC076	NAC Transcription Factor gene 76	glyma.Wm82.gnm2.ann1.Glyma.11G075400
+APX-3a2	Ascorbate peroxidase 3 gene a2	glyma.Wm82.gnm2.ann1.Glyma.11G078400
+FDa2	Flowering Locus D	glyma.Wm82.gnm2.ann1.Glyma.11G080000
+SEPB2	peroxidase sEPb2	glyma.Wm82.gnm2.ann1.Glyma.11g080300
+APS-5a2	Ascorbate peroxidase 5 gene a2	glyma.Wm82.gnm2.ann1.Glyma.11g080900
+NRPB1-2	DNA-directed RNA polymerase II subunit 1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.11g081200
+C2-108	C2 domain containing protein gene 108	glyma.Wm82.gnm2.ann1.Glyma.11G081500
+MLH3	MutL Homolog 3	glyma.Wm82.gnm2.ann1.Glyma.11G086300
+SIR	sulfite reductase [ferredoxin], chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.11g093200
+NAC077	NAC Transcription Factor gene 77	glyma.Wm82.gnm2.ann1.Glyma.11G096600
+LEA2-58	late embryogenesis abundant 2 gene 58	glyma.Wm82.gnm2.ann1.Glyma.11G097100
+Lac43	Laccase 43	glyma.Wm82.gnm2.ann1.Glyma.11G097300
+XIP1-2	aquaporin XIP1-2	glyma.Wm82.gnm2.ann1.Glyma.11g097800
+CYP1	peptidyl-prolyl cis-trans isomerase 1	glyma.Wm82.gnm2.ann1.Glyma.11g098700
+MED35-1	Mediator Complex 35 gene 1	glyma.Wm82.gnm2.ann1.Glyma.11g102600
+C2-109	C2 domain containing protein gene 108	glyma.Wm82.gnm2.ann1.Glyma.11G103300
+LAX10	auxin transporter-like protein 10	glyma.Wm82.gnm2.ann1.Glyma.11g106000
+CYP41	peptidyl-prolyl cis-trans isomerase CYP41	glyma.Wm82.gnm2.ann1.Glyma.11g106400
+MYBZ2	transcription factor MYBZ2	glyma.Wm82.gnm2.ann1.Glyma.11g107100
+APX-3a1	Ascorbate peroxidase 3 gene a1	glyma.Wm82.gnm2.ann1.Glyma.11G107200
+C2-110	C2 domain containing protein gene 110	glyma.Wm82.gnm2.ann1.Glyma.11G107300
+bZIP84	Basic leucine zipper transcription factor-like protein gene 84	glyma.Wm82.gnm2.ann1.Glyma.11G108100
+DET2	Steroid reductase	glyma.Wm82.gnm2.ann1.Glyma.11G110300
+BZIP28, bZIP85	Basic leucine zipper transcription factor-like protein gene 85	glyma.Wm82.gnm2.ann1.Glyma.11G110400
+GRF11	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.11g110700
+EDS5	MATE efflux family protein 4, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.11g112100
+CLV1A	receptor protein kinase-like protein	glyma.Wm82.gnm2.ann1.Glyma.11g114100
+bZIP86	Basic leucine zipper transcription factor-like protein gene 86	glyma.Wm82.gnm2.ann1.Glyma.11G114800
+CIB1	basic helix-loop-helix transcription activator CIB1	glyma.Wm82.gnm2.ann1.Glyma.11g117100
+STP	sorbitol-like transporter	glyma.Wm82.gnm2.ann1.Glyma.11g119500
+ARI7	ariadne A subfamily protein ARI7	glyma.Wm82.gnm2.ann1.Glyma.11g121300
+HB2	Non-symbiotic hemoglobin 1-like gene	glyma.Wm82.gnm2.ann1.Glyma.11g121700
+GLB1, HB1	Non-symbiotic hemoglobin 2 gene	glyma.Wm82.gnm2.ann1.Glyma.11g121800
+GLYII-4	putative hydroxyacylglutathione hydrolase	glyma.Wm82.gnm2.ann1.Glyma.11g126200
+SKIP16	F-box protein SKIP16-like	glyma.Wm82.gnm2.ann1.Glyma.11g126500
+bZIP87	Basic leucine zipper transcription factor-like protein gene 87	glyma.Wm82.gnm2.ann1.Glyma.11G126600
+ARI1	putative E3 ubiquitin-protein ligase ARI1	glyma.Wm82.gnm2.ann1.Glyma.11g129000
+C2-111	C2 domain containing protein gene 111	glyma.Wm82.gnm2.ann1.Glyma.11G130400
+ALDH3J1	aldehyde dehydrogenase family 3 member J1	glyma.Wm82.gnm2.ann1.Glyma.11g133300
+LUXC	transcription factor LUXc	glyma.Wm82.gnm2.ann1.Glyma.11g136600
+Lac44	Laccase 44	glyma.Wm82.gnm2.ann1.Glyma.11G137500
+EXPA5C	expansin A5c	glyma.Wm82.gnm2.ann1.Glyma.11g139100
+MED37-8	Mediator Complex 37 gene 8	glyma.Wm82.gnm2.ann1.Glyma.11g140500
+DRB2B	dsRNA-binding protein Drb2b	glyma.Wm82.gnm2.ann1.Glyma.11g145900
+PIP2-3	aquaporin PIP2-3	glyma.Wm82.gnm2.ann1.Glyma.11g146500
+IQD39	protein IQ-DOMAIN 39	glyma.Wm82.gnm2.ann1.Glyma.11g149200
+DRR2	disease resitance-responsive 2protein	glyma.Wm82.gnm2.ann1.Glyma.11g150300
+DRR1	disease resistance response protein 1	glyma.Wm82.gnm2.ann1.Glyma.11g150400
+DRR3	disease resitance-responsive 3 protein	glyma.Wm82.gnm2.ann1.Glyma.11g150700
+ATG6	beclin 1 protein	glyma.Wm82.gnm2.ann1.Glyma.11g153900
+C2-112	C2 domain containing protein gene 112	glyma.Wm82.gnm2.ann1.Glyma.11G154100
+PRP3	repetitive proline-rich cell wall protein 3	glyma.Wm82.gnm2.ann1.Glyma.11g154900
+WNK4	with no lysine kinase 4	glyma.Wm82.gnm2.ann1.Glyma.11g159900
+RIP1	RIP1-like peroxidase	glyma.Wm82.gnm2.ann1.Glyma.11g161800
+WRKY114, WRKY19	WRKY transcription factor 19	glyma.Wm82.gnm2.ann1.Glyma.11g163300
+Lac45	Laccase 45	glyma.Wm82.gnm2.ann1.Glyma.11G164000
+FabD	malonyl-CoA:ACP malonyltransferase	glyma.Wm82.gnm2.ann1.Glyma.11g164500
+bZIP88	Basic leucine zipper transcription factor-like protein gene 88	glyma.Wm82.gnm2.ann1.Glyma.11G167400
+bZIP91	Basic leucine zipper transcription factor-like protein gene 91	glyma.Wm82.gnm2.ann1.Glyma.11G168000
+FAD3, FAD3-2b, FAD3d	omega-3-fatty acid desaturase 3 gene 4	glyma.Wm82.gnm2.ann1.Glyma.11g174100
+CYP34	peptidyl-prolyl cis-trans isomerase CYP34	glyma.Wm82.gnm2.ann1.Glyma.11g175200
+ALMT22	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.11g179100
+LEA2-59	late embryogenesis abundant 2 gene 59	glyma.Wm82.gnm2.ann1.Glyma.11G179900
+NAC078, NAC90	PREDICTED: NAC domain-containing protein 90-like	glyma.Wm82.gnm2.ann1.Glyma.11G182000
+LEA2-60	late embryogenesis abundant 2 gene 60	glyma.Wm82.gnm2.ann1.Glyma.11G182400
+PHR19	MYB-CC domain-containing transcription factor PHR19	glyma.Wm82.gnm2.ann1.Glyma.11g1834001
+bZIP92	Basic leucine zipper transcription factor-like protein gene 92	glyma.Wm82.gnm2.ann1.Glyma.11G183700
+HDA12	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.11g187800
+HDT2	histone deacetylase HDT1-like	glyma.Wm82.gnm2.ann1.Glyma.11g189500
+BHLH59	basic helix-loop-helix transcription factor bHLH59	glyma.Wm82.gnm2.ann1.Glyma.11g192800
+GLYI-14	Glyoxylase 1 gene 14	glyma.Wm82.gnm2.ann1.Glyma.11g194200
+GLXI, GLYI-15	Glyoxylase 1 gene 15	glyma.Wm82.gnm2.ann1.Glyma.11g194300
+ACS	acyl-CoA synthase gene•••••	glyma.Wm82.gnm2.ann1.Glyma.11g194500
+TCP16	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 16	glyma.Wm82.gnm2.ann1.Glyma.11G196000
+GSTU43	tau class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.11g198500
+LEA2-61	late embryogenesis abundant 2 gene 61	glyma.Wm82.gnm2.ann1.Glyma.11G199600
+LEA2-62	late embryogenesis abundant 2 gene 62	glyma.Wm82.gnm2.ann1.Glyma.11G203000
+YSL1	probable metal-nicotianamine transporter YSL7-like	glyma.Wm82.gnm2.ann1.Glyma.11g203400
+CRK26	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g204500
+CRK27	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g204700
+CRK28	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g204800
+CRK29	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g204900
+CRK30	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g205200
+CRK31	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g205300
+CRK32	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g205400
+CRK33	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g205600
+CRK34	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g206100
+CPK2, CRK35	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g206300
+CRK36	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g206400
+CRK37	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g206700
+CRK39	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g207000
+CRK40	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g207300
+CRK41	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.11g207500
+GRF12	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.11g208800
+CEN1	protein SELF-PRUNING-like	glyma.Wm82.gnm2.ann1.Glyma.11g209500
+ZPR3A	protein LITTLE ZIPPER 3-like	glyma.Wm82.gnm2.ann1.Glyma.11g209700
 PT11A	prenyltransferase family protein PT11a	glyma.Wm82.gnm2.ann1.Glyma.11g210300
 PT11B	prenyltransferase family protein PT11b	glyma.Wm82.gnm2.ann1.Glyma.11g210400
 PT11C	prenyltransferase family protein PT11c	glyma.Wm82.gnm2.ann1.Glyma.11g210500
-PTI1	protein kinase Pti1	glyma.Wm82.gnm2.ann1.Glyma.20g245600
-PTI1A	Pti1 kinase-like protein	glyma.Wm82.gnm2.ann1.Glyma.07g234300
-PTI1B	Pti1 kinase-like protein	glyma.Wm82.gnm2.ann1.Glyma.17g039800
-PTOX	plastid terminal oxidase	glyma.Wm82.gnm2.ann1.Glyma.09g008500
-PTP1	Tyrosine phosphatase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.10g218100
-PTS-L1	pterocarpan synthase-like	glyma.Wm82.gnm2.ann1.Glyma.03g147800
-PTS-L2	pterocarpan synthase-like	glyma.Wm82.gnm2.ann1.Glyma.19g150900
-PTS-L3	pterocarpan synthase-like	glyma.Wm82.gnm2.ann1.Glyma.19g151000
-PTS-L4	pterocarpan synthase-like	glyma.Wm82.gnm2.ann1.Glyma.03g147900
-PTS-L5	pterocarpan synthase-like	glyma.Wm82.gnm2.ann1.Glyma.19g151300
-PTS1	pterocarpan synthase	glyma.Wm82.gnm2.ann1.Glyma.03g147700
-PTS3	pterocarpan synthase	glyma.Wm82.gnm2.ann1.Glyma.19g151100
-PTS4	pterocarpan synthase	glyma.Wm82.gnm2.ann1.Glyma.19g151200
-PUB8	E3 ubiquitin-protein ligase PUB8	glyma.Wm82.gnm2.ann1.Glyma.02g195900
-PUR1	glutamine phosphoribosylpyrophosphate amidotransferase	glyma.Wm82.gnm2.ann1.Glyma.04g007300
-PUR3	glycinamide ribonucleotide transformylase	glyma.Wm82.gnm2.ann1.Glyma.19g115900
-PURD	phosphoribosylamine--glycine ligase	glyma.Wm82.gnm2.ann1.Glyma.10g156900
-Phi-1	phosphate-induced protein	glyma.Wm82.gnm2.ann1.Glyma.14G176500
-RAB2	guanine nucleotide regulatory protein	glyma.Wm82.gnm2.ann1.Glyma.09g016700
-RAB7P	ras-related protein RABD1-like	glyma.Wm82.gnm2.ann1.Glyma.12g165300
-RAD51a	Radiation- repair 51 gene a	glyma.Wm82.gnm2.ann1.Glyma.13G175300
-RAD51b	Radiation- repair 51 gene b	glyma.Wm82.gnm2.ann1.Glyma.17G049800
-RAP2.7	Target of Early Activation	glyma.Wm82.gnm2.ann1.Glyma.19G178200
-RAR1-1	RAR1 protein	glyma.Wm82.gnm2.ann1.Glyma.10g242200
-RAR1-2	CHORD superfamily protein	glyma.Wm82.gnm2.ann1.Glyma.20g151900
-RAV	RAV-like DNA-binding protein	glyma.Wm82.gnm2.ann1.Glyma.10g204400
-RAV1	AP2/ERF transcription factor family protein RAV1	glyma.Wm82.gnm2.ann1.Glyma.01g087500
-RBCS-1	Ribulose bisphosphate carboxylase small chain 1, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.13g046200
-RCA03	ribulose bisphosphate carboxylase/oxygenase activase 1, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.03g068100
+NAC079	NAC Transcription Factor gene 79	glyma.Wm82.gnm2.ann1.Glyma.11G212400
+PPR113	Psudo-Response Regulator gene 113	glyma.Wm82.gnm2.ann1.Glyma.11G213300
+GS1-beta1	glutamate--ammonia ligase	glyma.Wm82.gnm2.ann1.Glyma.11g215500
+DHAR-3b, DHAR2	DHAR class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.11g216400
+GAI2, GR8	giberellic acid responsive gene 8	glyma.Wm82.gnm2.ann1.Glyma.11G216500
+C2-113	C2 domain containing protein gene 113	glyma.Wm82.gnm2.ann1.Glyma.11G216900
+C2-114	C2 domain containing protein gene 114	glyma.Wm82.gnm2.ann1.Glyma.11G219000
+CCS52	WD-repeat cell cycle regulatory protein	glyma.Wm82.gnm2.ann1.Glyma.11g219600
 RCA11	ribulose bisphosphate carboxylase/oxygenase activase, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.11g221000
-RCA14	ribulose bisphosphate carboxylase/oxygenase activase 1, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.14g067000
-RCAALPHA	ribulose bisphosphate carboxylase/oxygenase activase 1, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.02g249600
-RCABETA	ribulose bisphosphate carboxylase/oxygenase activase, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.18g036400
-RCC1	Regulator of chromosome condensation 1	glyma.Wm82.gnm2.ann1.Glyma.10G226900
-RDR3	RNA-dependent RNA polymerase	glyma.Wm82.gnm2.ann1.Glyma.01g008700
-RFP1	RING-type E3 ubiquitin ligase	glyma.Wm82.gnm2.ann1.Glyma.13g071600
-RHG4	receptor-like kinase RHG4	glyma.Wm82.gnm2.ann1.Glyma.08g107700
-RIC1	CLE-related protein RIC1	glyma.Wm82.gnm1.ann1.Glyma13g36830
-RIC2	CLE-related protein RIC2	glyma.Wm82.gnm2.ann1.Glyma.06g284100
-RIN4B	RPM1-interacting protein 4-like	glyma.Wm82.gnm2.ann1.Glyma.16g090700
-RIN4a	RIN4a protein	glyma.Wm82.gnm2.ann1.Glyma.03g084000
-RIN4c	RIN4c protein	glyma.Wm82.gnm2.ann1.Glyma.18g166800
-RIN4d	RIN4d protein	glyma.Wm82.gnm2.ann1.Glyma.08g349500
-RIP1	RIP1-like peroxidase	glyma.Wm82.gnm2.ann1.Glyma.11g161800
-RJ1	LysM-type receptor kinase NFR1alpha	glyma.Wm82.gnm2.ann1.Glyma.02g270800
-RLK1	receptor-like protein kinase 1	glyma.Wm82.gnm2.ann1.Glyma.05g110400
-RLK2	receptor-like protein kinase 2	glyma.Wm82.gnm2.ann1.Glyma.11g043800
-RLK3	receptor-like protein kinase 3	glyma.Wm82.gnm2.ann1.Glyma.01g197800
-RNA polymerase II	DNA-directed RNA polymerase II subunit RPB7	glyma.Wm82.gnm2.ann1.Glyma.08g085100
-RNF12	RING-H2 finger protein	glyma.Wm82.gnm2.ann1.Glyma.10g259300
-ROP10	Rho-related protein ROP10	glyma.Wm82.gnm2.ann1.Glyma.04g180200
-RPL2	ribosomal protein L2	glyma.Wm82.gnm2.ann1.Glyma.02g049300
-RPL37	ribosomal protein L37	glyma.Wm82.gnm2.ann1.Glyma.07g004900
-RPS10C	40S ribosomal protein S10	glyma.Wm82.gnm1.ann1.Glyma08g02070
-RPS11	ribosomal protein S11	glyma.Wm82.gnm2.ann1.Glyma.13g165200
-RPS13	ribosomal protein S13	glyma.Wm82.gnm2.ann1.Glyma.05g052400
-RPS6	ribosomal protein S6	glyma.Wm82.gnm2.ann1.Glyma.18g151800
-RPSHC18-NBL1	NB-LRR type disease resistance protein	glyma.Wm82.gnm2.ann1.Glyma.03g037100
-RPSHC18-NBL2	NB-LRR type disease resistance protein	glyma.Wm82.gnm2.ann1.Glyma.03g037300
-RPSQ	LRR receptor kinase-like protein	glyma.Wm82.gnm2.ann1.Glyma.03g117600
-RR01	Ubiquitous, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma02g03140
-RR02	Ubiquitous, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma17g10170
-RR03	Ubiquitous, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma05g01730
-RR04	Shoot preferential, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma08g40330
-RR05	Ubiquitous, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma18g17330
-RR06	Root specific, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma15g37770
-RR07	Ubiquitous, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma04g42680
-RR08	Ubiquitous, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma06g12100
-RR09	Root Preferential, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma03g28570
-RR10	Ubiquitous, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma19g31320
-RR11	Root Preferential, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma11g21650
-RR12	Root Preferential, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma04g29250
-RR13	Root Preferential, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma13g03560
-RR14	Root Preferential, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma06g19870
-RR15	Root specific, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma04g34820
-RR16	Ubiquitous, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma06g14750
-RR17	Shoot preferential, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma04g40100
-RR18	Root specific, Response Regulator Type-A	glyma.Wm82.gnm1.ann1.Glyma13g26770
-RR19	Root Preferential, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma17g03380
-RR20	Root Preferential, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma09g04470
-RR21	Root Specific, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma07g37220
-RR22	Root Preferential, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma15g15520
-RR23	Root Preferential, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma11g37480
-RR24	Root Preferential, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma05g27670
-RR25	Root Specific, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma08g10650
-RR26	Ubiquitous, Response Regiulator Type-B	glyma.Wm82.gnm1.ann1.Glyma04g06650
-RR27	Root Specific, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma17g33230
-RR28	Ubiquitous, Response Regiulator Type-B	glyma.Wm82.gnm1.ann1.Glyma14g13320
-RR29	Root Preferential, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma15g24770
-RR30	Root Preferential, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma09g14650
-RR31	Root Preferential, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma06g06730
-RR32	Root Specific, Response Regulator Type-B	glyma.Wm82.gnm1.ann1.Glyma13g22320
-RR33	Ubiquitous, Response Regiulator Type-B	glyma.Wm82.gnm1.ann1.Glyma07g26890
-RR34	Root Specific, Response Regulator Type-C	glyma.Wm82.gnm1.ann1.Glyma03g32720
-RR35	Root Preferential, Response Regulator Type-C	glyma.Wm82.gnm1.ann1.Glyma19g35470
-RR36	Root Specific, Response Regulator Type-C	glyma.Wm82.gnm1.ann1.Glyma19g35480
-RS	raffinose synthase	glyma.Wm82.gnm2.ann1.Glyma.03g137900
-RS1	Raffinose Synthase 1	glyma.Wm82.gnm1.ann1.Glyma03g29440
-RS2	Raffinose Synthase 2	glyma.Wm82.gnm2.ann1.Glyma.06g179200
-RS3	Raffinose Synthase 3	glyma.Wm82.gnm2.ann1.Glyma.05g003900
-RSP13	ribosomal protein S13	glyma.Wm82.gnm2.ann1.Glyma.02g078000
-RSV3	putative NBS-LRR family protein	glyma.Wm82.gnm2.ann1.Glyma.14g204700
-RTRP2	probable E3 ubiquitin-protein ligase rbrA-like protein	glyma.Wm82.gnm2.ann1.Glyma.12g071900
-RTRP3	reverse transcriptase-like domain-containing RBR protein	glyma.Wm82.gnm2.ann1.Glyma.09g020000
-RTRP4	reverse transcriptase-like domain-containing RBR protein	glyma.Wm82.gnm2.ann1.Glyma.15g126500
-RTRP5	RING/U-box superfamily protein	glyma.Wm82.gnm2.ann1.Glyma.09g074200
-Raf1-2	Raf1 proto-oncogene serine/threonine protein kinase gene 2	glyma.Wm82.gnm2.ann1.Glyma.10G066000
-Raf19-1	Raf19 proto-oncogene serine/threonine protein kinase gene 1	glyma.Wm82.gnm2.ann1.Glyma.07G264700
-Raf30-2	Raf30 proto-oncogene serine/threonine protein kinase gene 2	glyma.Wm82.gnm2.ann1.Glyma.20G105300
-Raf41-1	Raf41 proto-oncogene serine/threonine protein kinase gene 1	glyma.Wm82.gnm2.ann1.Glyma.05G002600
-Raf42-3	Raf42 proto-oncogene serine/threonine protein kinase gene 3	glyma.Wm82.gnm2.ann1.Glyma.17G105100
-Raf47-1	Raf47proto-oncogene serine/threonine protein kinase gene 1	glyma.Wm82.gnm2.ann1.Glyma.14G026700
-Raf49-1	Raf49 proto-oncogene serine/threonine protein kinase gene 1	glyma.Wm82.gnm2.ann1.Glyma.14G099300
-Raf49-2	Raf49 proto-oncogene serine/threonine protein kinase gene 2	glyma.Wm82.gnm2.ann1.Glyma.17G225400
-Raf49-3	Raf49 proto-oncogene serine/threonine protein kinase gene 3	glyma.Wm82.gnm2.ann1.Glyma.06G055300
-Raf52	Raf52 proto-oncogene serine/threonine protein kinase	glyma.Wm82.gnm2.ann1.Glyma.04G020100
-Raf6-4	Raf6 proto-oncogene serine/threonine protein kinase gene 4	glyma.Wm82.gnm2.ann1.Glyma.02G215300
-S6K1A	S6 Kinase 1	glyma.Wm82.gnm2.ann1.Glyma.09g273600
-S6K1B	S6 Kinase 1	glyma.Wm82.gnm2.ann1.Glyma.18g212800
-SABATH1	salicylic acid methyl transferase-like protein	glyma.Wm82.gnm2.ann1.Glyma.01g063100
-SABATH2, SAMT1.02	salicylic acid methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.02G054200
-SACPD-A	stearoyl-acyl carrier protein desaturase	glyma.Wm82.gnm1.ann1.Glyma07g32850
-SACPD-B	stearoyl-acyl carrier protein desaturase	glyma.Wm82.gnm1.ann1.Glyma02g15600
-SALI5-4A	sali5-4a protein	glyma.Wm82.gnm2.ann1.Glyma.12g217300
-SALT3	K+/H+ antiporter gene 1	glyma.Wm82.gnm1.ann1.Glyma03g32900
-SAMDC	S-adenosylmethionine decarboxylase	glyma.Wm82.gnm2.ann1.Glyma.02g128000
-SAN1A	senescence-associated nodulin 1A	glyma.Wm82.gnm2.ann1.Glyma.07g209100
-SAN1B	senescence-associated nodulin 1B	glyma.Wm82.gnm2.ann1.Glyma.07g208900
-SARK	senescence-associated receptor-like kinase	glyma.Wm82.gnm2.ann1.Glyma.13g266100
-SAT1	serine O-acetyltransferase 1	glyma.Wm82.gnm2.ann1.Glyma.18g080000
-SAc3	Actin 3 gene	glyma.Wm82.gnm2.ann1.Glyma.08g146500
-SAc4	Actin 4 gene	glyma.Wm82.gnm2.ann1.Glyma.12g063400
-SB100	heat shock protein	glyma.Wm82.gnm2.ann1.Glyma.05g022200
-SBP2	sucrose-binding protein 2	glyma.Wm82.gnm2.ann1.Glyma.02g145700
-SBP56	56kDa selenium binding protein 56	glyma.Wm82.gnm2.ann1.Glyma.08G108000
-SBP65	Late embryonic abundant protein 65 kd	glyma.Wm82.gnm2.ann1.Glyma.13g291800
-SBPRP	proline-rich protein	glyma.Wm82.gnm2.ann1.Glyma.14g115500
-SC-03	thiamin biosynthetic enzyme	glyma.Wm82.gnm2.ann1.Glyma.12g135000
-SC-04	thiamin biosynthetic enzyme	glyma.Wm82.gnm2.ann1.Glyma.06g269700
-SCA1	plasma membrane Ca2+-ATPase	glyma.Wm82.gnm2.ann1.Glyma.01g193600
-SCA2	plasma membrane Ca2+-ATPase	glyma.Wm82.gnm2.ann1.Glyma.06g046000
-SCAM-1	calmodulin	glyma.Wm82.gnm2.ann1.Glyma.03g004100
-SCAM-2	calmodulin	glyma.Wm82.gnm2.ann1.Glyma.13g074800
-SCAM-3	calmodulin	glyma.Wm82.gnm2.ann1.Glyma.19g068300
-SCAM-4	calmodulin	glyma.Wm82.gnm2.ann1.Glyma.10g178400
-SCAM-5	calmodulin	glyma.Wm82.gnm2.ann1.Glyma.02g002100
-SCB1	Seed coat BURP domian protein 1	glyma.Wm82.gnm2.ann1.Glyma.07g176700
-SCHI	chilling-induced protein	glyma.Wm82.gnm2.ann1.Glyma.13g275000
-SCOF-1	scof-1 protein	glyma.Wm82.gnm2.ann1.Glyma.17g236200
-SCTF-1, ZAT6	C2H2-type Zinc Finger transcription factor 6	glyma.Wm82.gnm2.ann1.Glyma.06G045400
-SDP1	triacylglycerol lipase SDP1	glyma.Wm82.gnm2.ann1.Glyma.10g105200
-SDP1-1	triacylglycerol lipase SDP1	glyma.Wm82.gnm2.ann1.Glyma.02g190000
-SDP1-3	triacylglycerol lipase SDP1	glyma.Wm82.gnm2.ann1.Glyma.19g132900
-SDP1-4	triacylglycerol lipase SDP1	glyma.Wm82.gnm2.ann1.Glyma.03g130900
-SDP6	glycerol-3-phosphate dehydrogenase SDP6, mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.02g165500
-SDR	short-chain dehydrogenase/reductase (SDR) family protein 	glyma.Wm82.gnm1.ann1.Glyma07g08090
-SEO-F1	sieve element occlusion by forisomes 1	glyma.Wm82.gnm2.ann1.Glyma.10g185500
-SEO-F2	sieve element occlusion by forisomes 2	glyma.Wm82.gnm2.ann1.Glyma.10g185600
-SEO-F3	sieve element occlusion by forisomes 3	glyma.Wm82.gnm2.ann1.Glyma.10g000400
-SEO-F4	sieve element occlusion by forisomes 4	glyma.Wm82.gnm2.ann1.Glyma.10g185700
-SEOA	sieve element occlusion a	glyma.Wm82.gnm2.ann1.Glyma.02g000700
-SEOC	sieve element occlusion c	glyma.Wm82.gnm2.ann1.Glyma.04g190300
-SEOD	sieve element occlusion d	glyma.Wm82.gnm2.ann1.Glyma.06g175200
-SEOE	sieve element occlusion e	glyma.Wm82.gnm2.ann1.Glyma.08g130500
-SEOF	sieve element occlusion f	glyma.Wm82.gnm2.ann1.Glyma.10g000500
-SEOG	sieve element occlusion g	glyma.Wm82.gnm2.ann1.Glyma.10g185800
-SEOI	sieve element occlusion i	glyma.Wm82.gnm2.ann1.Glyma.11g244200
-SEOJ	sieve element occlusion j	glyma.Wm82.gnm2.ann1.Glyma.13g077200
-SEOL	uncharacterized LOC100807591	glyma.Wm82.gnm2.ann1.Glyma.13g1911001
-SEOM	sieve element occlusion m	glyma.Wm82.gnm2.ann1.Glyma.16g067700
-SEOO	sieve element occlusion o	glyma.Wm82.gnm2.ann1.Glyma.20g0530001
-SEOP	sieve element occlusion p	glyma.Wm82.gnm2.ann1.Glyma.20g052900
-SEOR	sieve element occlusion r	glyma.Wm82.gnm2.ann1.Glyma.20g204400
-SEOS	sieve element occlusion s	glyma.Wm82.gnm2.ann1.Glyma.20g204500
-SEOU	uncharacterized LOC100795343	glyma.Wm82.gnm2.ann1.Glyma.20g204800
-SEP1	transcription factor SEP1	glyma.Wm82.gnm2.ann1.Glyma.19g034500
-SEPB2	peroxidase sEPb2	glyma.Wm82.gnm2.ann1.Glyma.11g080300
-SERK1	somatic embryogenesis receptor kinase	glyma.Wm82.gnm2.ann1.Glyma.10g218800
-SF	serine/arginine-rich splicing factor	glyma.Wm82.gnm2.ann1.Glyma.05G117600
-SF3'H1, T	Tawny	glyma.Wm82.gnm2.ann1.Glyma.06g202300
-SFERH-2	ferritin	glyma.Wm82.gnm2.ann1.Glyma.01g124500
+GMP2	mannose-1-phosphate guanylyltransferase 1-like	glyma.Wm82.gnm2.ann1.Glyma.11g223700
+COI1	coronatine-insensitive 1	glyma.Wm82.gnm2.ann1.Glyma.11g227300
+C2-115	C2 domain containing protein gene 115	glyma.Wm82.gnm2.ann1.Glyma.11G227500
+PIP1-8	aquaporin PIP1-8	glyma.Wm82.gnm2.ann1.Glyma.11g228000
+LAX11	auxin transporter-like protein 11	glyma.Wm82.gnm2.ann1.Glyma.11g228300
+CYP90A15	cytochrome P450 90A1	glyma.Wm82.gnm2.ann1.Glyma.11g228900
+ELF4A	protein EARLY FLOWERING 4a	glyma.Wm82.gnm2.ann1.Glyma.11g229700
+CYP26	peptidyl-prolyl cis-trans isomerase CYP26	glyma.Wm82.gnm2.ann1.Glyma.11g229800
+C2-116	C2 domain containing protein gene 116	glyma.Wm82.gnm2.ann1.Glyma.11G229900
+C2-117	C2 domain containing protein gene 117	glyma.Wm82.gnm2.ann1.Glyma.11G230000
+C2-118	C2 domain containing protein gene 118	glyma.Wm82.gnm2.ann1.Glyma.11G230100
 SFERH-3	ferritin	glyma.Wm82.gnm2.ann1.Glyma.11g232600
-SFERH-4	ferritin	glyma.Wm82.gnm2.ann1.Glyma.14g056800
-SFR2	beta-glycosidase-like	glyma.Wm82.gnm2.ann1.Glyma.17g037100
-SFT	seed-flooding tolerance	glyma.Wm82.gnm2.ann1.Glyma.13g248000
-SG-1-LIKE	putative UDP-glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.07g254900
-SG-3, UGT91H4	Plant uridine 5' -diphosphate glycosyltransferase 91H4	glyma.Wm82.gnm2.ann1.Glyma.10g104700
-SG-4, UGT73P10	Plant uridine 5' -diphosphate glycosyltransferase 73P10	glyma.Wm82.gnm2.ann1.Glyma.01g046300
-SG-9	UDP-glycosyltransferase UGT73B4	glyma.Wm82.gnm2.ann1.Glyma.16g033700
-SGF14G	14-3-3 protein SGF14g	glyma.Wm82.gnm2.ann1.Glyma.02g208700
-SGF14e	14-3-3 protein SGF14e	glyma.Wm82.gnm2.ann1.Glyma.01g058000
-SGF14f	14-3-3 protein SGF14f	glyma.Wm82.gnm2.ann1.Glyma.02g115900
-SGR	AP2-domain transcription factor SGR	glyma.Wm82.gnm2.ann1.Glyma.02g264700
-SGR1	Stay-green gene 1	glyma.Wm82.gnm2.ann1.Glyma.11g027400
-SGR2	Stay-green gene 2	glyma.Wm82.gnm2.ann1.Glyma.01g214600
-SGS3	sRNA biogenesis gene 3	glyma.Wm82.gnm2.ann1.Glyma.04G203600
-SGT1-1	Suppressor of the G2 allele of SKP1 gene 1	glyma.Wm82.gnm2.ann1.Glyma.01g222400
-SGT1-2	Suppressor of the G2 allele of SKP1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.09g128800
-SGT2, UGT73P2	Plant uridine 5' -diphosphate glycosyltransferase 73P2	glyma.Wm82.gnm2.ann1.Glyma.11G053400
-SGT3, UGT91H	Plant uridine 5' -diphosphate glycosyltransferase 91H	glyma.Wm82.gnm2.ann1.Glyma.08G181000
-SGlu4	glucan endo-1,3-beta-glucosidase	glyma.Wm82.gnm2.ann1.Glyma.15g142400
-SHMT, SHMT08	serine hyrdroxmethyltransferase	glyma.Wm82.gnm2.ann1.Glyma.08g108900
-SHOOT2	SHOOT2 protein	glyma.Wm82.gnm2.ann1.Glyma.19g190000
-SIG5B	RNA polymerase sigma factor sigE, chloroplastic/mitochondrial-like	glyma.Wm82.gnm2.ann1.Glyma.06g125700
-SIK1	stress-induced receptor-like kinase	glyma.Wm82.gnm2.ann1.Glyma.02g100300
-SIK2	stress-induced receptor-like kinase 2	glyma.Wm82.gnm2.ann1.Glyma.15g021400
-SIP1-1	aquaporin SIP1-1	glyma.Wm82.gnm2.ann1.Glyma.02g069800
-SIP1-2	aquaporin SIP1-2	glyma.Wm82.gnm2.ann1.Glyma.16g151300
-SIP1-3	aquaporin SIP1-3	glyma.Wm82.gnm2.ann1.Glyma.19g108400
-SIP1-4	aquaporin SIP1-4	glyma.Wm82.gnm2.ann1.Glyma.16g043800
-SIP1-6	aquaporin SIP1-6	glyma.Wm82.gnm2.ann1.Glyma.06g307000
-SIP2-1	aquaporin SIP2-1	glyma.Wm82.gnm2.ann1.Glyma.03g119300
-SIP2-2	aquaporin SIP2-2	glyma.Wm82.gnm2.ann1.Glyma.19g123600
-SIR	sulfite reductase [ferredoxin], chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.11g093200
-SIZ1A	E3 SUMO-protein ligase SIZ1a	glyma.Wm82.gnm2.ann1.Glyma.12g071300
-SIZ1B	E3 SUMO-protein ligase SIZ1b	glyma.Wm82.gnm2.ann1.Glyma.u020100
-SKIP16	F-box protein SKIP16-like	glyma.Wm82.gnm2.ann1.Glyma.11g126500
-SKP2A	protein binding  	glyma.Wm82.gnm1.ann1.Glyma14g26660
-SLD1.1	delta8-sphingolipid desaturase 1	glyma.Wm82.gnm2.ann1.Glyma.01g046000
-SLD1.2, SLD2-1	delta(8)-fatty-acid desaturase 2 gene 1	glyma.Wm82.gnm2.ann1.Glyma.02g106300
-SLD1.3, SLD2-2	delta(8)-fatty-acid desaturase 2 gene 2	glyma.Wm82.gnm2.ann1.Glyma.08g299900
-SLD1.4	sphingolipid delta-8 desaturase	glyma.Wm82.gnm2.ann1.Glyma.14g095400
-SLD1.5	delta8-sphingolipid desaturase	glyma.Wm82.gnm2.ann1.Glyma.17g228400
-SLD1.6	sphingolipid delta-8 desaturase	glyma.Wm82.gnm2.ann1.Glyma.18g120400
-SLTI114	matrix metalloproteinase	glyma.Wm82.gnm2.ann1.Glyma.02g028100
-SLTI248	DEAD-box RNA helicase	glyma.Wm82.gnm2.ann1.Glyma.01g010400
-SMEP1	metalloproteinase	glyma.Wm82.gnm2.ann1.Glyma.02g215700
-SMT2-1	sterol 24-C methyltransferase 2-1	glyma.Wm82.gnm2.ann1.Glyma.04g020600
-SMT2-2	24-methylenesterol C-methyltransferase 2-2	glyma.Wm82.gnm2.ann1.Glyma.06g020700
-SNAC41	NAC domain-containing protein 18-like	glyma.Wm82.gnm2.ann1.Glyma.06g249100
-SNAP-1	nucleosome assembly protein 1	glyma.Wm82.gnm2.ann1.Glyma.15g170700
-SNAP09	soluble NSF attachment protein 9	glyma.Wm82.gnm2.ann1.Glyma.09g279400
-SNF5	chromatin structure-remodeling complex protein BSH-like	glyma.Wm82.gnm2.ann1.Glyma.13g117200
-SNRK1	SNF-1-like serine/threonine protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13g060400
-SNRK1.1	sucrose non-fermenting-1 related protein kinase	glyma.Wm82.gnm2.ann1.Glyma.08g240300
-SOD, SOD1	superoxide dismutase [Cu-Zn]	glyma.Wm82.gnm2.ann1.Glyma.19g240400
-SODB	Fe-superoxide dismutase	glyma.Wm82.gnm2.ann1.Glyma.20g196900
-SODB2	iron-superoxide dismutase	glyma.Wm82.gnm2.ann1.Glyma.10g193500
-SOMT-2	flavonoid 4'-O-methyltransferase SOMT-2	glyma.Wm82.gnm2.ann1.Glyma.08g2467002
-SOMT-9	O-methyltransferase SOMT-9	glyma.Wm82.gnm2.ann1.Glyma.17g171100
-SOS1	Na+/H+ antiporter	glyma.Wm82.gnm2.ann1.Glyma.08g092000
-SOY69	actin	glyma.Wm82.gnm2.ann1.Glyma.05g000900
-SOYAP1	aspartic proteinase 1	glyma.Wm82.gnm2.ann1.Glyma.17g011500
-SOYAP2	aspartic proteinase 2	glyma.Wm82.gnm2.ann1.Glyma.19g225500
-SOYCTA	putative cadmium-transporting ATPase	glyma.Wm82.gnm2.ann1.Glyma.05g098800
-SOYGBFA	G-box binding factor	glyma.Wm82.gnm2.ann1.Glyma.11g065000
+Lac46	Laccase 46	glyma.Wm82.gnm2.ann1.Glyma.11G233400
+PDH2	prephenate dehydrogenase 2	glyma.Wm82.gnm2.ann1.Glyma.11g233900
+SNAP11	soluble NSF attachment protein 11	glyma.Wm82.gnm2.ann1.Glyma.11g234500
 SOYSTGA	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.11g236300
-SPCH1	transcription factor SPEECHLESS	glyma.Wm82.gnm2.ann1.Glyma.04g238400
-SPCH2	transcription factor SPEECHLESS-like	glyma.Wm82.gnm2.ann1.Glyma.06g125500
-SPCH3	transcription factor SPEECHLESS-like	glyma.Wm82.gnm2.ann1.Glyma.13g040100
-SPCH4	transcription factor SPEECHLESS-like	glyma.Wm82.gnm2.ann1.Glyma.14g160700
-SPCP1	nodulin-26	glyma.Wm82.gnm2.ann1.Glyma.03g185900
-SPK-1	protein kinase	glyma.Wm82.gnm2.ann1.Glyma.01g204200
-SPK-2	protein kinase 2	glyma.Wm82.gnm2.ann1.Glyma.11g038800
-SPK-3	protein kinase 3	glyma.Wm82.gnm2.ann1.Glyma.08g005100
-SPK-4	protein kinase	glyma.Wm82.gnm2.ann1.Glyma.04g205400
-SPL9A	squamosa promoter-binding-like protein 9a	glyma.Wm82.gnm2.ann1.Glyma.02g177500
-SPL9B	squamosa promoter-binding-like protein 9b	glyma.Wm82.gnm2.ann1.Glyma.09g113800
-SPL9C	squamosa promoter-binding-like protein 9c	glyma.Wm82.gnm2.ann1.Glyma.03g143100
-SPL9D	squamosa promoter-binding-like protein 9d	glyma.Wm82.gnm2.ann1.Glyma.19g146000
-SPX1	SPX domain-containing protein 1	glyma.Wm82.gnm2.ann1.Glyma.01g135500
-SPX2	SPX domain-containing protein 2	glyma.Wm82.gnm2.ann1.Glyma.04g067400
-SPX3	SPX domain-containing protein 3	glyma.Wm82.gnm2.ann1.Glyma.04g147600
-SPX5	SPX domain-containing protein 5	glyma.Wm82.gnm2.ann1.Glyma.10g261900
-SPX6	SPX domain-containing 6	glyma.Wm82.gnm2.ann1.Glyma.13g061700
-SPX7	SPX domain-containing 7	glyma.Wm82.gnm2.ann1.Glyma.13g166800
-SPX8	SPX domain-containing protein 8	glyma.Wm82.gnm2.ann1.Glyma.17g114700
-SPX9	SPX domain-containing protein 9	glyma.Wm82.gnm2.ann1.Glyma.20g129000
-SPY1	probable UDP-N-acetylglucosamine--peptide N-acetylglucosaminyltransferase SPINDLY-like	glyma.Wm82.gnm2.ann1.Glyma.02g201300
-SR1	Serine racemase-1 involved in D-Serine biosynthetic process	glyma.Wm82.gnm1.ann1.Glyma05G37930
-SR2	Serine racemase-2	glyma.Wm82.gnm1.ann1.Glyma08G01670
-SRA2	GTP binding protein	glyma.Wm82.gnm2.ann1.Glyma.09g243300
-SRC1	src1 protein	glyma.Wm82.gnm2.ann1.Glyma.17g187600
-SRT1	NAD-dependent protein deacylase SRT2-like	glyma.Wm82.gnm2.ann1.Glyma.04g210000
-SRT2	NAD-dependent protein deacylase SRT2-like	glyma.Wm82.gnm2.ann1.Glyma.06g156000
-SRT4	NAD-dependent protein deacetylase SRT1-like	glyma.Wm82.gnm2.ann1.Glyma.18g076300
-SS	sucrose synthase	glyma.Wm82.gnm2.ann1.Glyma.13g114000
-SSH1	polyphosphoinositide binding protein Ssh1p	glyma.Wm82.gnm2.ann1.Glyma.07g268700
-SSTP-1	subtilisin-type protease precursor	glyma.Wm82.gnm2.ann1.Glyma.06g022600
-SSTP-2	subtilisin-type protease precursor	glyma.Wm82.gnm2.ann1.Glyma.06g022500
-ST1	sulfotransferase 1	glyma.Wm82.gnm2.ann1.Glyma.13G191400
-STF-3	zinc finger protein ZAT10-like	glyma.Wm82.gnm2.ann1.Glyma.14g088300
-STF2	transcription factor STF2	glyma.Wm82.gnm2.ann1.Glyma.08g302500
-STM	Short Transmembrane Mitochondrial Protein	glyma.Wm82.gnm2.ann1.Glyma.07G263600
-STOP1	C2-H2 zinc finger protein	glyma.Wm82.gnm2.ann1.Glyma.10g215200
-STP	sorbitol-like transporter	glyma.Wm82.gnm2.ann1.Glyma.11g119500
-STP1	monosaccharide transporter	glyma.Wm82.gnm2.ann1.Glyma.07g189500
-STV2B	sialyltransferase-like	glyma.Wm82.gnm2.ann1.Glyma.08g051300
-SUB1	SUB1 homolog (S. cerevisiae)	glyma.Wm82.gnm2.ann1.Glyma.08g109000
-SUBI-1, Ubiqutin	Ubiqutin	glyma.Wm82.gnm2.ann1.Glyma.20G141600
-SUBI-2	polyubiquitin	glyma.Wm82.gnm2.ann1.Glyma.13g117900
-SUT1	sucrose transporter	glyma.Wm82.gnm2.ann1.Glyma.10g217900
-SVPL	MADS-box protein SVP-like	glyma.Wm82.gnm2.ann1.Glyma.02g041500
-SWEET11	sucrose effluxer gene 11	glyma.Wm82.gnm1.ann1.Glyma05g38340
-SWEET12	sucrose effluxer gene 12	glyma.Wm82.gnm1.ann1.Glyma05g38350
-SWEET18	sucrose effluxer gene 18	glyma.Wm82.gnm1.ann1.Glyma06g21570
-SWEET19	sucrose effluxer gene 19	glyma.Wm82.gnm1.ann1.Glyma06g21640
-SWEET27	sucrose effluxer gene 27	glyma.Wm82.gnm1.ann1.Glyma08g48280
-SWEET3	sucrose effluxer gene 3	glyma.Wm82.gnm1.ann1.Glyma03g39430
-SWEET35	sucrose effluxer gene 35	glyma.Wm82.gnm1.ann1.Glyma14g17810
-SWEET6	sucrose effluxer gene 6	glyma.Wm82.gnm1.ann1.Glyma04g37530
-SYMRK-ALPHA	symbiosis receptor kinase SymRK-alpha	glyma.Wm82.gnm2.ann1.Glyma.01g020100
-SYMRK-BETA	symbiosis receptor kinase SymRK-beta	glyma.Wm82.gnm2.ann1.Glyma.09g202300
-SYP38	syntaxin	glyma.Wm82.gnm1.ann1.Glyma14g06610
-TAP1	acetyltransferase TAP1	glyma.Wm82.gnm2.ann1.Glyma.18g216900
-TBP1	TATA-box binding protein	glyma.Wm82.gnm2.ann1.Glyma.16g140200
-TBP2	TATA BINDING PROTEIN 2	glyma.Wm82.gnm1.ann1.Glyma16g25450
-TCHQD1	glutathione S-transferase TCHQD-like	glyma.Wm82.gnm2.ann1.Glyma.06g117800
-TCHQD2	glutathione S-transferase TCHQD-like	glyma.Wm82.gnm2.ann1.Glyma.13g034200
-TCHQD3	Glutathione S-transferase TCHQD3	glyma.Wm82.gnm2.ann1.Glyma.14g155200
-TCP, TCP42	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 42	glyma.Wm82.gnm2.ann1.Glyma.15G092500
-TCP1	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 1	glyma.Wm82.gnm2.ann1.Glyma.01G045500
-TCP10	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 10	glyma.Wm82.gnm2.ann1.Glyma.08G299400
-TCP11	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 11	glyma.Wm82.gnm2.ann1.Glyma.09G284300
-TCP12	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 12	glyma.Wm82.gnm2.ann1.Glyma.09G284500
-TCP13	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 13	glyma.Wm82.gnm2.ann1.Glyma.10G057400
-TCP14	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 14	glyma.Wm82.gnm2.ann1.Glyma.10G240200
-TCP16	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 16	glyma.Wm82.gnm2.ann1.Glyma.11G196000
-TCP17	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 17	glyma.Wm82.gnm2.ann1.Glyma.12G168300
-TCP18	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 18	glyma.Wm82.gnm2.ann1.Glyma.13G144100
-TCP19	Teosinte branched1 and cycloidea and proliferating cell factor family proteingene 19	glyma.Wm82.gnm2.ann1.Glyma.16G004300
-TCP2	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 2	glyma.Wm82.gnm2.ann1.Glyma.02G105900
-TCP20	Teosinte branched1 and cycloidea and proliferating cell factor family proteingene 20	glyma.Wm82.gnm2.ann1.Glyma.16G053900
-TCP21	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 21	glyma.Wm82.gnm2.ann1.Glyma.17G099100
-TCP22	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 22	glyma.Wm82.gnm2.ann1.Glyma.17G132400
-TCP23	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 23	glyma.Wm82.gnm2.ann1.Glyma.18G121400
-TCP24	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 24	glyma.Wm82.gnm2.ann1.Glyma.19G095300
-TCP25	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 25	glyma.Wm82.gnm2.ann1.Glyma.20G103400
-TCP26	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 26	glyma.Wm82.gnm2.ann1.Glyma.20G154400
-TCP27	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 27	glyma.Wm82.gnm2.ann1.Glyma.04G161400
-TCP28	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 28	glyma.Wm82.gnm2.ann1.Glyma.05G019900
-TCP29	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 29	glyma.Wm82.gnm2.ann1.Glyma.05G142000
-TCP3	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 3	glyma.Wm82.gnm2.ann1.Glyma.03G018800
-TCP30	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 30	glyma.Wm82.gnm2.ann1.Glyma.06G204300
-TCP31	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 31	glyma.Wm82.gnm2.ann1.Glyma.06G232300
-TCP32	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 32	glyma.Wm82.gnm2.ann1.Glyma.06G284500
-TCP33	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 33	glyma.Wm82.gnm2.ann1.Glyma.08G097900
-TCP34	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 34	glyma.Wm82.gnm2.ann1.Glyma.08G247300
+Lac47	Laccase 47	glyma.Wm82.gnm2.ann1.Glyma.11G236800
+MIPS	myo-inositol-3-phosphate synthase	glyma.Wm82.gnm2.ann1.Glyma.11g238800
+C2-119	C2 domain containing protein gene 119	glyma.Wm82.gnm2.ann1.Glyma.11G239900
+SEOI	sieve element occlusion i	glyma.Wm82.gnm2.ann1.Glyma.11g244200
+URE	urease	glyma.Wm82.gnm2.ann1.Glyma.11g248700
+DPB3-1	dr1-associated corepressor	glyma.Wm82.gnm2.ann1.Glyma.11g250000
+NTF2B-3	nucleus transporter 2B gene 3	glyma.Wm82.gnm2.ann1.Glyma.11g251700
+CAMTA14	Calmodulin binding transcription activator 14	glyma.Wm82.gnm2.ann1.Glyma.11G251900
+PPR114	Psudo-Response Regulator gene 114	glyma.Wm82.gnm2.ann1.Glyma.11G254200
+Lac48	Laccase 48	glyma.Wm82.gnm2.ann1.Glyma.11G256700
+MED13-2	Mediator Complex 13 gene 2	glyma.Wm82.gnm2.ann1.Glyma.11G256800
+C2-120	C2 domain containing protein gene 120	glyma.Wm82.gnm2.ann1.Glyma.12G001500
+PM27	seed maturation protein PM27	glyma.Wm82.gnm2.ann1.Glyma.12g001600
+NAC171	NAC domain-containing protein 171	glyma.Wm82.gnm2.ann1.Glyma.12g003200
+NAC080	NAC Transcription Factor gene 80	glyma.Wm82.gnm2.ann1.Glyma.12G004900
+ATG3A	autophagy-related protein 3a	glyma.Wm82.gnm2.ann1.Glyma.12g005700
+PAP36	purple acid phosphatase 36	glyma.Wm82.gnm2.ann1.Glyma.12g007500
+PPR115	Psudo-Response Regulator gene 115	glyma.Wm82.gnm2.ann1.Glyma.12G009800
+ATG7	autophagy-related protein ATG7	glyma.Wm82.gnm2.ann1.Glyma.12g010000
+IQD40	protein IQ-DOMAIN 40	glyma.Wm82.gnm2.ann1.Glyma.12g011600
+PG11	polygalacturonase precursor	glyma.Wm82.gnm2.ann1.Glyma.12g012200
+HSP23.9	low molecular weight heat shock protein Hsp23.9	glyma.Wm82.gnm2.ann1.Glyma.12g013100
+GRF13	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.12g014700
+MYB101	transcription factor MYB101	glyma.Wm82.gnm2.ann1.Glyma.12g017000
+NAC081, NAC6	NAC domain protein NAC6	glyma.Wm82.gnm2.ann1.Glyma.12g022700
+LEA2-63	late embryogenesis abundant 2 gene 63	glyma.Wm82.gnm2.ann1.Glyma.12G023200
+Lac49	Laccase 49	glyma.Wm82.gnm2.ann1.Glyma.12G023300
+XIP1-1	aquaporin XIP1-1	glyma.Wm82.gnm2.ann1.Glyma.12g023600
+CYP, CYP2	peptidyl-prolyl cis-trans isomerase CYP2	glyma.Wm82.gnm2.ann1.Glyma.12g024700
+MED35-3	Mediator Complex 35 gene 3	glyma.Wm82.gnm2.ann1.Glyma.12g028100
+C2-121	C2 domain containing protein gene 121	glyma.Wm82.gnm2.ann1.Glyma.12G028200
+LAX12	auxin transporter-like protein 12	glyma.Wm82.gnm2.ann1.Glyma.12g030900
+CYP40	peptidyl-prolyl cis-trans isomerase CYP40	glyma.Wm82.gnm2.ann1.Glyma.12g031500
+MYB54	MYB transcription factor MYB54	glyma.Wm82.gnm2.ann1.Glyma.12g032200
+C2-122	C2 domain containing protein gene 122	glyma.Wm82.gnm2.ann1.Glyma.12G032400
+bZIP95	Basic leucine zipper transcription factor-like protein gene 95	glyma.Wm82.gnm2.ann1.Glyma.12G033000
+BZIP21, bZIP96	Basic leucine zipper transcription factor-like protein gene 96	glyma.Wm82.gnm2.ann1.Glyma.12G036400
+BFA3	chloroplast stromal protein BFA3	glyma.Wm82.gnm2.ann1.Glyma.12g038800
+NARK	nodule autoregulation receptor kinase	glyma.Wm82.gnm2.ann1.Glyma.12g040000
+bZIP97	Basic leucine zipper transcription factor-like protein gene 97	glyma.Wm82.gnm2.ann1.Glyma.12G040600
+GRP	glycine-rich RNA-binding protein	glyma.Wm82.gnm2.ann1.Glyma.12g043000
+COR1	cold-regulated protein	glyma.Wm82.gnm2.ann1.Glyma.12g047500
+GLYII-5	putative hydroxyacylglutathione hydrolase	glyma.Wm82.gnm2.ann1.Glyma.12g050800
+ARI2	putative E3 ubiquitin-protein ligase ARI2	glyma.Wm82.gnm2.ann1.Glyma.12g053500
+ICHG	isoflavone conjugate-specific beta-glucosidase	glyma.Wm82.gnm2.ann1.Glyma.12g053800
+ALDH3J2	aldehyde dehydrogenase family 3 member J2	glyma.Wm82.gnm2.ann1.Glyma.12g057400
+LUXB	transcription factor LUXb	glyma.Wm82.gnm2.ann1.Glyma.12g060200
+Lac50	Laccase 50	glyma.Wm82.gnm2.ann1.Glyma.12G060900
+EXP5A	expansin-A4-like	glyma.Wm82.gnm2.ann1.Glyma.12g062700
+SAc4	Actin 4 gene	glyma.Wm82.gnm2.ann1.Glyma.12g063400
+MED37-9	Mediator Complex 37 gene 9	glyma.Wm82.gnm2.ann1.Glyma.12g064000
+MYB145	MYB transcription factor MYB145	glyma.Wm82.gnm2.ann1.Glyma.12g066000
+FNSII-1	flavone synthase II	glyma.Wm82.gnm2.ann1.Glyma.12g067000
+FNSII-2	flavone synthase II	glyma.Wm82.gnm2.ann1.Glyma.12g067100
+SIZ1A	E3 SUMO-protein ligase SIZ1a	glyma.Wm82.gnm2.ann1.Glyma.12g071300
+RTRP2	probable E3 ubiquitin-protein ligase rbrA-like protein	glyma.Wm82.gnm2.ann1.Glyma.12g071900
+MAPK3-2	mitogen-activated protein kinase kinase gene 3 gene 2 	glyma.Wm82.gnm2.ann1.Glyma.12G073000
+APX-2, APX2	L-ascorbate peroxidase 2	glyma.Wm82.gnm2.ann1.Glyma.12g073100
+PRR7b	Pseudo Response Regultor 7 gene b	glyma.Wm82.gnm2.ann1.Glyma.12G073900
+CrRRk1R1 3	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.12G074600
+PIP2-4	aquaporin PIP2-4	glyma.Wm82.gnm2.ann1.Glyma.12g075400
+DRB2A	dsRNA-binding protein Drb2a	glyma.Wm82.gnm2.ann1.Glyma.12g075700
+GLYI-16	Glyoxylase 1 gene 16	glyma.Wm82.gnm2.ann1.Glyma.12g079700
+HD2A	histone deacetylase HDT1	glyma.Wm82.gnm2.ann1.Glyma.12g084700
+HDA13	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.12g086700
+PARP3	seed maturation protein PM38	glyma.Wm82.gnm2.ann1.Glyma.12g088300
+bZIP100, BZIP42	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.12g088700
+PHR20	MYB-CC domain-containing transcription factor PHR20	glyma.Wm82.gnm2.ann1.Glyma.12g089100
+NAC082	NAC Transcription Factor gene 82	glyma.Wm82.gnm2.ann1.Glyma.12G091200
+LEA2-64	late embryogenesis abundant 2 gene 64	glyma.Wm82.gnm2.ann1.Glyma.12G093600
+ALMT23	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.12g094400
+PM37	seed maturation protein PM37	glyma.Wm82.gnm2.ann1.Glyma.12g095700
+WRKY115	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.12G097100
+MAPKKK18-1	mitogen-activated protein kinase kinase 18 gene 1	glyma.Wm82.gnm2.ann1.Glyma.12G097200
+bZIP101	Basic leucine zipper transcription factor-like protein gene 101	glyma.Wm82.gnm2.ann1.Glyma.12G097500
+Lac51	Laccase 51	glyma.Wm82.gnm2.ann1.Glyma.12G097700
+ATG8d	autophagy-related protein 8d	glyma.Wm82.gnm2.ann1.Glyma.12g098400
+ICL	isocitrate lyase 2	glyma.Wm82.gnm2.ann1.Glyma.12g100500
+TPS9	terpene synthase 9	glyma.Wm82.gnm2.ann1.Glyma.12g102000
+PPR116	Psudo-Response Regulator gene 116	glyma.Wm82.gnm2.ann1.Glyma.12G102800
+DREBA	DREBa transcription factor	glyma.Wm82.gnm2.ann1.Glyma.12g103100
+EXPB7	expansin-B3-like	glyma.Wm82.gnm2.ann1.Glyma.12g111200
+PPR117	Psudo-Response Regulator gene 117	glyma.Wm82.gnm2.ann1.Glyma.12G115500
+ERF91	Ethylene-responsive factor gene 91	glyma.Wm82.gnm2.ann1.Glyma.12G117000
+PPR118	Psudo-Response Regulator gene 118	glyma.Wm82.gnm2.ann1.Glyma.12G118200
+bZIP102, BZIP48	bZIP transcription factor 48	glyma.Wm82.gnm2.ann1.Glyma.12g121000
 TCP35	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 35	glyma.Wm82.gnm2.ann1.Glyma.12G121500
-TCP36	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 36	glyma.Wm82.gnm2.ann1.Glyma.12G158900
-TCP37	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 37	glyma.Wm82.gnm2.ann1.Glyma.12G208800
-TCP38	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 38	glyma.Wm82.gnm2.ann1.Glyma.12G228300
-TCP39	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 39	glyma.Wm82.gnm2.ann1.Glyma.13G219900
-TCP4	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 4	glyma.Wm82.gnm2.ann1.Glyma.04G170600
-TCP40	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 40	glyma.Wm82.gnm2.ann1.Glyma.13G271700
-TCP41	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 41	glyma.Wm82.gnm2.ann1.Glyma.13G292500
-TCP43	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 43	glyma.Wm82.gnm2.ann1.Glyma.17G079900
-TCP44	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 44	glyma.Wm82.gnm2.ann1.Glyma.18G268700
-TCP45	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 45	glyma.Wm82.gnm2.ann1.Glyma.19G030900
-TCP46	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 46	glyma.Wm82.gnm2.ann1.Glyma.04G152400
-TCP47	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 47	glyma.Wm82.gnm2.ann1.Glyma.05G013300
-TCP49	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 49	glyma.Wm82.gnm2.ann1.Glyma.08G256400
-TCP5	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 5	glyma.Wm82.gnm2.ann1.Glyma.05G027400
-TCP50	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 50	glyma.Wm82.gnm2.ann1.Glyma.10G246200
-TCP51	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 51	glyma.Wm82.gnm2.ann1.Glyma.13G047400
-TCP52	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 52	glyma.Wm82.gnm2.ann1.Glyma.17G121500
-TCP53	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 53	glyma.Wm82.gnm2.ann1.Glyma.18G280700
-TCP54	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 54	glyma.Wm82.gnm2.ann1.Glyma.19G044400
-TCP55	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 55	glyma.Wm82.gnm2.ann1.Glyma.20G148500
-TCP6	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 6	glyma.Wm82.gnm2.ann1.Glyma.05G050400
-TCP7	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 7	glyma.Wm82.gnm2.ann1.Glyma.06G193000
-TCP8	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 8	glyma.Wm82.gnm2.ann1.Glyma.07G080300
-TCP9	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 9	glyma.Wm82.gnm2.ann1.Glyma.07G177200
-TDF-5	uncharacterized protein TDF-5	glyma.Wm82.gnm2.ann1.Glyma.17g109300
-TEFS1	Elongation factor 1-alpha	glyma.Wm82.gnm2.ann1.Glyma.17g186600
-TENA_E	seed maturation protein PM36	glyma.Wm82.gnm2.ann1.Glyma.17g032700
-TFIIB1	transcription factor TFIIB	glyma.Wm82.gnm2.ann1.Glyma.10g108600
-TFL1.4	terminal flowering 1-like protein 4	glyma.Wm82.gnm2.ann1.Glyma.09g143500
-TFL1b	Terminal Flower 1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.19g194300
-TGA01	bZIP transcription factor 1	glyma.Wm82.gnm2.ann1.Glyma.01g084200
-TGA03	bZIP transcription factor 3	glyma.Wm82.gnm2.ann1.Glyma.02g176800
-TGA04	bZIP transcription factor 4	glyma.Wm82.gnm2.ann1.Glyma.03g127600
-TGA08	bZIP transcription factor 8	glyma.Wm82.gnm2.ann1.Glyma.05g182500
-TGA17	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.12g184500
-TGA2.13	Transcription Factor	glyma.Wm82.gnm2.ann1.Glyma.13G193700
-TIL	temperature-induced lipocalin	glyma.Wm82.gnm2.ann1.Glyma.09g098900
-TIL'	temperature-induced lipocalin'	glyma.Wm82.gnm2.ann1.Glyma.15g205900
-TIP2-4	aquaporin TIP2-4	glyma.Wm82.gnm2.ann1.Glyma.08g203000
-TIP3-2	aquaporin TIP3-2	glyma.Wm82.gnm2.ann1.Glyma.16g210000
-TIP4-1	aquaporin TIP4-1	glyma.Wm82.gnm2.ann1.Glyma.04g083200
-TIP5-1	aquaporin TIP5-1	glyma.Wm82.gnm2.ann1.Glyma.09g224700
-TIR1A	protein TRANSPORT INHIBITOR RESPONSE 1A	glyma.Wm82.gnm2.ann1.Glyma.02g152800
-TIR1B	protein TRANSPORT INHIBITOR RESPONSE 1B	glyma.Wm82.gnm2.ann1.Glyma.10g021500
-TIR1C	protein TRANSPORT INHIBITOR RESPONSE 1C	glyma.Wm82.gnm2.ann1.Glyma.19g206800
-TIR1D	protein TRANSPORT INHIBITOR RESPONSE 1D	glyma.Wm82.gnm2.ann1.Glyma.03g209400
-TMT2a	gamma-Tocopherol methyltranserase 2 gene a	glyma.Wm82.gnm1.ann1.Glyma12g01690
-TOPP1	TOPP-type protein phosphatase gene 1	glyma.Wm82.gnm2.ann1.Glyma.02G006000
-TOPP10	TOPP-type protein phosphatase gene 10	glyma.Wm82.gnm2.ann1.Glyma.10G186600
-TOPP11	TOPP-type protein phosphatase gene 11	glyma.Wm82.gnm2.ann1.Glyma.14G065200
-TOPP12	TOPP-type protein phosphatase gene 12	glyma.Wm82.gnm2.ann1.Glyma.19G232300
-TOPP13	TOPP-type protein phosphatase gene 13	glyma.Wm82.gnm2.ann1.Glyma.19G248700
-TOPP14	TOPP-type protein phosphatase gene 14	glyma.Wm82.gnm2.ann1.Glyma.20G203900
-TOPP15	TOPP-type protein phosphatase gene 15	glyma.Wm82.gnm2.ann1.Glyma.20G222500
-TOPP2	TOPP-type protein phosphatase gene 2	glyma.Wm82.gnm2.ann1.Glyma.02G251600
-TOPP3	TOPP-type protein phosphatase gene 3	glyma.Wm82.gnm2.ann1.Glyma.03G234700
-TOPP4	TOPP-type protein phosphatase gene 4	glyma.Wm82.gnm2.ann1.Glyma.03G251500
-TOPP5	TOPP-type protein phosphatase gene 5	glyma.Wm82.gnm2.ann1.Glyma.05G212100
-TOPP6	TOPP-type protein phosphatase gene 6	glyma.Wm82.gnm2.ann1.Glyma.06G027300
-TOPP7	TOPP-type protein phosphatase gene 7	glyma.Wm82.gnm2.ann1.Glyma.08G018500
-TOPP8	TOPP-type protein phosphatase gene 8	glyma.Wm82.gnm2.ann1.Glyma.10G006800
-TOPP9	TOPP-type protein phosphatase gene 9	glyma.Wm82.gnm2.ann1.Glyma.10G166700
-TPP	trehalose 6-phosphate phosphatase	glyma.Wm82.gnm2.ann1.Glyma.18G018100
-TPR	Transcription Repressor	glyma.Wm82.gnm2.ann1.Glyma.13g367300
-TPS	trehalose 6-phosphate synthase	glyma.Wm82.gnm2.ann1.Glyma.17G067800
-TPS1	terpene synthase 1	glyma.Wm82.gnm2.ann1.Glyma.03g154400
+Lac52	Laccase 52	glyma.Wm82.gnm2.ann1.Glyma.12G121700
+SC-03	thiamin biosynthetic enzyme	glyma.Wm82.gnm2.ann1.Glyma.12g135000
 TPS10	terpene synthase 10	glyma.Wm82.gnm2.ann1.Glyma.12g138100
 TPS11	terpene synthase 11	glyma.Wm82.gnm2.ann1.Glyma.12g138600
 TPS13	terpene synthase 13	glyma.Wm82.gnm2.ann1.Glyma.12g140600
+NAC172	NAC domain-containing protein 172	glyma.Wm82.gnm2.ann1.Glyma.12g145100
+DGK9	diacylglycerol kinase 9	glyma.Wm82.gnm2.ann1.Glyma.12g146700
+PPR119	Psudo-Response Regulator gene 119	glyma.Wm82.gnm2.ann1.Glyma.12G146900
+CCDA	cytochrome c-type biogenesis ccda-like chloroplastic protein 2-like	glyma.Wm82.gnm2.ann1.Glyma.12g147300
+CrRLk1L14	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.12G148200
+CYP52	peptidyl-prolyl cis-trans isomerase CYP52	glyma.Wm82.gnm2.ann1.Glyma.12g148600
+WRKY116, WRKY44	WRKY transcription factor 44	glyma.Wm82.gnm2.ann1.Glyma.12g152600
+HGO1	homogentisate 1,2-dioxygenase	glyma.Wm82.gnm2.ann1.Glyma.12g158600
+TCP36	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 36	glyma.Wm82.gnm2.ann1.Glyma.12G158900
+MDH-1, Mdh1	malate dehydrogenase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.12g159300
+NAC173	NAC domain-containing protein 173	glyma.Wm82.gnm2.ann1.Glyma.12g160100
+PEPC1, PEPC16, PEPC6, PPC16	phosphoenolpyruvate carboxylase	glyma.Wm82.gnm2.ann1.Glyma.12G161300
+NAC086	NAC Transcription Factor gene 86	glyma.Wm82.gnm2.ann1.Glyma.12G161700
+ERF92	Ethylene-responsive factor gene 92	glyma.Wm82.gnm2.ann1.Glyma.12G162700
+MMT1	methionine S-methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.12g163700
+RAB7P	ras-related protein RABD1-like	glyma.Wm82.gnm2.ann1.Glyma.12g165300
+EF1BGAMMA2	elongation factor 1-gamma-like	glyma.Wm82.gnm2.ann1.Glyma.12g165500
+GLYI-17	putative lactoylglutathione lyase	glyma.Wm82.gnm2.ann1.Glyma.12g167400
+TCP17	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 17	glyma.Wm82.gnm2.ann1.Glyma.12G168300
+NAC087	NAC Transcription Factor gene 87	glyma.Wm82.gnm2.ann1.Glyma.12G171600
+PIP2-5	aquaporin PIP2-5	glyma.Wm82.gnm2.ann1.Glyma.12g172500
+PDIL-2	protein disulfide isomerase-like protein	glyma.Wm82.gnm2.ann1.Glyma.12g172800
+LOG	Lonely Guy	glyma.Wm82.gnm2.ann1.Glyma.12G174900
+BHLH57	bHLH transcription factor	glyma.Wm82.gnm2.ann1.Glyma.12g178500
+ZFP3	C2H2-type zinc finger protein 3	glyma.Wm82.gnm2.ann1.Glyma.12g178900
+TPS27	terpene synthase 27	glyma.Wm82.gnm2.ann1.Glyma.12g179500
+HDT4	histone deacetylase HDT1-like	glyma.Wm82.gnm2.ann1.Glyma.12g181400
+PSK1	putative phytosulfokines 6-like	glyma.Wm82.gnm2.ann1.Glyma.12g181700
+CYP35	peptidyl-prolyl cis-trans isomerase CYP35	glyma.Wm82.gnm2.ann1.Glyma.12g182700
+PPR120	Psudo-Response Regulator gene 120	glyma.Wm82.gnm2.ann1.Glyma.12G183600
+CEN3	CENTRORADIALIS-like protein 3	glyma.Wm82.gnm2.ann1.Glyma.12g184000
+PPR121	Psudo-Response Regulator gene 121	glyma.Wm82.gnm2.ann1.Glyma.12G184200
+bZIP103	Basic leucine zipper transcription factor-like protein gene 103	glyma.Wm82.gnm2.ann1.Glyma.12G184400
+TGA17	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.12g184500
+PHR21	MYB-CC domain-containing transcription factor PHR21	glyma.Wm82.gnm2.ann1.Glyma.12g184700
+NAC088	NAC Transcription Factor gene 88	glyma.Wm82.gnm2.ann1.Glyma.12G186200
+NAC174	NAC Transcription Factor gene 174	glyma.Wm82.gnm2.ann1.Glyma.12G186900
+LEA2-65	late embryogenesis abundant 2 gene 65	glyma.Wm82.gnm2.ann1.Glyma.12G187600
+HDA14	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.12g188200
+ALMT24	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.12g188400
+ALMT25	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.12g188500
+Lac53	Laccase 53	glyma.Wm82.gnm2.ann1.Glyma.12G192800
+LEA2-66	late embryogenesis abundant 2 gene 66	glyma.Wm82.gnm2.ann1.Glyma.12G194700
+COL12	zinc finger protein CONSTANS-LIKE 12-like	glyma.Wm82.gnm2.ann1.Glyma.12g196100
 TPS14	terpene synthase 14	glyma.Wm82.gnm2.ann1.Glyma.12g197400
 TPS15	terpene synthase 15	glyma.Wm82.gnm2.ann1.Glyma.12g197500
+PETC	Rieske iron-sulphur protein precursor	glyma.Wm82.gnm2.ann1.Glyma.12g199400
+DGK3	diacylglycerol kinase 3	glyma.Wm82.gnm2.ann1.Glyma.12g200100
+LEA2-67	late embryogenesis abundant 2 gene 67	glyma.Wm82.gnm2.ann1.Glyma.12G202900
+DREB5	dehydration-responsive element binding protein 5	glyma.Wm82.gnm2.ann1.Glyma.12g203100
+EXPB8	expansin-B3-like	glyma.Wm82.gnm2.ann1.Glyma.12g203600
+NAC090	NAC Transcription Factor gene 90	glyma.Wm82.gnm2.ann1.Glyma.12G206900
+bZIP105, BZIP58	transcription factor bZIP58	glyma.Wm82.gnm2.ann1.Glyma.12g208400
+TCP37	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 37	glyma.Wm82.gnm2.ann1.Glyma.12G208800
+NIC1	CLAVATA3/ESR (CLE)-related protein NIC1	glyma.Wm82.gnm2.ann1.Glyma.12g208900
+GF14n, SGF14O	14-3-3 protein SGF14o	glyma.Wm82.gnm2.ann1.Glyma.12g210400
+PEPC4, PEPC7, ppc4	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.12G210600
+WRKY117, WRKY16	WRKY transcription factor 16	glyma.Wm82.gnm2.ann1.Glyma.12g212300
+COBL15	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.12G213400
+NDR1b	CC-NB-LRR resistance (R) protein	glyma.Wm82.gnm2.ann1.Glyma.12g214100
+CAMK1	CaM-binding protein kinase CaMK1	glyma.Wm82.gnm2.ann1.Glyma.12g216000
 TPS16	terpene synthase 16	glyma.Wm82.gnm2.ann1.Glyma.12g216200
+NF-YC08	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.12g217200
+SALI5-4A	sali5-4a protein	glyma.Wm82.gnm2.ann1.Glyma.12g217300
+CrRLk1L15	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.12G220400
+NAC4	NAC domain protein NAC4	glyma.Wm82.gnm2.ann1.Glyma.12g221500
+NAC093, NLP4	protein CUP-SHAPED COTYLEDON 2-like	glyma.Wm82.gnm2.ann1.Glyma.12g226500
+ERF6, ERF93	Ethylene-responsive factor gene 93	glyma.Wm82.gnm2.ann1.Glyma.12G226600
+bZIP106	Basic leucine zipper transcription factor-like protein gene 106	glyma.Wm82.gnm2.ann1.Glyma.12G227700
+IQD42	protein IQ-DOMAIN 42	glyma.Wm82.gnm2.ann1.Glyma.12g228200
+TCP38	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 38	glyma.Wm82.gnm2.ann1.Glyma.12G228300
+GF14o, SGF14n	14-3-3 protein SGF14n	glyma.Wm82.gnm2.ann1.Glyma.12g229200
+PEPC, PEPC15, PEPC8, PEPCase, PPC1	phosphoenolpyruvate carboxylase	glyma.Wm82.gnm2.ann1.Glyma.12g229400
+BES1-10	protein BRI1-EMS-SUPPRESSOR 1	glyma.Wm82.gnm2.ann1.Glyma.12g231400
+BES1-12	protein BRI1-EMS-SUPPRESSOR 1	glyma.Wm82.gnm2.ann1.Glyma.12g231500
+SWEET29	sugar efflux transporter SWEET29	glyma.Wm82.gnm2.ann1.Glyma.12g234500
+CrRLk1L16	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.12G235900
+NF-YA11	nuclear transcription factor Y subunit A-11	glyma.Wm82.gnm2.ann1.Glyma.12g236800
+PPR122	Psudo-Response Regulator gene 122	glyma.Wm82.gnm2.ann1.Glyma.12G239300
+C2-123	C2 domain containing protein gene 123	glyma.Wm82.gnm2.ann1.Glyma.12G239600
+IPK2	inositol polyphosphate 6-/3-/5-kinase	glyma.Wm82.gnm2.ann1.Glyma.12g240900
+LEA2-68	late embryogenesis abundant 2 gene 68	glyma.Wm82.gnm2.ann1.Glyma.13G000500
+SWEET32	sugar efflux transporter SWEET32	glyma.Wm82.gnm2.ann1.Glyma.13g002700
+C2-124	C2 domain containing protein gene 124	glyma.Wm82.gnm2.ann1.Glyma.13G003100
+C2-125	C2 domain containing protein gene 125	glyma.Wm82.gnm2.ann1.Glyma.13G003800
+N-56	probable 2-isopropylmalate synthase	glyma.Wm82.gnm2.ann1.Glyma.13g024700
+ALDH3H3	aldehyde dehydrogenase family 3 member H3	glyma.Wm82.gnm2.ann1.Glyma.13g030400
+NAC19	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.13g030900
+Lac54	Laccase 54	glyma.Wm82.gnm2.ann1.Glyma.13G033600
+PIa	Pistillata gene a	glyma.Wm82.gnm2.ann1.Glyma.13G034100
+TCHQD2	glutathione S-transferase TCHQD-like	glyma.Wm82.gnm2.ann1.Glyma.13g034200
+GA20OX5	gibberellin 20 oxidase 5	glyma.Wm82.gnm2.ann1.Glyma.13g035600
+SWEET31	sugar efflux transporter SWEET31	glyma.Wm82.gnm2.ann1.Glyma.13g037900
+PIN6A	auxin efflux carrier component 6a	glyma.Wm82.gnm2.ann1.Glyma.13g038300
+GASA18	gibberellin-regulated protein 18	glyma.Wm82.gnm2.ann1.Glyma.13g039300
+GASA19	gibberellin-regulated protein 19	glyma.Wm82.gnm2.ann1.Glyma.13g039600
+SPCH3	transcription factor SPEECHLESS-like	glyma.Wm82.gnm2.ann1.Glyma.13g040100
+PHT1-13	inorganic phosphate transporter 1-13	glyma.Wm82.gnm2.ann1.Glyma.13g040200
+ERF94	Ethylene-responsive factor gene 94	glyma.Wm82.gnm2.ann1.Glyma.13G040400
+SWEET30	sugar efflux transporter SWEET30	glyma.Wm82.gnm2.ann1.Glyma.13g041300
+RBCS-1	Ribulose bisphosphate carboxylase small chain 1, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.13g046200
+AOC4	allene oxide cyclase 3, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.13g047300
+TCP51	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 51	glyma.Wm82.gnm2.ann1.Glyma.13G047400
+COL2a	Constance-like 2 gene a	glyma.Wm82.gnm2.ann1.Glyma.13G050300
+bZIP107	Basic leucine zipper transcription factor-like protein gene 107	glyma.Wm82.gnm2.ann1.Glyma.13G050700
+AGL8c	Agamous 8-Like gene c	glyma.Wm82.gnm2.ann1.Glyma.13G052100
+COBL16	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.13G053300
+GrnCrRLk1L17	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G053600
+GinCrRI,k1l,18	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G053700
+GinCrRl,k1l,19	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G053800
+CrRLkUGo	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G054200
+GinCrRI,k1l,21	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G054300
+GinCrRI,k1l,22	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G054400
+IF7MaT	malonyl-CoA:isoflavone 7-O-glucoside-6''-O-malonyltransferase	glyma.Wm82.gnm2.ann1.Glyma.13g056100
+SNRK1	SNF-1-like serine/threonine protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13g060400
+ERF95	Ethylene-responsive factor gene 95	glyma.Wm82.gnm2.ann1.Glyma.13G060600
+PPR123	Psudo-Response Regulator gene 123	glyma.Wm82.gnm2.ann1.Glyma.13G060800
+SPX6	SPX domain-containing 6	glyma.Wm82.gnm2.ann1.Glyma.13g061700
+PRR124	Psudo-Response Regulator gene 124	glyma.Wm82.gnm2.ann1.Glyma.13G062300
+MYB53	MYB transcription factor MYB53	glyma.Wm82.gnm2.ann1.Glyma.13g063200
+NAC094	NAC Transcription Factor gene 94	glyma.Wm82.gnm2.ann1.Glyma.13G063300
+MED4-3	Mediator Complex 4 gene 3	glyma.Wm82.gnm2.ann1.Glyma.13g067700
+CYP82A3	cytochrome P450 82A3-like	glyma.Wm82.gnm2.ann1.Glyma.13g068800
+FTRC	ferredoxin thioredoxin reductase precursor	glyma.Wm82.gnm2.ann1.Glyma.13g069100
+GASA21	gibberellin-regulated protein 21	glyma.Wm82.gnm2.ann1.Glyma.13g069900
+RFP1	RING-type E3 ubiquitin ligase	glyma.Wm82.gnm2.ann1.Glyma.13g071600
+F3'5'H	flavonoid 3', 5'-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.13g072100
+SCAM-2	calmodulin	glyma.Wm82.gnm2.ann1.Glyma.13g074800
+bZIP108	Basic leucine zipper transcription factor-like protein gene 108	glyma.Wm82.gnm2.ann1.Glyma.13G075000
+Lac55	Laccase 55	glyma.Wm82.gnm2.ann1.Glyma.13G076900
+SEOJ	sieve element occlusion j	glyma.Wm82.gnm2.ann1.Glyma.13g077200
+AP2-3, ERF96	Ethylene-responsive factor gene 96	glyma.Wm82.gnm2.ann1.Glyma.13G081600
+FLS1	Flavonol synthase 1	glyma.Wm82.gnm2.ann1.Glyma.13g082300
+NR1-2	nitrate reductase 1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.13g084000
+MEKK	MAPK/ERK kinase kinase family protein	glyma.Wm82.gnm2.ann1.Glyma.13g084100
+bZIP109, BZIP83	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.13g085100
+bZIP110	Basic leucine zipper transcription factor-like protein gene 110	glyma.Wm82.gnm2.ann1.Glyma.13G085300
+ANNEXIN	annexin D1-like	glyma.Wm82.gnm2.ann1.Glyma.13g088700
+DGK7	diacylglycerol kinase 7	glyma.Wm82.gnm2.ann1.Glyma.13g093100
+COL10	zinc finger protein CONSTANS-LIKE 5-like	glyma.Wm82.gnm2.ann1.Glyma.13g093800
+ZTL2	clock-associated PAS protein ZEITLUPE 2	glyma.Wm82.gnm2.ann1.Glyma.13g097600
+VTE2-1	homogentisate phytyltransferase 1, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.13g097800
+BZIP82	bZIP transcription factor bZIP82	glyma.Wm82.gnm2.ann1.Glyma.13g099500
+bHLH35	PREDICTED: transcription factor bHLH35-like	glyma.Wm82.gnm2.ann1.Glyma.13G101100
+PIN2A	auxin efflux carrier component 2a	glyma.Wm82.gnm2.ann1.Glyma.13g101900
+WRKY118, WRKY13	WRKY transcription factor 13	glyma.Wm82.gnm2.ann1.Glyma.13g102000
+DGAT1A	diacylglycerol acyltransferase	glyma.Wm82.gnm2.ann1.Glyma.13g106100
+GLYI-18	putative lactoylglutathione lyase	glyma.Wm82.gnm2.ann1.Glyma.13g106600
+NF-YA12	nuclear transcription factor Y subunit A-12	glyma.Wm82.gnm2.ann1.Glyma.13g107900
+MED20-1	Mediator Complex 20 gene 1	glyma.Wm82.gnm2.ann1.Glyma.13g109300
+GRF14	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.13g109500
+FabF	3-ketoacyl-ACP-synthase II	glyma.Wm82.gnm2.ann1.Glyma.13g112700
+SS	sucrose synthase	glyma.Wm82.gnm2.ann1.Glyma.13g114000
+Ms1	Male Sterile 1	glyma.Wm82.gnm2.ann1.Glyma.13G114200
+IAA40	Indole-3-Acetic Acid Responsive Gene 40	glyma.Wm82.gnm2.ann1.Glyma.13G117100
+SNF5	chromatin structure-remodeling complex protein BSH-like	glyma.Wm82.gnm2.ann1.Glyma.13g117200
+WRKY119	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.13G117600
+SUBI-2	polyubiquitin	glyma.Wm82.gnm2.ann1.Glyma.13g117900
+PGMPM10	51 kDa seed maturation protein	glyma.Wm82.gnm2.ann1.Glyma.13g119400
+PPR125	Psudo-Response Regulator gene 125	glyma.Wm82.gnm2.ann1.Glyma.13G119700
+PPR126	Psudo-Response Regulator gene 126	glyma.Wm82.gnm2.ann1.Glyma.13G121800
+ERF97	Ethylene-responsive factor gene 97	glyma.Wm82.gnm2.ann1.Glyma.13G122500
+ERF98	Ethylene-responsive factor gene 98	glyma.Wm82.gnm2.ann1.Glyma.13G122600
+ERF99	Ethylene-responsive factor gene 99	glyma.Wm82.gnm2.ann1.Glyma.13G122700
+ERF100	Ethylene-responsive factor gene 100	glyma.Wm82.gnm2.ann1.Glyma.13G122800
+ERF101	Ethylene-responsive factor gene 101	glyma.Wm82.gnm2.ann1.Glyma.13G122900
+ERF102	Ethylene-responsive factor gene 102	glyma.Wm82.gnm2.ann1.Glyma.13G123000
+ERF103	Ethylene-responsive factor gene 103	glyma.Wm82.gnm2.ann1.Glyma.13G123100
+glycinin A3B4, Gy5	Glycinin gene 5	glyma.Wm82.gnm2.ann1.Glyma.13g123500
+PHR22	MYB-CC domain-containing transcription factor PHR22	glyma.Wm82.gnm2.ann1.Glyma.13g126200
+IAA41	Indole-3-Acetic Acid Responsive Gene 41	glyma.Wm82.gnm2.ann1.Glyma.13G127000
+GSTL3	glutathione S-transferase L3	glyma.Wm82.gnm2.ann1.Glyma.13g135500
+PRR7c	Pseudo Response Regultor 7 gene c	glyma.Wm82.gnm2.ann1.Glyma.13G135900
+IQD43	protein IQ-DOMAIN 43	glyma.Wm82.gnm2.ann1.Glyma.13g137500
+IAA42	Indole-3-Acetic Acid Responsive Gene 42	glyma.Wm82.gnm2.ann1.Glyma.13G140500
+TCP18	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 18	glyma.Wm82.gnm2.ann1.Glyma.13G144100
+PAL2.3	phenylalanine ammonia-lyase 2.3	glyma.Wm82.gnm2.ann1.Glyma.13g145000
+MP2, PM2	maturation polypeptide 2 gene	glyma.Wm82.gnm2.ann1.Glyma.13g149000
+HSF-28	heat stress transcription factor 28	glyma.Wm82.gnm2.ann1.Glyma.13g151200
+bZIP111	Basic leucine zipper transcription factor-like protein gene 111	glyma.Wm82.gnm2.ann1.Glyma.13G153200
+IAA43	Indole-3-Acetic Acid Responsive Gene 43	glyma.Wm82.gnm2.ann1.Glyma.13G159000
+RPS11	ribosomal protein S11	glyma.Wm82.gnm2.ann1.Glyma.13g165200
+SPX7	SPX domain-containing 7	glyma.Wm82.gnm2.ann1.Glyma.13g166800
+GLYI-19	putative lactoylglutathione lyase	glyma.Wm82.gnm2.ann1.Glyma.13g168200
+ERA1B	farnesyltransferase ERA1B	glyma.Wm82.gnm2.ann1.Glyma.13g168600
+CYP53	peptidyl-prolyl cis-trans isomerase CYP53	glyma.Wm82.gnm2.ann1.Glyma.13g169500
+SWEET33	sugar efflux transporter SWEET33	glyma.Wm82.gnm2.ann1.Glyma.13g169700
+ALDH2B6	aldehyde dehydrogenase family 2 member B6	glyma.Wm82.gnm2.ann1.Glyma.13g170600
+IQD44	protein IQ-DOMAIN 44	glyma.Wm82.gnm2.ann1.Glyma.13g172000
+IOMT1	isoflavone 4'-O-methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.13g173300
+IFS2	2-hydroxyisoflavanone synthase	glyma.Wm82.gnm2.ann1.Glyma.13g173500
+IOMT2	isoflavone 4'-O-methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.13g173600
+NAC097	NAC Transcription Factor gene 97	glyma.Wm82.gnm2.ann1.Glyma.13G174700
+RAD51a	Radiation- repair 51 gene a	glyma.Wm82.gnm2.ann1.Glyma.13G175300
+HSP17.6-L	17.6 kDa class I heat shock protein	glyma.Wm82.gnm2.ann1.Glyma.13g176000
+HSP17.5-E	17.5 kDa class I heat shock protein	glyma.Wm82.gnm2.ann1.Glyma.13g176200
+PPR127	Psudo-Response Regulator gene 127	glyma.Wm82.gnm2.ann1.Glyma.13G179700
+HSF-27	heat stress transcription factor 27	glyma.Wm82.gnm2.ann1.Glyma.13g180200
+MED16-1	Mediator Complex 16 gene 1	glyma.Wm82.gnm2.ann1.Glyma.13g181200
 TPS17	terpene synthase 17	glyma.Wm82.gnm2.ann1.Glyma.13g1836001
+CRK42	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13g188900
+CRK43	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13g189000
+SEOL	uncharacterized LOC100807591	glyma.Wm82.gnm2.ann1.Glyma.13g1911001
+ANN14	annexin A7-like	glyma.Wm82.gnm2.ann1.Glyma.13g191200
+ST1	sulfotransferase 1	glyma.Wm82.gnm2.ann1.Glyma.13G191400
+BZIP99, TGA2.13	Transcription Factor	glyma.Wm82.gnm2.ann1.Glyma.13G193700
+A1	albumin 1	glyma.Wm82.gnm2.ann1.Glyma.13g194400
+C2-126	C2 domain containing protein gene 126	glyma.Wm82.gnm2.ann1.Glyma.13G198600
+GinCrRI,k1l,23	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.13G201400
+NF-YA13	nuclear transcription factor Y subunit A-13	glyma.Wm82.gnm2.ann1.Glyma.13g202300
+NF-YC09	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.13g207500
+NF-YC10	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.13g207600
+NF-YC11	nuclear factor Y transcription factor family protein	glyma.Wm82.gnm2.ann1.Glyma.13g207700
+MED5-3	Mediator Complex 5 gene 3	glyma.Wm82.gnm2.ann1.Glyma.13g209800
+GS-2	glutamine synthetase precursor	glyma.Wm82.gnm2.ann1.Glyma.13g210800
+BMY9	Beta-amylase 9	glyma.Wm82.gnm2.ann1.Glyma.13g215000
+GA2OX5	gibberellin 2-beta-dioxygenase 5	glyma.Wm82.gnm2.ann1.Glyma.13g218200
+TCP39	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 39	glyma.Wm82.gnm2.ann1.Glyma.13G219900
+PPR128	Psudo-Response Regulator gene 128	glyma.Wm82.gnm2.ann1.Glyma.13G220400
+NIP1-8	aquaporin NIP1-8	glyma.Wm82.gnm2.ann1.Glyma.13g224900
+HSF-29	heat stress transcription factor 29	glyma.Wm82.gnm2.ann1.Glyma.13g225700
+BIN2	putative BR-insensitive 2	glyma.Wm82.gnm2.ann1.Glyma.13g228100
+DOF10	dof zinc finger protein DOF1.5-like	glyma.Wm82.gnm2.ann1.Glyma.13g230200
+chl1, CHLI	Mg-protoporphyrin IX chelatase subunit ChlI	glyma.Wm82.gnm2.ann1.Glyma.13g232500
+IQD45	protein IQ-DOMAIN 45	glyma.Wm82.gnm2.ann1.Glyma.13g232700
+ERF105	Ethylene-responsive factor gene 105	glyma.Wm82.gnm2.ann1.Glyma.13G233800
+ERF106	Ethylene-responsive factor gene 106	glyma.Wm82.gnm2.ann1.Glyma.13G233900
+NAC098	NAC Transcription Factor gene 98	glyma.Wm82.gnm2.ann1.Glyma.13G234700
+ERF107	Ethylene-responsive factor gene 107	glyma.Wm82.gnm2.ann1.Glyma.13G236500
+ERF108	Ethylene-responsive factor gene 108	glyma.Wm82.gnm2.ann1.Glyma.13G236600
+PM32	maturation protein pPM32	glyma.Wm82.gnm2.ann1.Glyma.13g237700
+DES1.1	sphingolipid delta(4)-desaturase DES1-like	glyma.Wm82.gnm2.ann1.Glyma.13g240700
+AHAS3, ALS-3, ALS3	Acetolactate synthase gene 3	glyma.Wm82.gnm2.ann1.Glyma.13g241000
+MED16-2	Mediator Complex 16 gene 2	glyma.Wm82.gnm2.ann1.Glyma.13g241100
+SFT	seed-flooding tolerance	glyma.Wm82.gnm2.ann1.Glyma.13g248000
+LEA2-69	late embryogenesis abundant 2 gene 69	glyma.Wm82.gnm2.ann1.Glyma.13G248600
+NES	nerol synthase	glyma.Wm82.gnm2.ann1.Glyma.13g250400
+PR1, PR1-1	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.13g251600
+PR1-2	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.13g251700
+PR1-4	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.13g252000
+PR1-3	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.13g252300
+PR1-5	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.13g252400
+NMHC5	MADS-box transcription factor NMHC5	glyma.Wm82.gnm2.ann1.Glyma.13g2552001
+GA2OX6	gibberellin 2-beta-dioxygenase 6	glyma.Wm82.gnm2.ann1.Glyma.13g259400
+GA2OX7	gibberellin 2-beta-dioxygenase 7	glyma.Wm82.gnm2.ann1.Glyma.13g259500
+BZIP94	bZIP transcription factor bZIP94	glyma.Wm82.gnm2.ann1.Glyma.13g260300
+C2-127	C2 domain containing protein gene 127	glyma.Wm82.gnm2.ann1.Glyma.13G261200
+GLYII-6	putative hydroxyacylglutathione hydrolase	glyma.Wm82.gnm2.ann1.Glyma.13g261400
+CHI3A1	chalcone isomerase 3A1	glyma.Wm82.gnm2.ann1.Glyma.13g262500
+SWEET34	sugar efflux transporter SWEET34	glyma.Wm82.gnm2.ann1.Glyma.13g264400
+SARK	senescence-associated receptor-like kinase	glyma.Wm82.gnm2.ann1.Glyma.13g266100
+BES1-11	protein BRI1-EMS-SUPPRESSOR 1	glyma.Wm82.gnm2.ann1.Glyma.13g266500
+BES1-9	protein BRI1-EMS-SUPPRESSOR 1	glyma.Wm82.gnm2.ann1.Glyma.13g266600
+WRKY120	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.13G267400
+WRKY121	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.13G267500
+WRKY122	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.13G267600
+WRKY123	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.13G267700
+GH	gamma glutamyl hydrolase	glyma.Wm82.gnm2.ann1.Glyma.13g267800
+PEPC7, PEPC9, ppc7	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.13G270400
+GF14p, SGF14P	14-3-3 protein SGF14p	glyma.Wm82.gnm2.ann1.Glyma.13g270600
+TCP40	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 40	glyma.Wm82.gnm2.ann1.Glyma.13G271700
+IQD46	protein IQ-DOMAIN 46	glyma.Wm82.gnm2.ann1.Glyma.13g271800
+BZIP112	putative bZIP domain class transcription factor	glyma.Wm82.gnm2.ann1.Glyma.13g272500
+ERF109	Ethylene-responsive factor gene 109	glyma.Wm82.gnm2.ann1.Glyma.13G274100
+NAC100	NAC Transcription Factor gene 100	glyma.Wm82.gnm2.ann1.Glyma.13G274300
+SCHI	chilling-induced protein	glyma.Wm82.gnm2.ann1.Glyma.13g275000
+NAC27	NAC transcription factor NAC27	glyma.Wm82.gnm2.ann1.Glyma.13g279900
+RD22	dehydration-responsive protein 22	glyma.Wm82.gnm2.ann1.Glyma.13G283900
+NF-YC12	nuclear factor Y transcription factor	glyma.Wm82.gnm2.ann1.Glyma.13g284000
 TPS19	terpene synthase 19	glyma.Wm82.gnm2.ann1.Glyma.13g285200
-TPS2	terpene synthase 2	glyma.Wm82.gnm2.ann1.Glyma.03g154700
+CYP82A2	cytochrome P450 82A2-like	glyma.Wm82.gnm2.ann1.Glyma.13g285300
+NDR1A	NDR1-like protein	glyma.Wm82.gnm2.ann1.Glyma.13g287500
+GA2ox8A	giberellin 2-oxidase 8 gene A	glyma.Wm82.gnm2.ann1.Glyma.13G287600
+GA2ox8B	giberellin 2-oxidase 8 gene B	glyma.Wm82.gnm2.ann1.Glyma.13G288000
+GM2S-1	2S albumin	glyma.Wm82.gnm2.ann1.Glyma.13g288100
+COBL17	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.13G288300
+WRKY124, WRKY52	WRKY transcription factor 52	glyma.Wm82.gnm2.ann1.Glyma.13g289400
+PEPC10, PEPC2	phosphoenolpyruvate carboxylase 2-like	glyma.Wm82.gnm2.ann1.Glyma.13G290700
+GF14D, GF14q	GF14 gene family gene q	glyma.Wm82.gnm2.ann1.Glyma.13G290900
+SBP65	Late embryonic abundant protein 65 kd	glyma.Wm82.gnm2.ann1.Glyma.13g291800
+TCP41	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 41	glyma.Wm82.gnm2.ann1.Glyma.13G292500
+bZIP115, BZIP8	bZIP transcription factor 8	glyma.Wm82.gnm2.ann1.Glyma.13g292800
+NAC175	NAC domain-containing protein 175	glyma.Wm82.gnm2.ann1.Glyma.13g294000
+EXPB9	expansin-B3-like	glyma.Wm82.gnm2.ann1.Glyma.13g298100
+LEA2-70	late embryogenesis abundant 2 gene 70	glyma.Wm82.gnm2.ann1.Glyma.13G298800
+DREB	dehydration-responsive element-binding protein	glyma.Wm82.gnm2.ann1.Glyma.13g304300
 TPS20	terpene synthase 20	glyma.Wm82.gnm2.ann1.Glyma.13g304500
+MYB172	MYB transcription factor MYB172	glyma.Wm82.gnm2.ann1.Glyma.13g307300
+LEA2-71	late embryogenesis abundant 2 gene 71	glyma.Wm82.gnm2.ann1.Glyma.13G307700
+LEA2-72	late embryogenesis abundant 2 gene 72	glyma.Wm82.gnm2.ann1.Glyma.13G307900
+WRKY125, WRKY36	WRKY transcription factor 36	glyma.Wm82.gnm2.ann1.Glyma.13g310100
+IQD47	protein IQ-DOMAIN 47	glyma.Wm82.gnm2.ann1.Glyma.13g311700
+LEA2-73	late embryogenesis abundant 2 gene 73	glyma.Wm82.gnm2.ann1.Glyma.13G313600
+LEA2-74	late embryogenesis abundant 2 gene 74	glyma.Wm82.gnm2.ann1.Glyma.13G313700
+NAC103	NAC Transcription Factor gene 103	glyma.Wm82.gnm2.ann1.Glyma.13G314600
+NAC104	NAC Transcription Factor gene 104	glyma.Wm82.gnm2.ann1.Glyma.13G315300
+PHR23	MYB-CC domain-containing transcription factor PHR23	glyma.Wm82.gnm2.ann1.Glyma.13g316600
+bZIP116, BZIP90	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.13g316900
+CEN4	protein CENTRORADIALIS-like	glyma.Wm82.gnm2.ann1.Glyma.13g317100
+CYP20	peptidyl-prolyl cis-trans isomerase CYP20	glyma.Wm82.gnm2.ann1.Glyma.13g318300
 TPS21	terpene synthase 21	glyma.Wm82.gnm2.ann1.Glyma.13g321100
-TPS23	terpene synthase 23	glyma.Wm82.gnm2.ann1.Glyma.20g074400
-TPS27	terpene synthase 27	glyma.Wm82.gnm2.ann1.Glyma.12g179500
-TPS3	geraniol synthase	glyma.Wm82.gnm2.ann1.Glyma.06g302200
-TPS4	terpene synthase 4	glyma.Wm82.gnm2.ann1.Glyma.07g187600
-TPS5	terpene synthase 5	glyma.Wm82.gnm2.ann1.Glyma.07g187700
-TPS6	terpene synthase 6	glyma.Wm82.gnm2.ann1.Glyma.08g061600
-TPS8	terpene synthase 8	glyma.Wm82.gnm2.ann1.Glyma.09g122500
-TPS9	terpene synthase 9	glyma.Wm82.gnm2.ann1.Glyma.12g102000
-TSA	tryptophan synthase alpha chain	glyma.Wm82.gnm2.ann1.Glyma.19g160800
-TSB	tryptophan synthase beta subunit	glyma.Wm82.gnm2.ann1.Glyma.11g003500
-TSF1	Twin sister of FT gene 1	glyma.Wm82.gnm2.ann1.Glyma.18g299000
-TSF2	Twin sister of FT gene 2	glyma.Wm82.gnm2.ann1.Glyma.18g298900
+BHLH56	basic helix-loop-helix transcription factor	glyma.Wm82.gnm2.ann1.Glyma.13g322100
+4CL	4-coumarate--CoA ligase-like 7-like	glyma.Wm82.gnm2.ann1.Glyma.13g323000
+CDC48	plamsma membrane-associated AAA-ATPase	glyma.Wm82.gnm2.ann1.Glyma.13g323600
+NRT2	NRT2 protein	glyma.Wm82.gnm2.ann1.Glyma.13g323800
+PIP2-6	aquaporin PIP2-6	glyma.Wm82.gnm2.ann1.Glyma.13g325900
+NAC105	NAC Transcription Factor gene 105	glyma.Wm82.gnm2.ann1.Glyma.13G327600
+PPR129	Psudo-Response Regulator gene 129	glyma.Wm82.gnm2.ann1.Glyma.13G332400
+MYB139	MYB transcription factor MYB139	glyma.Wm82.gnm2.ann1.Glyma.13g333200
+Lac56	Laccase 56	glyma.Wm82.gnm2.ann1.Glyma.13G338100
+MATE	aluminum-activated citrate transporter	glyma.Wm82.gnm2.ann1.Glyma.13g339800
+ALDH3J3	aldehyde dehydrogenase family 3 member J3	glyma.Wm82.gnm2.ann1.Glyma.13g340000
+C2-128	C2 domain containing protein gene 128	glyma.Wm82.gnm2.ann1.Glyma.13G342700
+PPR130	Psudo-Response Regulator gene 130	glyma.Wm82.gnm2.ann1.Glyma.13G345000
+bZIP118, BZIP51	bZIP transcription factor 51	glyma.Wm82.gnm2.ann1.Glyma.13g345200
+GLYII-7	putative hydroxyacylglutathione hydrolase	glyma.Wm82.gnm2.ann1.Glyma.13g345400
+LOX2, Lx2	Lipoxygenase 2 gene	glyma.Wm82.gnm2.ann1.Glyma.13g347500
+LOX1, Lx1	lipoxygenase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.13g347600
+L-4, LOX4, LoxB, LOXB1, VSP94	Vegitative storage protein 94 Kd gene	glyma.Wm82.gnm2.ann1.Glyma.13g347700
+IQD48	protein IQ-DOMAIN 48	glyma.Wm82.gnm2.ann1.Glyma.13g348400
+LEA2-75	late embryogenesis abundant 2 gene 75	glyma.Wm82.gnm2.ann1.Glyma.13G349900
+IQD49	protein IQ-DOMAIN 49	glyma.Wm82.gnm2.ann1.Glyma.13g353800
+IAA44	Indole-3-Acetic Acid Responsive Gene 44	glyma.Wm82.gnm2.ann1.Glyma.13G354100
+MYB62	MYB transcription factor MYB62	glyma.Wm82.gnm2.ann1.Glyma.13g354800
+IAA45	Indole-3-Acetic Acid Responsive Gene 45	glyma.Wm82.gnm2.ann1.Glyma.13G356600
+LEA2-76	late embryogenesis abundant 2 gene 76	glyma.Wm82.gnm2.ann1.Glyma.13G357600
+LEA2-77	late embryogenesis abundant 2 gene 77	glyma.Wm82.gnm2.ann1.Glyma.13G359200
+IAA46	Indole-3-Acetic Acid Responsive Gene 46	glyma.Wm82.gnm2.ann1.Glyma.13G361100
+IAA47	Indole-3-Acetic Acid Responsive Gene 47	glyma.Wm82.gnm2.ann1.Glyma.13G361200
+GA3OX3	gibberellin 3-beta-dioxygenase 3	glyma.Wm82.gnm2.ann1.Glyma.13g361700
+PM30	Seed maturation protein 30 gene	glyma.Wm82.gnm2.ann1.Glyma.13g363300
+N-44	nodulin-44	glyma.Wm82.gnm2.ann1.Glyma.13g364400
+C2-129	C2 domain containing protein gene 129	glyma.Wm82.gnm2.ann1.Glyma.13G364900
+TPR	Transcription Repressor	glyma.Wm82.gnm2.ann1.Glyma.13g367300
+MED15-2	Mediator Complex 15 gene 2	glyma.Wm82.gnm2.ann1.Glyma.13g367700
+ERF110	Ethylene-responsive factor gene 110	glyma.Wm82.gnm2.ann1.Glyma.13G369400
+CCR	cinnamoyl-CoA reductase	glyma.Wm82.gnm2.ann1.Glyma.13g369800
+NRAMP6A	metal transporter Nramp6a	glyma.Wm82.gnm2.ann1.Glyma.13g369900
+WRKY126	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.13G370100
+CYP701A16	ent-kaurene oxidase, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.13g371400
+4CL2	4-coumarate:coenzyme A ligase gene 2	glyma.Wm82.gnm2.ann1.Glyma.13g372000
+MED8-1	Mediator Complex 8 gene 1	glyma.Wm82.gnm2.ann1.Glyma.13g372700
+CPX	coproporphyrinogen oxidase	glyma.Wm82.gnm2.ann1.Glyma.14g003200
+PPR131	Psudo-Response Regulator gene 131	glyma.Wm82.gnm2.ann1.Glyma.14G003900
+CHR1	chalcone reductase CHR1	glyma.Wm82.gnm2.ann1.Glyma.14g005700
+WRKY127	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.14G006800
+MED17-2	Mediator Complex 17 gene 2	glyma.Wm82.gnm2.ann1.Glyma.14g007400
+NF-YA14	nuclear transcription factor Y subunit A-14	glyma.Wm82.gnm2.ann1.Glyma.14g010000
+LEA2-78	late embryogenesis abundant 2 gene 78	glyma.Wm82.gnm2.ann1.Glyma.14G010800
+WRKY128, WRKY7	WRKY transcription factor 7	glyma.Wm82.gnm2.ann1.Glyma.14g016200
+C2-130	C2 domain containing protein gene 130	glyma.Wm82.gnm2.ann1.Glyma.14G016700
+ERF111	Ethylene-responsive factor gene 111	glyma.Wm82.gnm2.ann1.Glyma.14G020100
+GPPS	geranyl-diphosphate synthase	glyma.Wm82.gnm2.ann1.Glyma.14g023000
+Phy, PHYTASE	purple acid phosphatase 18-like	glyma.Wm82.gnm2.ann1.Glyma.14g024700
+Raf47-1	Raf47proto-oncogene serine/threonine protein kinase gene 1	glyma.Wm82.gnm2.ann1.Glyma.14G026700
+AGL1	agamous-like MADS-box protein AGL1	glyma.Wm82.gnm2.ann1.Glyma.14g027200
+WRKY129	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.14G028900
+HPPD	4-hydroxyphenylpyruvate dioxygenase	glyma.Wm82.gnm2.ann1.Glyma.14g030400
+NAC106, NAC42-2	NAC domain-containing protein 42-like	glyma.Wm82.gnm2.ann1.Glyma.14g030700
+GST24	glutathione S-transferase 24	glyma.Wm82.gnm2.ann1.Glyma.14g031000
+C2-131	C2 domain containing protein gene 131	glyma.Wm82.gnm2.ann1.Glyma.14G034900
+CYCB1;3	mitotic cyclin b1-type	glyma.Wm82.gnm2.ann1.Glyma.14g037100
+LEA-1, LEA2-79	late embryogenesis abundant 2 gene 79	glyma.Wm82.gnm2.ann1.Glyma.14G037300
+Lac57	Laccase 57	glyma.Wm82.gnm2.ann1.Glyma.14G041300
+LEA2-80	late embryogenesis abundant 2 gene 80	glyma.Wm82.gnm2.ann1.Glyma.14G041700
+BZIP114	putative bZIP domain class transcription factor	glyma.Wm82.gnm2.ann1.Glyma.14g041800
+NFR1B	LysM-type receptor kinase NFR1B	glyma.Wm82.gnm2.ann1.Glyma.14g046200
+COP1	Ubiquitin Ligase	glyma.Wm82.gnm2.ann1.Glyma.14G049700
+ERF112	Ethylene-responsive factor gene 112	glyma.Wm82.gnm2.ann1.Glyma.14G050100
+PDIM-1	protein disulfide isomerse like protein	glyma.Wm82.gnm2.ann1.Glyma.14g050600
+SNAP14	soluble NSF attachment protein 14	glyma.Wm82.gnm2.ann1.Glyma.14g054900
+Lac58	Laccase 58	glyma.Wm82.gnm2.ann1.Glyma.14G056100
+DREB2A2	dehydration-responsive element-binding protein 2A2	glyma.Wm82.gnm2.ann1.Glyma.14g056200
+SFERH-4	ferritin	glyma.Wm82.gnm2.ann1.Glyma.14g056800
+C2-132	C2 domain containing protein gene 132	glyma.Wm82.gnm2.ann1.Glyma.14G059200
+C2-133	C2 domain containing protein gene 133	glyma.Wm82.gnm2.ann1.Glyma.14G059300
+C2-134	C2 domain containing protein gene 134	glyma.Wm82.gnm2.ann1.Glyma.14G059400
+LAX13	auxin transporter-like protein 13	glyma.Wm82.gnm2.ann1.Glyma.14g060700
+PIP1-7	aquaporin PIP1-7	glyma.Wm82.gnm2.ann1.Glyma.14g061500
+MYB75	MYB transcription factor MYB75	glyma.Wm82.gnm2.ann1.Glyma.14g062200
+Lac59	Laccase 59	glyma.Wm82.gnm2.ann1.Glyma.14G062300
+TOPP11	TOPP-type protein phosphatase gene 11	glyma.Wm82.gnm2.ann1.Glyma.14G065200
+ALDH18B4	delta-1-pyrroline-5-carboxylate synthase	glyma.Wm82.gnm2.ann1.Glyma.14g065600
+GMP1	mannose-1-phosphate guanylyltransferase 1-like	glyma.Wm82.gnm2.ann1.Glyma.14g065900
+RCA14	ribulose bisphosphate carboxylase/oxygenase activase 1, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.14g067000
+C2-135	C2 domain containing protein gene 135	glyma.Wm82.gnm2.ann1.Glyma.14G068400
+NIP4-2	aquaporin NIP4-2	glyma.Wm82.gnm2.ann1.Glyma.14g069500
+IPK1	inositol pentakisphosphate 2-kinase	glyma.Wm82.gnm2.ann1.Glyma.14g072200
+DFR1, DHFR1, W3	White flower 3	glyma.Wm82.gnm2.ann1.Glyma.14g072700
+DDKCS	3-ketoacyl-CoA synthase 4-like	glyma.Wm82.gnm2.ann1.Glyma.14g074300
+MYB164	MYB transcription factor MYB164	glyma.Wm82.gnm2.ann1.Glyma.14g074500
+BZL2	protein BRASSINAZOLE-RESISTANT 1-like	glyma.Wm82.gnm2.ann1.Glyma.14g076900
+AOS1	allene oxide synthase	glyma.Wm82.gnm2.ann1.Glyma.14g078600
+MAPKKK24-3	mitogen-activated protein kinase kinase kinase 24 gene 3	glyma.Wm82.gnm2.ann1.Glyma.14G080100
+NAC107	NAC Transcription Factor gene 107	glyma.Wm82.gnm2.ann1.Glyma.14G084300
+DREB1	dehydration responsive element binding protein	glyma.Wm82.gnm2.ann1.Glyma.14g084700
+WRKY130	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.14G085500
+ASP1	L-asparaginase	glyma.Wm82.gnm2.ann1.Glyma.14g086300
+MYB81	MYB transcription factor MYB81	glyma.Wm82.gnm2.ann1.Glyma.14g086500
+GASA22	gibberellin-regulated protein 22	glyma.Wm82.gnm2.ann1.Glyma.14g087200
+STF-3	zinc finger protein ZAT10-like	glyma.Wm82.gnm2.ann1.Glyma.14g088300
+ELF3B	protein EARLY FLOWERING 3b	glyma.Wm82.gnm2.ann1.Glyma.14g091900
+VPE2	vacuolar processing enzyme 2	glyma.Wm82.gnm2.ann1.Glyma.14g092800
+SLD1.4	sphingolipid delta-8 desaturase	glyma.Wm82.gnm2.ann1.Glyma.14g095400
+IDD	Zinc finger transcription factor	glyma.Wm82.gnm2.ann1.Glyma.14G095900
+HSF-30	heat stress transcription factor 30	glyma.Wm82.gnm2.ann1.Glyma.14g096800
+IQD50	protein IQ-DOMAIN 50	glyma.Wm82.gnm2.ann1.Glyma.14g097000
+CHI3C1	chalcone isomerase 3C1	glyma.Wm82.gnm2.ann1.Glyma.14g098100
+C2-136	C2 domain containing protein gene 136	glyma.Wm82.gnm2.ann1.Glyma.14G098500
+Raf49-1	Raf49 proto-oncogene serine/threonine protein kinase gene 1	glyma.Wm82.gnm2.ann1.Glyma.14G099300
+PHD4	PHD finger superfamily protein	glyma.Wm82.gnm2.ann1.Glyma.14g099700
+WRKY131	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.14G100100
+WRKY133	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.14G102900
+WRKY134	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.14G103100
+MGD1	monogalactosyldiacylglycerol synthase 1	glyma.Wm82.gnm2.ann1.Glyma.14g104100
+ERF113	Ethylene-responsive factor gene 113	glyma.Wm82.gnm2.ann1.Glyma.14G111600
+SBPRP	proline-rich protein	glyma.Wm82.gnm2.ann1.Glyma.14g115500
+SWEET36	sugar efflux transporter SWEET36	glyma.Wm82.gnm2.ann1.Glyma.14g120300
+PIN6B	auxin efflux carrier component 6b	glyma.Wm82.gnm2.ann1.Glyma.14g120900
+Adh1	Alcohol dehydrogenase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.14g121200
+ACPD-3, SACPD-C	stearoyl-acyl carrier protein desaturase	glyma.Wm82.gnm2.ann1.Glyma.14g121400
+PHT1-12	inorganic phosphate transporter 1-12	glyma.Wm82.gnm2.ann1.Glyma.14g123500
+ERF114	Ethylene-responsive factor gene 114	glyma.Wm82.gnm2.ann1.Glyma.14G123900
+CYP54	peptidyl-prolyl cis-trans isomerase CYP54	glyma.Wm82.gnm2.ann1.Glyma.14g125200
+BES1-8	protein BRI1-EMS-SUPPRESSOR 1	glyma.Wm82.gnm2.ann1.Glyma.14g127400
+GA3OX4	gibberellin 3-beta-dioxygenase 4	glyma.Wm82.gnm2.ann1.Glyma.14g128400
+WRKY135, WRKY31	WRKY transcription factor 31	glyma.Wm82.gnm2.ann1.Glyma.14g135400
+BZIP16	bZIP transcription factor bZIP16	glyma.Wm82.gnm2.ann1.Glyma.14g1397001
+NAC176	NAC domain-containing protein 176	glyma.Wm82.gnm2.ann1.Glyma.14g140100
+BURP2	BURP domain protein 2	glyma.Wm82.gnm2.ann1.Glyma.14g140900
+AP2-4, ERF115	Ethylene-responsive factor gene 115	glyma.Wm82.gnm2.ann1.Glyma.14G147500
+ALDH3H4	aldehyde dehydrogenase family 3 member H4	glyma.Wm82.gnm2.ann1.Glyma.14g152100
+NAC21	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.14g152700
+MYB-G20-1, W2	White flower 2	glyma.Wm82.gnm2.ann1.Glyma.14g154400
+PIc	Pistillata gene c	glyma.Wm82.gnm2.ann1.Glyma.14G155100
+TCHQD3	Glutathione S-transferase TCHQD3	glyma.Wm82.gnm2.ann1.Glyma.14g155200
+GA20OX6	gibberellin 20 oxidase 6	glyma.Wm82.gnm2.ann1.Glyma.14g157400
+IQD51	protein IQ-DOMAIN 51	glyma.Wm82.gnm2.ann1.Glyma.14g159300
+SWEET37	sugar efflux transporter SWEET37	glyma.Wm82.gnm2.ann1.Glyma.14g159900
+LEA2-81	late embryogenesis abundant 2 gene 81	glyma.Wm82.gnm2.ann1.Glyma.14G160000
+SWEET38	sugar efflux transporter SWEET38	glyma.Wm82.gnm2.ann1.Glyma.14g160100
+SPCH4	transcription factor SPEECHLESS-like	glyma.Wm82.gnm2.ann1.Glyma.14g160700
+NR	Nitrate reductase	glyma.Wm82.gnm2.ann1.Glyma.14g165000
+bZIP120, TGA21	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.14g167000
+bZIP121	Basic leucine zipper transcription factor-like protein gene 121	glyma.Wm82.gnm2.ann1.Glyma.14G167100
+CRY1c1	Cryptochrome 1c1	glyma.Wm82.gnm2.ann1.Glyma.14g174200
+NIP3-1	aquaporin NIP3-1	glyma.Wm82.gnm2.ann1.Glyma.14g174300
+Phi-1	phosphate-induced protein	glyma.Wm82.gnm2.ann1.Glyma.14G176500
+GF14r, SGF14K	14-3-3 protein SGF14k	glyma.Wm82.gnm2.ann1.Glyma.14g176900
+APX-4b	Ascorbate peroxidase 6 gene b	glyma.Wm82.gnm2.ann1.Glyma.14G177200
+PPR132	Psudo-Response Regulator gene 132	glyma.Wm82.gnm2.ann1.Glyma.14G184600
+IAA48	Indole-3-Acetic Acid Responsive Gene 48	glyma.Wm82.gnm2.ann1.Glyma.14G185400
+WRKY136	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.14G185800
+WRKY137	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.14G186000
+WRKY138	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.14G186100
+C2-137	C2 domain containing protein gene 137	glyma.Wm82.gnm2.ann1.Glyma.14G187500
+GLYII-8	putative hydroxyacylglutathione hydrolase	glyma.Wm82.gnm2.ann1.Glyma.14g187700
+PHT1-11	inorganic phosphate transporter 1-11	glyma.Wm82.gnm2.ann1.Glyma.14g188000
+NAC110	NAC Transcription Factor gene 110	glyma.Wm82.gnm2.ann1.Glyma.14G189300
+Lac60	Laccase 60	glyma.Wm82.gnm2.ann1.Glyma.14G191500
+MYB57	MYB transcription factor MYB57	glyma.Wm82.gnm2.ann1.Glyma.14g191700
+C2-138	C2 domain containing protein gene 138	glyma.Wm82.gnm2.ann1.Glyma.14G193800
+FAD3a	omega-3-fatty acid desaturase 3 gene 1	glyma.Wm82.gnm2.ann1.Glyma.14g194300
+PPR133	Psudo-Response Regulator gene 133	glyma.Wm82.gnm2.ann1.Glyma.14G194400
+AS2	asparagine synthetase 2	glyma.Wm82.gnm2.ann1.Glyma.14g195000
+MAKKK13-2	mitogen-activated protein kinase kinase 13 gene 2 	glyma.Wm82.gnm2.ann1.Glyma.14G195300
+bZIP122	Basic leucine zipper transcription factor-like protein gene 122	glyma.Wm82.gnm2.ann1.Glyma.14G197200
+Lac61	Laccase 61	glyma.Wm82.gnm2.ann1.Glyma.14G198900
+WRKY139, WRP1	WRKY-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.14g199800
+WRKY140, WRKY49	WRKY transcription factor 49	glyma.Wm82.gnm2.ann1.Glyma.14g200200
+DAD1	dolichyl-diphosphooligosaccharide--protein glycosyltransferase subunit DAD1	glyma.Wm82.gnm2.ann1.Glyma.14g201900
+WNK13	with no lysine kinase 13	glyma.Wm82.gnm2.ann1.Glyma.14g203700
+bZIP123, ZIP43	bZIP transcription factor 43	glyma.Wm82.gnm2.ann1.Glyma.14g204100
+RSV3	putative NBS-LRR family protein	glyma.Wm82.gnm2.ann1.Glyma.14g204700
+LEA2-82	late embryogenesis abundant 2 gene 82	glyma.Wm82.gnm2.ann1.Glyma.14G208000
+ARF8B	auxin response factor 8b	glyma.Wm82.gnm2.ann1.Glyma.14g208500
+NAC111	NAC Transcription Factor gene 111	glyma.Wm82.gnm2.ann1.Glyma.14G210000
+MYB177	MYB transcription factor MYB177	glyma.Wm82.gnm2.ann1.Glyma.14g210600
+IDH	isocitrate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.14g211000
+GS1-GAMMA, GS1-gamma1	Gamma glutamine synthase 1 gene	glyma.Wm82.gnm2.ann1.Glyma.14g213300
+GASA23	gibberellin-regulated protein 23	glyma.Wm82.gnm2.ann1.Glyma.14g215600
+bZIP124, BZIP3	bZIP transcription factor 3	glyma.Wm82.gnm2.ann1.Glyma.14g217200
+GASA24	gibberellin-regulated protein 24	glyma.Wm82.gnm2.ann1.Glyma.14g219100
+C2-139	C2 domain containing protein gene 139	glyma.Wm82.gnm2.ann1.Glyma.14G220000
+Lac62	Laccase 62	glyma.Wm82.gnm2.ann1.Glyma.14G223000
+CAT3	catalase	glyma.Wm82.gnm2.ann1.Glyma.14g223500
+PPR134	Psudo-Response Regulator gene 134	glyma.Wm82.gnm2.ann1.Glyma.14G224400
+KASIII-2	beta-ketoacyl-ACP synthetase 3 gene 2	glyma.Wm82.gnm2.ann1.Glyma.15g003100
+WRKY141, WRKY27, WRKY40	Putative WRKY transcription factor	glyma.Wm82.gnm2.ann1.Glyma.15G003300
+NRAMP6B	metal transporter Nramp6b	glyma.Wm82.gnm2.ann1.Glyma.15g003500
+NIP6-3	aquaporin NIP6-3	glyma.Wm82.gnm2.ann1.Glyma.15g003900
+ERF116	Ethylene-responsive factor gene 116	glyma.Wm82.gnm2.ann1.Glyma.15G004200
+bHLH15	bHLH protein	glyma.Wm82.gnm2.ann1.Glyma.15G005100
+MED15-3	Mediator Complex 15 gene 3	glyma.Wm82.gnm2.ann1.Glyma.15g005500
+C2-140	C2 domain containing protein gene 140	glyma.Wm82.gnm2.ann1.Glyma.15G008400
+C2-141	C2 domain containing protein gene 141	glyma.Wm82.gnm2.ann1.Glyma.15G008500
+ERF117	Ethylene-responsive factor gene 117	glyma.Wm82.gnm2.ann1.Glyma.15G008600
+GLYI-20	putative lactoylglutathione lyase	glyma.Wm82.gnm2.ann1.Glyma.15g009500
+GA3OX5	gibberellin 3-beta-dioxygenase 5	glyma.Wm82.gnm2.ann1.Glyma.15g012100
+IAA49	Indole-3-Acetic Acid Responsive Gene 49	glyma.Wm82.gnm2.ann1.Glyma.15G012700
+IAA50	Indole-3-Acetic Acid Responsive Gene 50	glyma.Wm82.gnm2.ann1.Glyma.15G012800
+LEA2-83	late embryogenesis abundant 2 gene 83	glyma.Wm82.gnm2.ann1.Glyma.15G015800
+PPR135	Psudo-Response Regulator gene 135	glyma.Wm82.gnm2.ann1.Glyma.15G016600
+FWL8	protein FW2.2-like 8	glyma.Wm82.gnm2.ann1.Glyma.15g016800
+IAA51	Indole-3-Acetic Acid Responsive Gene 51	glyma.Wm82.gnm2.ann1.Glyma.15G017500
+MYB52	MYB transcription factor MYB52	glyma.Wm82.gnm2.ann1.Glyma.15g019400
+IAA52	Indole-3-Acetic Acid Responsive Gene 52	glyma.Wm82.gnm2.ann1.Glyma.15G020300
+IQD52	protein IQ-DOMAIN 52	glyma.Wm82.gnm2.ann1.Glyma.15g020600
+SIK2	stress-induced receptor-like kinase 2	glyma.Wm82.gnm2.ann1.Glyma.15g021400
+LEA2-84	late embryogenesis abundant 2 gene 84	glyma.Wm82.gnm2.ann1.Glyma.15G024400
+IQD53	protein IQ-DOMAIN 53	glyma.Wm82.gnm2.ann1.Glyma.15g025400
+LOX3, Lx3	Lipoxygenase 3 gene	glyma.Wm82.gnm2.ann1.Glyma.15g026300
+L-5, LOX8, VLXB	lipoxygenase L-5	glyma.Wm82.gnm2.ann1.Glyma.15g026500
+NF-YA15	nuclear transcription factor Y subunit A-15	glyma.Wm82.gnm2.ann1.Glyma.15g027400
+GLYII-9	putative hydroxyacylglutathione hydrolase	glyma.Wm82.gnm2.ann1.Glyma.15g028900
+bZIP125	Basic leucine zipper transcription factor-like protein gene 125	glyma.Wm82.gnm2.ann1.Glyma.15G029100
+DBB	DBB protein	glyma.Wm82.gnm2.ann1.Glyma.15g029500
+ARI3	putative E3 ubiquitin-protein ligase ARI3	glyma.Wm82.gnm2.ann1.Glyma.15g031100
+C2-142	C2 domain containing protein gene 142	glyma.Wm82.gnm2.ann1.Glyma.15G031600
+LPAAT	lysophosphatidic acid acyltransferase	glyma.Wm82.gnm2.ann1.Glyma.15g034100
+ALDH3J4	aldehyde dehydrogenase family 3 member J4	glyma.Wm82.gnm2.ann1.Glyma.15g034400
+MYB82	MYB transcription factor MYB82	glyma.Wm82.gnm2.ann1.Glyma.15g034500
+PPR136	Psudo-Response Regulator gene 136	glyma.Wm82.gnm2.ann1.Glyma.15G041800
+GinCrRl,k1l,2-l	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.15G042900
+N-22	nodulin-22	glyma.Wm82.gnm2.ann1.Glyma.15g045000
+LEA2-85	late embryogenesis abundant 2 gene 85	glyma.Wm82.gnm2.ann1.Glyma.15G048800
+bZIP126	Basic leucine zipper transcription factor-like protein gene 126	glyma.Wm82.gnm2.ann1.Glyma.15G049000
+SWEET39	sugar efflux transporter SWEET39	glyma.Wm82.gnm2.ann1.Glyma.15g049200
+CYP71D10	cytochrome P450 CYP71D10	glyma.Wm82.gnm2.ann1.Glyma.15g050300
+PRX3	peroxidase 43	glyma.Wm82.gnm2.ann1.Glyma.15g050800
+NAC112	NAC Transcription Factor gene 112	glyma.Wm82.gnm2.ann1.Glyma.15G051200
+FabZ	3-hydroxyacyl-ACP dehydrase	glyma.Wm82.gnm2.ann1.Glyma.15g052500
+CAMTA3	Calmodulin binding transcription activator 3	glyma.Wm82.gnm2.ann1.Glyma.15G053600
+HSP40.1	DnaJ domain-containing protein HSP40.1	glyma.Wm82.gnm2.ann1.Glyma.15g057800
+ALDH6B3	putative methylmalonate-semialdehyde dehydrogenase [acylating]	glyma.Wm82.gnm2.ann1.Glyma.15g058900
+PGYRP7	proline/glycine/tyrosine-rich protein	glyma.Wm82.gnm2.ann1.Glyma.15g060400
+PR1-6	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.15g062400
+PR1-7	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.15g062500
+PR1-8	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.15g062700
+PRI1-9	pathogenesis-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.15g062800
+LEA2-86	late embryogenesis abundant 2 gene 86	glyma.Wm82.gnm2.ann1.Glyma.15G065400
+EN1	endonuclease	glyma.Wm82.gnm2.ann1.Glyma.15g068600
+MED16-3	Mediator Complex 15 gene 3	glyma.Wm82.gnm2.ann1.Glyma.15g072300
+AHAS4, ALS-4, ALS4	Acetolactate synthase gene 4	glyma.Wm82.gnm2.ann1.Glyma.15g072500
+DES1.2	sphingolipid delta(4)-desaturase DES1-like	glyma.Wm82.gnm2.ann1.Glyma.15g072800
+PK6	protein kinase	glyma.Wm82.gnm2.ann1.Glyma.15g074900
+ERF118	Ethylene-responsive factor gene 118	glyma.Wm82.gnm2.ann1.Glyma.15G077000
+ERF119	Ethylene-responsive factor gene 119	glyma.Wm82.gnm2.ann1.Glyma.15G077100
+NAC114	NAC Transcription Factor gene 114	glyma.Wm82.gnm2.ann1.Glyma.15G078300
+ERF120	Ethylene-responsive factor gene 120	glyma.Wm82.gnm2.ann1.Glyma.15G079100
+ERF121	Ethylene-responsive factor gene 121	glyma.Wm82.gnm2.ann1.Glyma.15G079200
+IQD54	protein IQ-DOMAIN 54	glyma.Wm82.gnm2.ann1.Glyma.15g080000
+PPR137	Psudo-Response Regulator gene 137	glyma.Wm82.gnm2.ann1.Glyma.15G084700
+HSF-31	heat stress transcription factor 31	glyma.Wm82.gnm2.ann1.Glyma.15g086400
+NIP1-4	aquaporin NIP1-4	glyma.Wm82.gnm2.ann1.Glyma.15g087300
+PPR138	Psudo-Response Regulator gene 138	glyma.Wm82.gnm2.ann1.Glyma.15G092000
+TCP, TCP42	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 42	glyma.Wm82.gnm2.ann1.Glyma.15G092500
+GA2OX8	gibberellin 2-beta-dioxygenase 8	glyma.Wm82.gnm2.ann1.Glyma.15g093900
+BMY1, BMY1-2	Beta-amylase 1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.15g098100
+MED5-4	Mediator Complex 5 gene 4	glyma.Wm82.gnm2.ann1.Glyma.15g102800
+IPT	isopentenyl transferase	glyma.Wm82.gnm2.ann1.Glyma.15g103800
+ATPC	ATP synthase gamma chain, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.15g107900
+ATG8C	autophagy-related protein 8c	glyma.Wm82.gnm2.ann1.Glyma.15g108200
+GLYI-21	putative lactoylglutathione lyase	glyma.Wm82.gnm2.ann1.Glyma.15g108400
+Lac63	Laccase 63	glyma.Wm82.gnm2.ann1.Glyma.15G109000
+WRKY142	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.15G110300
+NF-YB3b	Nuclear Transcripiton Factor Y Subunit Beta 3 gene b	glyma.Wm82.gnm2.ann1.Glyma.15G118800
+HPS	hydrophobic seed protein precursor	glyma.Wm82.gnm2.ann1.Glyma.15g119700
+C2-143	C2 domain containing protein gene 143	glyma.Wm82.gnm2.ann1.Glyma.15G120400
+C2-144	C2 domain containing protein gene 144	glyma.Wm82.gnm2.ann1.Glyma.15G121500
+PHR24	MYB-CC domain-containing transcription factor PHR24	glyma.Wm82.gnm2.ann1.Glyma.15g123000
+PHR25	MYB-CC domain-containing transcription factor PHR25	glyma.Wm82.gnm2.ann1.Glyma.15g123100
+ADF1	actin depolymerizing factor 1	glyma.Wm82.gnm2.ann1.Glyma.15g125300
+COPZ2	nonclathrin coat protein zeta2-COP	glyma.Wm82.gnm2.ann1.Glyma.15g125800
+RTRP4	reverse transcriptase-like domain-containing RBR protein	glyma.Wm82.gnm2.ann1.Glyma.15g126500
+NPR1.2.15	Non-induced pathogenesis-related gene	glyma.Wm82.gnm2.ann1.Glyma.15G127200
+bZIP127	Basic leucine zipper transcription factor-like protein gene 127	glyma.Wm82.gnm2.ann1.Glyma.15G129700
+NF-YA16	nuclear transcription factor Y subunit A-16	glyma.Wm82.gnm2.ann1.Glyma.15g129900
+C2-145	C2 domain containing protein gene 145	glyma.Wm82.gnm2.ann1.Glyma.15G130300
 TUBB	tubulin beta chain	glyma.Wm82.gnm2.ann1.Glyma.15g132200
-TUBB1, Tubulin	tubulin	glyma.Wm82.gnm2.ann1.Glyma.08G014200
-TUBB2	tubulin beta-2	glyma.Wm82.gnm2.ann1.Glyma.03g074400
-TUBB3	beta-tubulin	glyma.Wm82.gnm2.ann1.Glyma.03g124400
-TUBG1	tubulin gamma-1 chain	glyma.Wm82.gnm2.ann1.Glyma.03g255800
-TUBG2	tubulin gamma-2 chain	glyma.Wm82.gnm2.ann1.Glyma.19g2533001
-TUFA	elongation factor Tu, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.06g176900
-TUFB1	elongation factor Tu	glyma.Wm82.gnm2.ann1.Glyma.05g041900
-TYRA-A	arogenate dehydrogenase 2	glyma.Wm82.gnm2.ann1.Glyma.17g122300
-UBC4	ubiquitin carrier protein 4	glyma.Wm82.gnm2.ann1.Glyma.07g069300
-UC1	Uncharacterized protein 1, but possessing aMyb-DNA binding domain	glyma.Wm82.gnm1.ann1.Glyma20G32540
-UC2	Uncharacterized protein 2	glyma.Wm82.gnm1.ann1.Glyma17G07200
-UF3GT1-1	anthocyanidin 3-O-glucosyltransferase 7 gene 1	glyma.Wm82.gnm2.ann1.Glyma.07g183300
-UF3GT1-2	anthocyanidin 3-O-glucosyltransferase 7 gene 2	glyma.Wm82.gnm2.ann1.Glyma.07g183400
-UF3GT1-3, UGT78K1	UDP-glucose:flavonoid 3-O-glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.07g183200
-UGD1	UDP-glucose dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.08g243000
-UGT1	glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.03g256500
+WRKY143	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.15G135600
+COPE1	epsilon1-COP	glyma.Wm82.gnm2.ann1.Glyma.15g136100
+WRKY144	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.15G139000
+PHYB2	Phytochrome B gene 2	glyma.Wm82.gnm2.ann1.Glyma.15g140000
+ALDH22A3	aldehyde dehydrogenase 22A3	glyma.Wm82.gnm2.ann1.Glyma.15g140900
+SGlu4	glucan endo-1,3-beta-glucosidase	glyma.Wm82.gnm2.ann1.Glyma.15g142400
+CAMTA8	Calmodulin binding transcription activator 8	glyma.Wm82.gnm2.ann1.Glyma.15G143400
+SWEET40	sugar efflux transporter SWEET40	glyma.Wm82.gnm2.ann1.Glyma.15g149800
+ERF122	Ethylene-responsive factor gene 122	glyma.Wm82.gnm2.ann1.Glyma.15G152000
+C2-146, SRC2	SOYBEAN GENE REGULATED BY COLD 2	glyma.Wm82.gnm2.ann1.Glyma.15g152900
+PPR139	Psudo-Response Regulator gene 139	glyma.Wm82.gnm2.ann1.Glyma.15G156600
+AAH	allantoate amidohydrolase	glyma.Wm82.gnm2.ann1.Glyma.15g156900
+FTSH9	ATP-dependent zinc metalloprotease FTSH 8, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.15g158900
+ERF123	Ethylene-responsive factor gene 123	glyma.Wm82.gnm2.ann1.Glyma.15G159200
+MED18-2	Mediator Complex 18 gene 2	glyma.Wm82.gnm2.ann1.Glyma.15g160500
+ZTL	adagio protein 1	glyma.Wm82.gnm2.ann1.Glyma.15g162300
+PIN9b	PIN-formed 9 gene b	glyma.Wm82.gnm2.ann1.Glyma.15G168100
+WRKY145, WRKY42	WRKY transcription factor 42	glyma.Wm82.gnm2.ann1.Glyma.15g168200
+XET1	xyloglucan endotransglycosylase	glyma.Wm82.gnm2.ann1.Glyma.15g169100
+FVE	WD-40 repeat-containing protein MSI4-like	glyma.Wm82.gnm2.ann1.Glyma.15g169800
+SNAP-1	nucleosome assembly protein 1	glyma.Wm82.gnm2.ann1.Glyma.15g170700
+MYB121	transcription factor MYBZ1	glyma.Wm82.gnm2.ann1.Glyma.15g176000
+GRF15	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.15g176500
+GER10	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.15g176900
+ALDH7B2	aldehyde dehydrogenase family 7 member B2	glyma.Wm82.gnm2.ann1.Glyma.15g178400
+WRKY146	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.15G186300
+PHYE2	Phytochrome E gene 2	glyma.Wm82.gnm2.ann1.Glyma.15g196500
+CYP55	peptidyl-prolyl cis-trans isomerase CYP55	glyma.Wm82.gnm2.ann1.Glyma.15g202300
+MED22-2	Mediator Complex 22 gene 2	glyma.Wm82.gnm2.ann1.Glyma.15g204300
+TIL'	temperature-induced lipocalin'	glyma.Wm82.gnm2.ann1.Glyma.15g205900
+PIN9d	PIN-formed 9 gene d	glyma.Wm82.gnm2.ann1.Glyma.15G208600
+BZIP113	putative bZIP domain class transcription factor	glyma.Wm82.gnm2.ann1.Glyma.15g209600
+SWEET41	sugar efflux transporter SWEET41	glyma.Wm82.gnm2.ann1.Glyma.15g210400
+SWEET42	sugar efflux transporter SWEET42	glyma.Wm82.gnm2.ann1.Glyma.15g211800
+CYP56	peptidyl-prolyl cis-trans isomerase CYP56	glyma.Wm82.gnm2.ann1.Glyma.15g213200
+PHR26	MYB-CC domain-containing transcription factor PHR26	glyma.Wm82.gnm2.ann1.Glyma.15g215000
+WRI1B	ethylene-responsive transcription factor WRI1b	glyma.Wm82.gnm2.ann1.Glyma.15g221600
+BZIP128	bZIP transcription factor 128	glyma.Wm82.gnm2.ann1.Glyma.15g222400
+GER15	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.15g222500
+CRK44	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.15g226500
+CRK45	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.15g226800
+CRK46	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.15g227000
+CYSTATIN	cysteine proteinase inhibitor	glyma.Wm82.gnm2.ann1.Glyma.15g227500
+CYP57	peptidyl-prolyl cis-trans isomerase CYP57	glyma.Wm82.gnm2.ann1.Glyma.15g231800
+bZIP129, BZIP98	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.15g232000
+C2-147	C2 domain containing protein gene 147	glyma.Wm82.gnm2.ann1.Glyma.15G236900
+ANN11	annexin D4-like	glyma.Wm82.gnm2.ann1.Glyma.15g238400
+CYP6	peptidyl-prolyl cis-trans isomerase CYP6	glyma.Wm82.gnm2.ann1.Glyma.15g242500
+CHI3A2	chalcone isomerase 3A2	glyma.Wm82.gnm2.ann1.Glyma.15g242900
+CYP72A69	11-oxo-beta-amyrin 30-oxidase	glyma.Wm82.gnm2.ann1.Glyma.15g243300
+GLYII-10	putative hydroxyacylglutathione hydrolase	glyma.Wm82.gnm2.ann1.Glyma.15g245500
+C2-148	C2 domain containing protein gene 148	glyma.Wm82.gnm2.ann1.Glyma.15G245600
+GA2OX9	gibberellin 2-beta-dioxygenase 9	glyma.Wm82.gnm2.ann1.Glyma.15g248400
+GSTU47	glutathione transferase	glyma.Wm82.gnm2.ann1.Glyma.15g251500
+GSTa	2,4-D inducible glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.15g251600
+GSTU50	tau class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.15g251800
+GA2OX10	gibberellin 2-beta-dioxygenase 10	glyma.Wm82.gnm2.ann1.Glyma.15g252100
+GST3	lactoylglutathione lyase gene 	glyma.Wm82.gnm2.ann1.Glyma.15g252200
+NAC115, NAC35	transcriptional factor NAC35	glyma.Wm82.gnm2.ann1.Glyma.15g254000
+PPR140	Psudo-Response Regulator gene 140	glyma.Wm82.gnm2.ann1.Glyma.15G254800
+NAC116	NAC Transcription Factor gene 116	glyma.Wm82.gnm2.ann1.Glyma.15G257700
+MYB14	MYB14 protein	glyma.Wm82.gnm2.ann1.Glyma.15g259400
+NF-YC13	nuclear factor Y transcription factor	glyma.Wm82.gnm2.ann1.Glyma.15g261300
+IMPDH1	inosine monophosphate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.15g263100
+ALDH5F2	putative succinate-semialdehyde dehydrogenase, mitochondrial	glyma.Wm82.gnm2.ann1.Glyma.15g263500
+PHR27	MYB-CC domain-containing transcription factor PHR27	glyma.Wm82.gnm2.ann1.Glyma.15g263700
+NAC117	NAC Transcription Factor gene 117	glyma.Wm82.gnm2.ann1.Glyma.15G264100
+NAC118	NAC Transcription Factor gene 118	glyma.Wm82.gnm2.ann1.Glyma.15G266500
+C2-149	C2 domain containing protein gene 149	glyma.Wm82.gnm2.ann1.Glyma.15G271400
+PPR141	Psudo-Response Regulator gene 141	glyma.Wm82.gnm2.ann1.Glyma.15G272100
+PPR142	Psudo-Response Regulator gene 142	glyma.Wm82.gnm2.ann1.Glyma.15G273200
+FRD3a	ferric reductase defective 3a	glyma.Wm82.gnm2.ann1.Glyma.15g274600
+PPR143	Psudo-Response Regulator gene 143	glyma.Wm82.gnm2.ann1.Glyma.15G277000
+MMT2	methionine S-methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.16g000200
+EF1BGAMMA3	EF1Bgamma class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.16g001900
+GLYI-22	putative lactoylglutathione lyase	glyma.Wm82.gnm2.ann1.Glyma.16g003500
+TCP19	Teosinte branched1 and cycloidea and proliferating cell factor family proteingene 19	glyma.Wm82.gnm2.ann1.Glyma.16G004300
+NF-YA18	nuclear transcription factor Y subunit A-18	glyma.Wm82.gnm2.ann1.Glyma.16g005500
+GRF16	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.16g007600
+EREB, ERF124	Ethylene-responsive factor gene 124	glyma.Wm82.gnm2.ann1.Glyma.16G012600
+ALAAT1	alanine aminotransferase 1	glyma.Wm82.gnm2.ann1.Glyma.16g013900
+LRPK	serine/threonine-protein kinase LRPK	glyma.Wm82.gnm2.ann1.Glyma.16g015400
+NAC177	NAC domain-containing protein 177	glyma.Wm82.gnm2.ann1.Glyma.16g016400
+NAC120	NAC Transcription Factor gene 120	glyma.Wm82.gnm2.ann1.Glyma.16G016600
+NAC121	NAC Transcription Factor gene 121	glyma.Wm82.gnm2.ann1.Glyma.16G016700
+LCL-1, LCL1, LHY1a	LATE ELONGATED HYPOCOTYL 1 gene a	glyma.Wm82.gnm2.ann1.Glyma.16G017400
+NAC122, SHAT1-5	NAC domain-containing protein 43-like	glyma.Wm82.gnm2.ann1.Glyma.16g019400
+IQD55	protein IQ-DOMAIN 55	glyma.Wm82.gnm2.ann1.Glyma.16g019700
+MYB92	MYB transcription factor MYB92	glyma.Wm82.gnm2.ann1.Glyma.16g023000
+PPR144	Psudo-Response Regulator gene 144	glyma.Wm82.gnm2.ann1.Glyma.16G026000
+WRKY147, WRKY60	WRKY transcription factor 60	glyma.Wm82.gnm2.ann1.Glyma.16g026400
+MED19-4	Mediator Complex 19 gene 4	glyma.Wm82.gnm2.ann1.Glyma.16g027500
+NRAMP4B	metal transporter Nramp4b	glyma.Wm82.gnm2.ann1.Glyma.16g027800
+GBF2	G-box binding factor	glyma.Wm82.gnm2.ann1.Glyma.16g029000
+LEA2-87	late embryogenesis abundant 2 gene 87	glyma.Wm82.gnm2.ann1.Glyma.16G031000
+LEA2-88, PM22	Maturation protein 22 gene	glyma.Wm82.gnm2.ann1.Glyma.16g031300
+WRKY148	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.16G031400
+WRKY149	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.16G031900
+MPK4A	mitogen-activated protein kinase MPK4a	glyma.Wm82.gnm2.ann1.Glyma.16g032900
+SG-9	UDP-glycosyltransferase UGT73B4	glyma.Wm82.gnm2.ann1.Glyma.16g033700
+ERF125	Ethylene-responsive factor gene 125	glyma.Wm82.gnm2.ann1.Glyma.16G040000
+GDH1	glutamate dehydrogenase 1	glyma.Wm82.gnm2.ann1.Glyma.16g041200
+NAC123	NAC Transcription Factor gene 123	glyma.Wm82.gnm2.ann1.Glyma.16G042900
+NAC12, NAC124	NAC Transcription Factor gene 124	glyma.Wm82.gnm2.ann1.Glyma.16G043200
+GS52	ecto-apyrase GS52	glyma.Wm82.gnm2.ann1.Glyma.16g043300
+SIP1-4	aquaporin SIP1-4	glyma.Wm82.gnm2.ann1.Glyma.16g043800
+FT5a, FTL4	Flowering locus T-like gene 4	glyma.Wm82.gnm2.ann1.Glyma.16g044100
+FT3a, FTL1	Flowering locus T-like gene 1	glyma.Wm82.gnm2.ann1.Glyma.16g044200
+XTH1	endo-xyloglucan transferase 1 gene 	glyma.Wm82.gnm2.ann1.Glyma.16g045000
+ERF126	Ethylene-responsive factor gene 126	glyma.Wm82.gnm2.ann1.Glyma.16G046300
+ERF127	Ethylene-responsive factor gene 127	glyma.Wm82.gnm2.ann1.Glyma.16G047600
+PPR145	Psudo-Response Regulator gene 145	glyma.Wm82.gnm2.ann1.Glyma.16G049100
+PPR146	Psudo-Response Regulator gene 146	glyma.Wm82.gnm2.ann1.Glyma.16G049800
+AFB3B	auxin signaling F-box 3 protein	glyma.Wm82.gnm2.ann1.Glyma.16g050500
+COL16	zinc finger protein CONSTANS-LIKE 15	glyma.Wm82.gnm2.ann1.Glyma.16g050900
+NAC125	NAC Transcription Factor gene 125	glyma.Wm82.gnm2.ann1.Glyma.16G051800
+TCP20	Teosinte branched1 and cycloidea and proliferating cell factor family proteingene 20	glyma.Wm82.gnm2.ann1.Glyma.16G053900
+WRKY150	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.16G054400
+GER2	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.16g060800
+GER3	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.16g060900
+GER4	germin-like protein 4	glyma.Wm82.gnm2.ann1.Glyma.16g061400
+G6PD, G6PDH4	Glucose-6-phosphate dehydrogenase gene 4	glyma.Wm82.gnm2.ann1.Glyma.16G063200
+SEOM	sieve element occlusion m	glyma.Wm82.gnm2.ann1.Glyma.16g067700
+NAC178	NAC Transcription Factor gene 178	glyma.Wm82.gnm2.ann1.Glyma.16G069300
+P91	P24 oleosin isoform B	glyma.Wm82.gnm2.ann1.Glyma.16g071800
+MER3	ATP-dependent DNA helicase	glyma.Wm82.gnm2.ann1.Glyma.16g072300
+MYB181	MYB transcription factor MYB181	glyma.Wm82.gnm2.ann1.Glyma.16g073000
+MDHAR-4a	Peroximal monodehydroascorbate reductase 4 gene a	glyma.Wm82.gnm2.ann1.Glyma.16g073100
+GPRP3	glycine and proline rich protein 3	glyma.Wm82.gnm2.ann1.Glyma.16g076800
+LHP1, LHP1-1	chromo domain-containing protein LHP1-1	glyma.Wm82.gnm2.ann1.Glyma.16g079900
+MAPK22-2	mitogen-activated protein kinase 22 gene 2	glyma.Wm82.gnm2.ann1.Glyma.16G088700
+DXR2	putative 1-deoxy-D-xylulose 5-phosphate reductoisomerase	glyma.Wm82.gnm2.ann1.Glyma.16g089000
+RIN4B	RPM1-interacting protein 4-like	glyma.Wm82.gnm2.ann1.Glyma.16g090700
+AP1	MADS-box transcription factor	glyma.Wm82.gnm2.ann1.Glyma.16g091300
+HSF-33	heat stress transcription factor 33	glyma.Wm82.gnm2.ann1.Glyma.16g091800
+ITPK1	inositol phosphate kinase	glyma.Wm82.gnm2.ann1.Glyma.16g092200
+bZIP131, BZIP69	bZIP transcription factor bZIP69	glyma.Wm82.gnm2.ann1.Glyma.16g092700
+bZIP132, BZIP93	bZIP transcription factor 93	glyma.Wm82.gnm2.ann1.Glyma.16g095200
+IQD56	protein IQ-DOMAIN 56	glyma.Wm82.gnm2.ann1.Glyma.16g121000
+NAC126	NAC Transcription Factor gene 126	glyma.Wm82.gnm2.ann1.Glyma.16G130200
+ALDH3F2	aldehyde dehydrogenase family 3 member F2	glyma.Wm82.gnm2.ann1.Glyma.16g131700
+TBP1	TATA-box binding protein	glyma.Wm82.gnm2.ann1.Glyma.16g140200
+BZIP117, bZIP133	Basic leucine zipper transcription factor-like protein gene 133	glyma.Wm82.gnm2.ann1.Glyma.16G141500
+ICEE	transcription factor ICE1-like	glyma.Wm82.gnm2.ann1.Glyma.16g147200
+ERF128	Ethylene-responsive factor gene 128	glyma.Wm82.gnm2.ann1.Glyma.16G147500
+ERF129	Ethylene-responsive factor gene 129	glyma.Wm82.gnm2.ann1.Glyma.16G148700
+E9-1, FT2a, FT2a (E9), FTL3	Flowering locus T-like gene 3	glyma.Wm82.gnm2.ann1.Glyma.16g150700
+FT2b, FTL5	Flowering locus T-like gene 5	glyma.Wm82.gnm2.ann1.Glyma.16g151000
+SIP1-2	aquaporin SIP1-2	glyma.Wm82.gnm2.ann1.Glyma.16g151300
+NAC127	NAC Transcription Factor gene 127	glyma.Wm82.gnm2.ann1.Glyma.16G151500
+NAC128, NAC23	NAC domain protein	glyma.Wm82.gnm2.ann1.Glyma.16g152100
+PHR28	MYB-CC domain-containing transcription factor PHR28	glyma.Wm82.gnm2.ann1.Glyma.16g152200
+PPR147	Psudo-Response Regulator gene 147	glyma.Wm82.gnm2.ann1.Glyma.16G152800
+ERF130	Ethylene-responsive factor gene 130	glyma.Wm82.gnm2.ann1.Glyma.16G154100
+PIP2-10	aquaporin PIP2-10	glyma.Wm82.gnm2.ann1.Glyma.16g155000
+PIP2-11	aquaporin PIP2-11	glyma.Wm82.gnm2.ann1.Glyma.16g155100
+GR-1a	Cytosolic glutathione reductase 1 gene a	glyma.Wm82.gnm2.ann1.Glyma.16G155700
+Lac64	Laccase 64	glyma.Wm82.gnm2.ann1.Glyma.16G158400
+PPR148	Psudo-Response Regulator gene 148	glyma.Wm82.gnm2.ann1.Glyma.16G161800
+GI2, Gic	Gigantea gene c	glyma.Wm82.gnm2.ann1.Glyma.16G163200
+PRX4	peroxidase	glyma.Wm82.gnm2.ann1.Glyma.16g164200
+PRXD16	Peroxiredoxin 6	glyma.Wm82.gnm2.ann1.Glyma.16G164400
+ERF131	Ethylene-responsive factor gene 131	glyma.Wm82.gnm2.ann1.Glyma.16G164800
+LHCB1-7	photosystem II type I chlorophyll a/b-binding protein	glyma.Wm82.gnm2.ann1.Glyma.16g165800
+BZIP130, bZIP134	Basic leucine zipper transcription factor-like protein gene 134	glyma.Wm82.gnm2.ann1.Glyma.16G168400
+PPR149	Psudo-Response Regulator gene 149	glyma.Wm82.gnm2.ann1.Glyma.16G172800
+IF7GT3	isoflavone 7-O-glucosyltransferase UGT3	glyma.Wm82.gnm2.ann1.Glyma.16g175200
 UGT2	isoflavone 7-O-glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.16g175300
 UGT4	isoflavone 7-O-glucosyltransferase UGT4	glyma.Wm82.gnm2.ann1.Glyma.16g175400
-UGT7	isoflavone 7-O-glucosyltransferase UGT7	glyma.Wm82.gnm2.ann1.Glyma.16g175900
-UGT708D1	UDP-glucose:2-hydroxyflavanone C-glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.09g162400
-UGT78K2, UGT78K2-1	UDP-glucose:flavonoid 3-O-glucosyltransferase gene 1	glyma.Wm82.gnm2.ann1.Glyma.08g066800
 UGT8	isoflavone 7-O-glucosyltransferase UGT8	glyma.Wm82.gnm2.ann1.Glyma.16g175500
-UO1	Urate Oxidase 1 gene	glyma.Wm82.gnm1.ann1.Glyma10g23790
-URE	urease	glyma.Wm82.gnm2.ann1.Glyma.11g248700
-USP1	UDP-sugar pyrophosphorylase	glyma.Wm82.gnm2.ann1.Glyma.04g245100
-UVR8	UVB-RESISTANCE 8  	glyma.Wm82.gnm1.ann1.Glyma05g32790
-VAD1	protein VASCULAR ASSOCIATED DEATH 1, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.20g070800
-VAMP721D	vesicle-associated membrane protein 721d	glyma.Wm82.gnm2.ann1.Glyma.09g019800
-VLXC	lipoxygenase	glyma.Wm82.gnm2.ann1.Glyma.07g006900
-VPE	vacuolar-processing enzyme	glyma.Wm82.gnm2.ann1.Glyma.17g137800
-VPE2	vacuolar processing enzyme 2	glyma.Wm82.gnm2.ann1.Glyma.14g092800
-VPS-like	Vacuolar protein sorting -like 	glyma.Wm82.gnm2.ann1.Glyma.09G196600
-VQ1	VQ motif containing protein gene 1	glyma.Wm82.gnm1.ann1.Glyma01g02280
-VQ10	VQ motif containing protein gene 10	glyma.Wm82.gnm1.ann1.Glyma04g10780
-VQ11	VQ motif containing protein gene 11	glyma.Wm82.gnm1.ann1.Glyma04g11211
-VQ12	VQ motif containing protein gene 12	glyma.Wm82.gnm1.ann1.Glyma04g16880
-VQ13	VQ motif containing protein gene 13	glyma.Wm82.gnm1.ann1.Glyma04g39270
-VQ14	VQ motif containing protein gene 14	glyma.Wm82.gnm1.ann1.Glyma04g41820
-VQ15	VQ motif containing protein gene 15	glyma.Wm82.gnm1.ann1.Glyma05g22760
-VQ16	VQ motif containing protein gene 16	glyma.Wm82.gnm1.ann1.Glyma05g26340
-VQ17	VQ motif containing protein gene 17	glyma.Wm82.gnm1.ann1.Glyma05g27220
-VQ18	VQ motif containing protein gene 18	glyma.Wm82.gnm1.ann1.Glyma05g31341
-VQ19	VQ motif containing protein gene 19	glyma.Wm82.gnm1.ann1.Glyma05g32350
-VQ2	VQ motif containing protein gene 2	glyma.Wm82.gnm1.ann1.Glyma01g12940
-VQ20	VQ motif containing protein gene 20	glyma.Wm82.gnm1.ann1.Glyma05g33250
-VQ21	VQ motif containing protein gene 21	glyma.Wm82.gnm1.ann1.Glyma06g10630
-VQ22	VQ motif containing protein gene 22	glyma.Wm82.gnm1.ann1.Glyma06g10951
-VQ23	VQ motif containing protein gene 23	glyma.Wm82.gnm1.ann1.Glyma06g10960
-VQ24	VQ motif containing protein gene 24	glyma.Wm82.gnm1.ann1.Glyma06g12960
-VQ25	VQ motif containing protein gene 25	glyma.Wm82.gnm1.ann1.Glyma06g15650
-VQ26	VQ motif containing protein gene 26	glyma.Wm82.gnm1.ann1.Glyma06g36640
-VQ27	VQ motif containing protein gene 27	glyma.Wm82.gnm1.ann1.Glyma07g03240
-VQ28	VQ motif containing protein gene 28	glyma.Wm82.gnm1.ann1.Glyma07g10290
-VQ29	VQ motif containing protein gene 29	glyma.Wm82.gnm1.ann1.Glyma07g31781
-VQ3	VQ motif containing protein gene 3	glyma.Wm82.gnm1.ann1.Glyma01g40320
-VQ30	VQ motif containing protein gene 30	glyma.Wm82.gnm1.ann1.Glyma08g00850
-VQ31	VQ motif containing protein gene 31	glyma.Wm82.gnm1.ann1.Glyma08g04651
-VQ32	VQ motif containing protein gene 32	glyma.Wm82.gnm1.ann1.Glyma08g09250
-VQ33	VQ motif containing protein gene 33	glyma.Wm82.gnm1.ann1.Glyma08g10166
-VQ34	VQ motif containing protein gene 34	glyma.Wm82.gnm1.ann1.Glyma08g14581
-VQ35	VQ motif containing protein gene 35	glyma.Wm82.gnm1.ann1.Glyma08g15620
-VQ36	VQ motif containing protein gene 36	glyma.Wm82.gnm1.ann1.Glyma08g16790
-VQ37	VQ motif containing protein gene 37	glyma.Wm82.gnm1.ann1.Glyma08g18820
-VQ38	VQ motif containing protein gene 38	glyma.Wm82.gnm1.ann1.Glyma08g22860
-VQ39	VQ motif containing protein gene 39	glyma.Wm82.gnm1.ann1.Glyma08g36730
-VQ4	VQ motif containing protein gene 4	glyma.Wm82.gnm1.ann1.Glyma02g29281
-VQ40	VQ motif containing protein gene 40	glyma.Wm82.gnm1.ann1.Glyma08g36740
-VQ41	VQ motif containing protein gene 41	glyma.Wm82.gnm1.ann1.Glyma08g36750
-VQ42	VQ motif containing protein gene 42	glyma.Wm82.gnm1.ann1.Glyma08g42125
-VQ43	VQ motif containing protein gene 43	glyma.Wm82.gnm1.ann1.Glyma09g05700
-VQ44	VQ motif containing protein gene 44	glyma.Wm82.gnm1.ann1.Glyma09g17151
-VQ45	VQ motif containing protein gene 45	glyma.Wm82.gnm1.ann1.Glyma09g31600
-VQ46	VQ motif containing protein gene 46	glyma.Wm82.gnm1.ann1.Glyma10g41970
-VQ47	VQ motif containing protein gene 47	glyma.Wm82.gnm1.ann1.Glyma11g04970
-VQ48	VQ motif containing protein gene 48	glyma.Wm82.gnm1.ann1.Glyma11g38180
-VQ49	VQ motif containing protein gene 49	glyma.Wm82.gnm1.ann1.Glyma12g24250
-VQ5	VQ motif containing protein gene 5	glyma.Wm82.gnm1.ann1.Glyma02g37135
-VQ50	VQ motif containing protein gene 50	glyma.Wm82.gnm1.ann1.Glyma12g35380
-VQ51	VQ motif containing protein gene 51	glyma.Wm82.gnm1.ann1.Glyma13g08831
-VQ52	VQ motif containing protein gene 52	glyma.Wm82.gnm1.ann1.Glyma13g10840
-VQ53	VQ motif containing protein gene 53	glyma.Wm82.gnm1.ann1.Glyma13g24700
-VQ54	VQ motif containing protein gene 54	glyma.Wm82.gnm1.ann1.Glyma13g26290
-VQ55	VQ motif containing protein gene 55	glyma.Wm82.gnm1.ann1.Glyma13g29005
-VQ56	VQ motif containing protein gene 56	glyma.Wm82.gnm1.ann1.Glyma13g31180
-VQ57	VQ motif containing protein gene 57	glyma.Wm82.gnm1.ann1.Glyma13g35130
-VQ58	VQ motif containing protein gene 58	glyma.Wm82.gnm1.ann1.Glyma14g00570
-VQ59	VQ motif containing protein gene 59	glyma.Wm82.gnm1.ann1.Glyma14g29580
-VQ6	VQ motif containing protein gene 6	glyma.Wm82.gnm1.ann1.Glyma03g27560
-VQ60	VQ motif containing protein gene 60	glyma.Wm82.gnm1.ann1.Glyma14g34681
-VQ61	VQ motif containing protein gene 61	glyma.Wm82.gnm1.ann1.Glyma15g08160
-VQ62	VQ motif containing protein gene 62	glyma.Wm82.gnm1.ann1.Glyma15g16990
-VQ63	VQ motif containing protein gene 63	glyma.Wm82.gnm1.ann1.Glyma15g37230
-VQ64	VQ motif containing protein gene 64	glyma.Wm82.gnm1.ann1.Glyma15g40000
-VQ65	VQ motif containing protein gene 65	glyma.Wm82.gnm1.ann1.Glyma15g42280
-VQ66	VQ motif containing protein gene 66	glyma.Wm82.gnm1.ann1.Glyma17g17210
-VQ67	VQ motif containing protein gene 67	glyma.Wm82.gnm1.ann1.Glyma18g02140
-VQ68	VQ motif containing protein gene 68	glyma.Wm82.gnm1.ann1.Glyma18g13001
-VQ69	VQ motif containing protein gene 69	glyma.Wm82.gnm1.ann1.Glyma19g30531
-VQ7	VQ motif containing protein gene 7	glyma.Wm82.gnm1.ann1.Glyma03g28360
-VQ70	VQ motif containing protein gene 70	glyma.Wm82.gnm1.ann1.Glyma19g31080
-VQ71	VQ motif containing protein gene 71	glyma.Wm82.gnm1.ann1.Glyma19g38980
-VQ72	VQ motif containing protein gene 72	glyma.Wm82.gnm1.ann1.Glyma19g43590
-VQ73	VQ motif containing protein gene 73	glyma.Wm82.gnm1.ann1.Glyma20g15230
-VQ74	VQ motif containing protein gene 74	glyma.Wm82.gnm1.ann1.Glyma20g25070
-VQ8	VQ motif containing protein gene 8	glyma.Wm82.gnm1.ann1.Glyma03g36330
-VQ9	VQ motif containing protein gene 9	glyma.Wm82.gnm1.ann1.Glyma03g40941
-VSPA, VSPA28	Vegetative storage protein A 28 kD	glyma.Wm82.gnm2.ann1.Glyma.07g014500
-VSPB	Vegetative storage protein B	glyma.Wm82.gnm2.ann1.Glyma.08g200100
-VTE2-1	homogentisate phytyltransferase 1, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.13g097800
-VTE2-2	homogentisate phytyltransferase VTE2-2	glyma.Wm82.gnm2.ann1.Glyma.02g168000
-VTL1b	vacuole iron transporter like	glyma.Wm82.gnm2.ann1.Glyma.08G076300
-W2	White flower 2	glyma.Wm82.gnm2.ann1.Glyma.14g154400
-WI12	wound-inducible protein 12	glyma.Wm82.gnm2.ann1.Glyma.18g022700
-WIN	wound-induced protein	glyma.Wm82.gnm2.ann1.Glyma.19g245400
-WNK1	with no lysine kinase 1	glyma.Wm82.gnm2.ann1.Glyma.20g228000
-WNK10	with no lysine kinase 10	glyma.Wm82.gnm2.ann1.Glyma.09g276300
-WNK11	with no lysine kinase 11	glyma.Wm82.gnm2.ann1.Glyma.18g215100
-WNK12	with no lysine kinase 12	glyma.Wm82.gnm2.ann1.Glyma.02g235700
-WNK13	with no lysine kinase 13	glyma.Wm82.gnm2.ann1.Glyma.14g203700
-WNK2	with no lysine kinase 2	glyma.Wm82.gnm2.ann1.Glyma.10g248400
-WNK3	with no lysine kinase	glyma.Wm82.gnm2.ann1.Glyma.04g188800
-WNK4	with no lysine kinase 4	glyma.Wm82.gnm2.ann1.Glyma.11g159900
-WNK5	with no lysine kinase 5	glyma.Wm82.gnm2.ann1.Glyma.03g036500
-WNK6	with no lysine kinase 6	glyma.Wm82.gnm2.ann1.Glyma.07g053500
-WNK7	with no lysine kinase 7	glyma.Wm82.gnm2.ann1.Glyma.06g176800
-WNK8	with no lysine kinase 8	glyma.Wm82.gnm2.ann1.Glyma.20g066900
-WNK9, ZIK9-2	Zinc Finger Protein Interacting With K Protein 9 gene 2	glyma.Wm82.gnm2.ann1.Glyma.19G242900
-WRI1	WRINKLED1	glyma.Wm82.gnm1.ann1.Glyma15g34770
-WRI1A	ethylene-responsive transcription factor WRI1a	glyma.Wm82.gnm2.ann1.Glyma.08g227700
-WRI1B	ethylene-responsive transcription factor WRI1b	glyma.Wm82.gnm2.ann1.Glyma.15g221600
-WRKY	WRKY protein	glyma.Wm82.gnm2.ann1.Glyma.05g203900
-WRKY183	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.19G217800
-WRKY184	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.19G221700
-WRKY185	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.19G254800
-WRKY186	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.20G028000
-WRKY187	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.20G030500
-WRKY188	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.20G163200
-WRKY3	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.01G056800
-WRKY65	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.06G242200
-WRKY66	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.06G307700
-WRKY67	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.06G320700
-WRKY68	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.07G023300
-WRKY69	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.07G057400
-WRKY70	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.07G116300
-WRKY71	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.07G133700
-WRKY72	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.07G161100
-WRKY73	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.07G227200
-WRKY74	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.07G238000
-WRKY77	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.08G018300
-WRKY78	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.08G021900
-WRP1	WRKY-related protein 1	glyma.Wm82.gnm2.ann1.Glyma.14g199800
-XET1	xyloglucan endotransglycosylase	glyma.Wm82.gnm2.ann1.Glyma.15g169100
-XIP1-1	aquaporin XIP1-1	glyma.Wm82.gnm2.ann1.Glyma.12g023600
-XIP1-2	aquaporin XIP1-2	glyma.Wm82.gnm2.ann1.Glyma.11g097800
-XTH1	endo-xyloglucan transferase 1 gene 	glyma.Wm82.gnm2.ann1.Glyma.16g045000
-XTH43f	xyloglucan endotransglycosylase/hydrolase	glyma.Wm82.gnm1.ann1.Glyma17g07250
-YSL1	probable metal-nicotianamine transporter YSL7-like	glyma.Wm82.gnm2.ann1.Glyma.11g203400
-YUC2A	indole-3-pyruvate monooxygenase YUCCA2	glyma.Wm82.gnm2.ann1.Glyma.08g038600
-ZAT4	zinc finger protein ZAT4	glyma.Wm82.gnm2.ann1.Glyma.17g076900
-ZEP	zeaxanthin epoxidase	glyma.Wm82.gnm2.ann1.Glyma.17g174500
-ZF351	tandem CCCH zinc finger protein 351	glyma.Wm82.gnm1.ann1.Glyma06g44440
-ZFP1	Cys2-His2 zinc finger protein	glyma.Wm82.gnm2.ann1.Glyma.17g165600
-ZFP3	C2H2-type zinc finger protein 3	glyma.Wm82.gnm2.ann1.Glyma.12g178900
-ZFP5	zinc finger protein ZAT4-like	glyma.Wm82.gnm2.ann1.Glyma.17g142300
-ZFP6	C2H2-type zinc finger protein 6	glyma.Wm82.gnm2.ann1.Glyma.19g186200
-ZIK8-1	Zinc Finger Protein Interacting With K Protein 8 gene 1	glyma.Wm82.gnm2.ann1.Glyma.18G081500
-ZIP	homeobox-leucine zipper	glyma.Wm82.gnm2.ann1.Glyma.08g124400
-ZIP43	bZIP transcription factor 43	glyma.Wm82.gnm2.ann1.Glyma.14g204100
-ZOU-1	bHLH transcription factor ZOU-1	glyma.Wm82.gnm2.ann1.Glyma.02g103200
-ZOU-2	bHLH transcription factor ZOU-2	glyma.Wm82.gnm2.ann1.Glyma.02g103100
-ZPR1A	protein LITTLE ZIPPER 2-like	glyma.Wm82.gnm2.ann1.Glyma.09g268100
-ZPR1B	protein LITTLE ZIPPER 2-like	glyma.Wm82.gnm2.ann1.Glyma.18g221802
-ZPR1C	protein LITTLE ZIPPER 2-like	glyma.Wm82.gnm2.ann1.Glyma.03g022200
-ZPR3A	protein LITTLE ZIPPER 3-like	glyma.Wm82.gnm2.ann1.Glyma.11g209700
-ZTL	adagio protein 1	glyma.Wm82.gnm2.ann1.Glyma.15g162300
+IF7GT	UDP-glucose:isoflavone 7-O-glucosyltransferase	glyma.Wm82.gnm2.ann1.Glyma.16g175600
+UGT7	isoflavone 7-O-glucosyltransferase UGT7	glyma.Wm82.gnm2.ann1.Glyma.16g175900
+IF7GT5	isoflavone 7-O-glucosyltransferase UGT5	glyma.Wm82.gnm2.ann1.Glyma.16g176000
+WRKY151	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.16G176700
+WRKY152	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.16G177000
+HSP90A2	heat shock protein 90-A2	glyma.Wm82.gnm2.ann1.Glyma.16g178800
+BCH2	beta-carotene hydroxylase BCH2	glyma.Wm82.gnm2.ann1.Glyma.16g179100
+CrRLk1L25	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.16G179600
+C2-150	C2 domain containing protein gene 150	glyma.Wm82.gnm2.ann1.Glyma.16G180300
+C2-151	C2 domain containing protein gene 151	glyma.Wm82.gnm2.ann1.Glyma.16G180400
+HSF-32	heat stress transcription factor 32	glyma.Wm82.gnm2.ann1.Glyma.16g196200
+BFT	phosphatidylethanolamine-binding protein BFT	glyma.Wm82.gnm2.ann1.Glyma.16g196300
+IQD57	protein IQ-DOMAIN 57	glyma.Wm82.gnm2.ann1.Glyma.16g196900
+GA20OX7	gibberellin 20-oxidase 7	glyma.Wm82.gnm2.ann1.Glyma.16g200800
+CRK47	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.16g202200
+CRK48	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.16g202400
+HIR4	hypersensitive-induced response protein 4-like	glyma.Wm82.gnm2.ann1.Glyma.16g204900
+HSP22.5	heat shock protein Hsp22.5	glyma.Wm82.gnm2.ann1.Glyma.16g206200
+D-II	Bowman-Birk proteinase isoinhibitor D-II	glyma.Wm82.gnm2.ann1.Glyma.16g208900
+TIP3-2	aquaporin TIP3-2	glyma.Wm82.gnm2.ann1.Glyma.16g210000
+KTI-3	kunitz family trypsin and protease inhibitor protein	glyma.Wm82.gnm2.ann1.Glyma.16g211700
+Rj2	TIR-NBS-LRR family protein	glyma.Wm82.gnm2.ann1.Glyma.16g212300
+NAC129	NAC Transcription Factor gene 129	glyma.Wm82.gnm2.ann1.Glyma.16G217400
+PPR150	Psudo-Response Regulator gene 150	glyma.Wm82.gnm2.ann1.Glyma.16G218400
+CHR3	chalcone reductase CHR3	glyma.Wm82.gnm2.ann1.Glyma.16g219400
+CHR2	chalcone reductase CHR2	glyma.Wm82.gnm2.ann1.Glyma.16g219500
+WRKY153	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.16G219800
+LEA2-89	late embryogenesis abundant 2 gene 89	glyma.Wm82.gnm2.ann1.Glyma.16G221900
+EF1BGAMMA4	elongation factor 1-gamma	glyma.Wm82.gnm2.ann1.Glyma.17g001400
+NAC130	NAC Transcription Factor gene 130	glyma.Wm82.gnm2.ann1.Glyma.17G002800
+GSTZ3	glutathione S-transferase GST 25	glyma.Wm82.gnm2.ann1.Glyma.17g003300
+C2-152	C2 domain containing protein gene 152	glyma.Wm82.gnm2.ann1.Glyma.17G004700
+LEC1-B	nuclear transcription factor Y subunit B-6-like	glyma.Wm82.gnm2.ann1.Glyma.17g005600
+WRKY154	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.17G011400
+SOYAP1	aspartic proteinase 1	glyma.Wm82.gnm2.ann1.Glyma.17g011500
+Lac65	Laccase 65	glyma.Wm82.gnm2.ann1.Glyma.17G012300
+PRX2	Cationic peroxidase 2 gene	glyma.Wm82.gnm2.ann1.Glyma.17g013600
+DAO	copper amino oxidase	glyma.Wm82.gnm2.ann1.Glyma.17g019300
+OXR17	Oxidoreductase 17	glyma.Wm82.gnm2.ann1.Glyma.17G021200
+ERF132	Ethylene-responsive factor gene 132	glyma.Wm82.gnm2.ann1.Glyma.17G024300
+PPR151	Psudo-Response Regulator gene 151	glyma.Wm82.gnm2.ann1.Glyma.17G024900
+LEA5	desiccation protective protein LEA5	glyma.Wm82.gnm2.ann1.Glyma.17g027400
+H4	stress-induced protein H4	glyma.Wm82.gnm2.ann1.Glyma.17g030200
+COBL18	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.17G030700
+CAMTA12	Calmodulin binding transcription activator 12	glyma.Wm82.gnm2.ann1.Glyma.17G031900
+TENA_E	seed maturation protein PM36	glyma.Wm82.gnm2.ann1.Glyma.17g032700
+ALDH22A4	aldehyde dehydrogenase 22A4	glyma.Wm82.gnm2.ann1.Glyma.17g033100
+WRKY155	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.17G035400
+CIF1	cell-wall inhibitor of beta-fructosidase	glyma.Wm82.gnm2.ann1.Glyma.17g036300
+SFR2	beta-glycosidase-like	glyma.Wm82.gnm2.ann1.Glyma.17g037100
+CAMTA7	Calmodulin binding transcription activator 7	glyma.Wm82.gnm2.ann1.Glyma.17G038800
+PTI1B	Pti1 kinase-like protein	glyma.Wm82.gnm2.ann1.Glyma.17g039800
+PDK3	mitochondrial pyruvate dehydrogenase E1alpha-kinase 3	glyma.Wm82.gnm2.ann1.Glyma.17g040500
+WRKY156	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.17G042300
+IAA53	Indole-3-Acetic Acid Responsive Gene 53	glyma.Wm82.gnm2.ann1.Glyma.17G042800
+KASII-A	beta-ketoacyl-ACP synthetase 2 gene 1	glyma.Wm82.gnm2.ann1.Glyma.17g047000
+DEP1	dense and erect panicle 1	glyma.Wm82.gnm2.ann1.Glyma.17g048600
+RAD51b	Radiation- repair 51 gene b	glyma.Wm82.gnm2.ann1.Glyma.17G049800
+GRF17	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.17g050200
+MED20-2	Mediator Complex 20 gene 2	glyma.Wm82.gnm2.ann1.Glyma.17g050300
+MYB205	transcription factor MYB205	glyma.Wm82.gnm2.ann1.Glyma.17g050500
+NF-YA19	nuclear transcription factor Y subunit A-19	glyma.Wm82.gnm2.ann1.Glyma.17g051400
+MAPKK2	mitogen-activated protein kinase kinase MAPKK2	glyma.Wm82.gnm2.ann1.Glyma.17g052400
+GLYI-23	putative lactoylglutathione lyase	glyma.Wm82.gnm2.ann1.Glyma.17g052700
+DGAT, DGAT1b	diacylglycerolacyltransferase-1b	glyma.Wm82.gnm2.ann1.Glyma.17g053300
+CKX3	cytokinin dehydrogenase 3-like	glyma.Wm82.gnm2.ann1.Glyma.17g054500
+WRKY157, WRKY33	WRKY transcription factor 33	glyma.Wm82.gnm2.ann1.Glyma.17g057100
+PIN2B	auxin efflux carrier component 2b	glyma.Wm82.gnm2.ann1.Glyma.17g057300
+HPT1	homogentisate phytylprenyltransferase	glyma.Wm82.gnm2.ann1.Glyma.17g061900
 ZTL1	PAS protein ZEITLUPE 1	glyma.Wm82.gnm2.ann1.Glyma.17g062000
-ZTL2	clock-associated PAS protein ZEITLUPE 2	glyma.Wm82.gnm2.ann1.Glyma.13g097600
-bHLH15	bHLH protein	glyma.Wm82.gnm2.ann1.Glyma.15G005100
-bHLH35	PREDICTED: transcription factor bHLH35-like	glyma.Wm82.gnm2.ann1.Glyma.13G101100
-bHLH5	bHLH protein	glyma.Wm82.gnm2.ann1.Glyma.05G134400
-bHLH7	bHLH protein	glyma.Wm82.gnm2.ann1.Glyma.07G205800
-bZIP100	Basic leucine zipper transcription factor-like protein gene 100	glyma.Wm82.gnm2.ann1.Glyma.12G088700
-bZIP102	Basic leucine zipper transcription factor-like protein gene 102	glyma.Wm82.gnm2.ann1.Glyma.12G121000
-bZIP103	Basic leucine zipper transcription factor-like protein gene 103	glyma.Wm82.gnm2.ann1.Glyma.12G184400
-bZIP106	Basic leucine zipper transcription factor-like protein gene 106	glyma.Wm82.gnm2.ann1.Glyma.12G227700
-bZIP107	Basic leucine zipper transcription factor-like protein gene 107	glyma.Wm82.gnm2.ann1.Glyma.13G050700
-bZIP116	Basic leucine zipper transcription factor-like protein gene 116	glyma.Wm82.gnm2.ann1.Glyma.13G316900
-bZIP118	Basic leucine zipper transcription factor-like protein gene 118	glyma.Wm82.gnm2.ann1.Glyma.13G345200
-bZIP12, TGA02	bZIP transcription factor 2	glyma.Wm82.gnm2.ann1.Glyma.02g097900
-bZIP120, TGA21	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.14g167000
-bZIP127	Basic leucine zipper transcription factor-like protein gene 127	glyma.Wm82.gnm2.ann1.Glyma.15G129700
-bZIP129	Basic leucine zipper transcription factor-like protein gene 129	glyma.Wm82.gnm2.ann1.Glyma.15G232000
-bZIP13	Basic leucine zipper transcription factor-like protein gene 13	glyma.Wm82.gnm2.ann1.Glyma.02G126100
-bZIP131	Basic leucine zipper transcription factor-like protein gene 131	glyma.Wm82.gnm2.ann1.Glyma.16G092700
-bZIP133	Basic leucine zipper transcription factor-like protein gene 133	glyma.Wm82.gnm2.ann1.Glyma.16G141500
-bZIP134	Basic leucine zipper transcription factor-like protein gene 134	glyma.Wm82.gnm2.ann1.Glyma.16G168400
+4CL1	4-coumarate:coenzyme A ligase gene 1	glyma.Wm82.gnm2.ann1.Glyma.17g064600
+19-1-5	syringolide-induced protein 19-1-5	glyma.Wm82.gnm2.ann1.Glyma.17g065000
+COL4b	Constans-like 4 gene b	glyma.Wm82.gnm2.ann1.Glyma.17G066600
+DGK10	diacylglycerol kinase 10	glyma.Wm82.gnm2.ann1.Glyma.17g067400
+TPS	trehalose 6-phosphate synthase	glyma.Wm82.gnm2.ann1.Glyma.17G067800
+PPR152	Psudo-Response Regulator gene 152	glyma.Wm82.gnm2.ann1.Glyma.17G072100
+HSP70	heat shock 70 kDa protein-like	glyma.Wm82.gnm2.ann1.Glyma.17g072400
+ENOD55-2	early nodulin	glyma.Wm82.gnm2.ann1.Glyma.17g073400
+WRKY158, WRKY24	WRKY transcription factor 24	glyma.Wm82.gnm2.ann1.Glyma.17g074000
+FAD6.2	delta-12 desaturase, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.17g074400
+ALDH11A2	aldehyde dehydrogenase 11A2	glyma.Wm82.gnm2.ann1.Glyma.17g075300
+ZAT4	zinc finger protein ZAT4	glyma.Wm82.gnm2.ann1.Glyma.17g076900
+DGK11	diacylglycerol kinase 11	glyma.Wm82.gnm2.ann1.Glyma.17g077100
+HDA15	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.17g078000
+TCP43	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 43	glyma.Wm82.gnm2.ann1.Glyma.17G079900
+INFA	translation initiation factor IF1	glyma.Wm82.gnm2.ann1.Glyma.17g080200
+COBL19	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.17G080600
+AGL8a	Agamous 8-Like gene a	glyma.Wm82.gnm2.ann1.Glyma.17G081200
+CAS	calcium sensing receptor, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.17g084300
+HDA16	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.17g085700
+CRK49	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.17g088000
+ITPK2	inositol phosphate kinase	glyma.Wm82.gnm2.ann1.Glyma.17g089000
+SWEET43	sugar efflux transporter SWEET43	glyma.Wm82.gnm2.ann1.Glyma.17g090800
+GASA26	gibberellin-regulated protein 26	glyma.Wm82.gnm2.ann1.Glyma.17g092800
+MYB173, MYB175	MYB transcription factor MYB173	glyma.Wm82.gnm2.ann1.Glyma.17g094400
+NRT1-2	nitrate transporter NRT1-2	glyma.Wm82.gnm2.ann1.Glyma.17g096400
+ALDH12A3	aldehyde dehydrogenase 12A3	glyma.Wm82.gnm2.ann1.Glyma.17g097800
+WRKY159	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.17G097900
+IQD58	protein IQ-DOMAIN 58	glyma.Wm82.gnm2.ann1.Glyma.17g098200
+TCP21	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 21	glyma.Wm82.gnm2.ann1.Glyma.17G099100
+PPR153	Psudo-Response Regulator gene 153	glyma.Wm82.gnm2.ann1.Glyma.17G099500
+PPR154	Psudo-Response Regulator gene 154	glyma.Wm82.gnm2.ann1.Glyma.17G100500
+CDF3d	Cycling Dof Factor 3 gene d	glyma.Wm82.gnm2.ann1.Glyma.17G101000
+NAC131	NAC Transcription Factor gene 131	glyma.Wm82.gnm2.ann1.Glyma.17G101500
+TOC1	Timing of cab expression	glyma.Wm82.gnm2.ann1.Glyma.17G102200
+GinCrRI,k1l,26	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.17G102600
+Raf42-3	Raf42 proto-oncogene serine/threonine protein kinase gene 3	glyma.Wm82.gnm2.ann1.Glyma.17G105100
+TDF-5	uncharacterized protein TDF-5	glyma.Wm82.gnm2.ann1.Glyma.17g109300
+PAP3	purple acid phosphatase-like protein	glyma.Wm82.gnm2.ann1.Glyma.17g109400
+C2-153	C2 domain containing protein gene 153	glyma.Wm82.gnm2.ann1.Glyma.17G109500
+ADR11	AAI_LTSS superfamily protein	glyma.Wm82.gnm2.ann1.Glyma.17g111100
+IAA54	Indole-3-Acetic Acid Responsive Gene 54	glyma.Wm82.gnm2.ann1.Glyma.17G112300
+ERF133	Ethylene-responsive factor gene 133	glyma.Wm82.gnm2.ann1.Glyma.17G114500
+SPX8	SPX domain-containing protein 8	glyma.Wm82.gnm2.ann1.Glyma.17g114700
+GLYI-24	putative lactoylglutathione lyase	glyma.Wm82.gnm2.ann1.Glyma.17g115900
+PPR155	Psudo-Response Regulator gene 155	glyma.Wm82.gnm2.ann1.Glyma.17G117000
+MED17-3	Mediator Complex 17 gene 3	glyma.Wm82.gnm2.ann1.Glyma.17g117600
+GSRLCK	receptor-like cytoplasmic serine/threonine protein kinase GsRLCK	glyma.Wm82.gnm2.ann1.Glyma.17g117800
+FATB1B	myristoyl-acyl carrier protein thioesterase	glyma.Wm82.gnm2.ann1.Glyma.17g120400
+HDA17	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.17g120900
+MYB109	MYB transcription factor MYB109	glyma.Wm82.gnm2.ann1.Glyma.17g121000
+TCP52	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 52	glyma.Wm82.gnm2.ann1.Glyma.17G121500
+TYRA-A	arogenate dehydrogenase 2	glyma.Wm82.gnm2.ann1.Glyma.17g122300
+CYP58	peptidyl-prolyl cis-trans isomerase CYP58	glyma.Wm82.gnm2.ann1.Glyma.17g122500
+ERF134	Ethylene-responsive factor gene 134	glyma.Wm82.gnm2.ann1.Glyma.17G124100
+MS	malate synthase	glyma.Wm82.gnm2.ann1.Glyma.17g128000
+IQD59	protein IQ-DOMAIN 59	glyma.Wm82.gnm2.ann1.Glyma.17g130900
+TCP22	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 22	glyma.Wm82.gnm2.ann1.Glyma.17G132400
+FUSA1	elongation factor G-1	glyma.Wm82.gnm2.ann1.Glyma.17g137600
+Hop-1, HOP1	hsp70-Hsp90 organizing protein 1	glyma.Wm82.gnm2.ann1.Glyma.17g137700
+VPE	vacuolar-processing enzyme	glyma.Wm82.gnm2.ann1.Glyma.17g137800
+NAC132	NAC Transcription Factor gene 132	glyma.Wm82.gnm2.ann1.Glyma.17G138100
+FILA	YABBY protein FILa	glyma.Wm82.gnm2.ann1.Glyma.17g138200
+Lac66	Laccase 66	glyma.Wm82.gnm2.ann1.Glyma.17G138300
+ZFP5	zinc finger protein ZAT4-like	glyma.Wm82.gnm2.ann1.Glyma.17g142300
+MYB180	MYB transcription factor MYB180	glyma.Wm82.gnm2.ann1.Glyma.17g144100
+ERF135	Ethylene-responsive factor gene 135	glyma.Wm82.gnm2.ann1.Glyma.17G145300
+ERF136	Ethylene-responsive factor gene 136	glyma.Wm82.gnm2.ann1.Glyma.17G145400
+PPR156	Psudo-Response Regulator gene 156	glyma.Wm82.gnm2.ann1.Glyma.17G146000
+EXB1	Expansin B1 like protein	glyma.Wm82.gnm2.ann1.Glyma.17G147500
+GDH2	glutamate dehydrogenase 2	glyma.Wm82.gnm2.ann1.Glyma.17g148000
+CYP33	peptidyl-prolyl cis-trans isomerase CYP33	glyma.Wm82.gnm2.ann1.Glyma.17g148700
+BMY2	Beta-amylase 2	glyma.Wm82.gnm2.ann1.Glyma.17g150100
+NAC133	NAC Transcription Factor gene 133	glyma.Wm82.gnm2.ann1.Glyma.17G154100
+ALMT26	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.17g154200
+ALMT27	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.17g154300
+PM16	Late embryogenesis abundant protein 16 gene	glyma.Wm82.gnm2.ann1.Glyma.17g155000
+PIN8b	PIN-formed 8 gene b	glyma.Wm82.gnm2.ann1.Glyma.17G157300
 bZIP135	Basic leucine zipper transcription factor-like protein gene 135	glyma.Wm82.gnm2.ann1.Glyma.17G158900
+MYB85	MYB transcription factor MYB85	glyma.Wm82.gnm2.ann1.Glyma.17g160500
+PM35	seed maturation protein PM35	glyma.Wm82.gnm2.ann1.Glyma.17g164200
+DMT1	ferrous ion membrane transport protein DMT1	glyma.Wm82.gnm2.ann1.Glyma.17g165200
+ZFP1	Cys2-His2 zinc finger protein	glyma.Wm82.gnm2.ann1.Glyma.17g165600
+PPR157	Psudo-Response Regulator gene 157	glyma.Wm82.gnm2.ann1.Glyma.17G165800
+GnCrRLk1L27	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.17G166200
+C2-154	C2 domain containing protein gene 154	glyma.Wm82.gnm2.ann1.Glyma.17G166900
+MYB178	MYB transcription factor MYB178	glyma.Wm82.gnm2.ann1.Glyma.17g1671001
+WRKY160	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.17G168900
+SOMT-9	O-methyltransferase SOMT-9	glyma.Wm82.gnm2.ann1.Glyma.17g171100
+LEA2-90	late embryogenesis abundant 2 gene 90	glyma.Wm82.gnm2.ann1.Glyma.17G172900
+MEKK2	mitogen-activated protein kinase	glyma.Wm82.gnm2.ann1.Glyma.17G173000
+DFR	dihydroflavanol reductase	glyma.Wm82.gnm2.ann1.Glyma.17g173200
+ZEP	zeaxanthin epoxidase	glyma.Wm82.gnm2.ann1.Glyma.17g174500
+HSF-35	heat stress transcription factor 35	glyma.Wm82.gnm2.ann1.Glyma.17g174900
+CYP9	peptidyl-prolyl cis-trans isomerase CYP9	glyma.Wm82.gnm2.ann1.Glyma.17g177600
+Lac67	Laccase 67	glyma.Wm82.gnm2.ann1.Glyma.17G180400
+Lac68	Laccase 68	glyma.Wm82.gnm2.ann1.Glyma.17G180500
+NAC134	NAC Transcription Factor gene 134	glyma.Wm82.gnm2.ann1.Glyma.17G185000
+IQD60	protein IQ-DOMAIN 60	glyma.Wm82.gnm2.ann1.Glyma.17g185200
+TEFS1	Elongation factor 1-alpha	glyma.Wm82.gnm2.ann1.Glyma.17g186600
+SRC1	src1 protein	glyma.Wm82.gnm2.ann1.Glyma.17g187600
 bZIP136	Basic leucine zipper transcription factor-like protein gene 136	glyma.Wm82.gnm2.ann1.Glyma.17G188500
 bZIP137	Basic leucine zipper transcription factor-like protein gene 137	glyma.Wm82.gnm2.ann1.Glyma.17G197300
+WRKY161	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.17G197500
+GA3OX6	gibberellin 3-beta-dioxygenase 6	glyma.Wm82.gnm2.ann1.Glyma.17g205300
+GF14s	GF14 gene family gene s	glyma.Wm82.gnm2.ann1.Glyma.17G208100
+CPP1	cysteine-rich polycomb-like protein	glyma.Wm82.gnm2.ann1.Glyma.17g208500
+PPR158	Psudo-Response Regulator gene 158	glyma.Wm82.gnm2.ann1.Glyma.17G209700
+ERF137	Ethylene-responsive factor gene 137	glyma.Wm82.gnm2.ann1.Glyma.17G210500
+ALDH11A3	aldehyde dehydrogenase 11A3	glyma.Wm82.gnm2.ann1.Glyma.17g218200
+CYP37	peptidyl-prolyl cis-trans isomerase CYP37	glyma.Wm82.gnm2.ann1.Glyma.17g218800
+PPR159	Psudo-Response Regulator gene 159	glyma.Wm82.gnm2.ann1.Glyma.17G220100
+WRKY162, WRKY30	WRKY transcription factor 30	glyma.Wm82.gnm2.ann1.Glyma.17g222300
+WRKY163, WRKY63	WRKY transcription factor 63	glyma.Wm82.gnm2.ann1.Glyma.17g222500
+WRKY164	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.17G224800
+HSP17.9-D	17.9 kDa class II heat shock protein	glyma.Wm82.gnm2.ann1.Glyma.17g224900
+Raf49-2	Raf49 proto-oncogene serine/threonine protein kinase gene 2	glyma.Wm82.gnm2.ann1.Glyma.17G225400
+CHI3C2	chalcone isomerase 3C2	glyma.Wm82.gnm2.ann1.Glyma.17g226600
+GPA2	guanine nucleotide-binding protein alpha-2 subunit	glyma.Wm82.gnm2.ann1.Glyma.17g226700
+IQD61	protein IQ-DOMAIN 61	glyma.Wm82.gnm2.ann1.Glyma.17g227400
+HSF-34	heat stress transcription factor 34	glyma.Wm82.gnm2.ann1.Glyma.17g227600
+SLD1.5	delta8-sphingolipid desaturase	glyma.Wm82.gnm2.ann1.Glyma.17g228400
+HDA18	histone deacetylase	glyma.Wm82.gnm2.ann1.Glyma.17g229600
+GRF18	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.17g232600
+GRF19	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.17g232700
+MED35-4	Mediator Complex 35 gene 4	glyma.Wm82.gnm2.ann1.Glyma.17g233000
+D14	alpha/beta hydroxylase D14	glyma.Wm82.gnm2.ann1.Glyma.17g235300
+SCOF-1	scof-1 protein	glyma.Wm82.gnm2.ann1.Glyma.17g236200
+GASA27	gibberellin-regulated protein 27	glyma.Wm82.gnm2.ann1.Glyma.17g237100
+MAF1	MFP1 attachment factor 1	glyma.Wm82.gnm2.ann1.Glyma.17g237500
+MYB70	MYB transcription factor MYB70	glyma.Wm82.gnm2.ann1.Glyma.17g237900
+WRKY165	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.17G239200
+NAC135	NAC Transcription Factor gene 135	glyma.Wm82.gnm2.ann1.Glyma.17G240700
+AOS2	allene oxide synthase	glyma.Wm82.gnm2.ann1.Glyma.17g246500
+BES1-1	protein BRI1-EMS-SUPPRESSOR 1	glyma.Wm82.gnm2.ann1.Glyma.17g248900
+DFR2, DHFR2, W4	White flower 4	glyma.Wm82.gnm2.ann1.Glyma.17g252200
 bZIP138	Basic leucine zipper transcription factor-like protein gene 138	glyma.Wm82.gnm2.ann1.Glyma.17G253200
 bZIP139	Basic leucine zipper transcription factor-like protein gene 139	glyma.Wm82.gnm2.ann1.Glyma.17G255800
+CYP83D1	cytochrome P450 monooxygenase CYP83D1	glyma.Wm82.gnm2.ann1.Glyma.17g255900
+GASA28	gibberellin-regulated protein 28	glyma.Wm82.gnm2.ann1.Glyma.17g258100
+GASA29	gibberellin-regulated protein 29	glyma.Wm82.gnm2.ann1.Glyma.17g258200
+C2-155	C2 domain containing protein gene 155	glyma.Wm82.gnm2.ann1.Glyma.17G259000
+EXP1	expansin 1	glyma.Wm82.gnm2.ann1.Glyma.17g260400
+Lac69	Laccase 69	glyma.Wm82.gnm2.ann1.Glyma.17G261500
+CAT1	catalase	glyma.Wm82.gnm2.ann1.Glyma.17g261700
+PPR160	Psudo-Response Regulator gene 160	glyma.Wm82.gnm2.ann1.Glyma.17G262700
+MED13-1	Mediator Complex 13 gene 1	glyma.Wm82.gnm2.ann1.Glyma.18g000100
+PAP15	purple acid phosphatase 15-like	glyma.Wm82.gnm2.ann1.Glyma.18g001300
+PDS1	phytoene desaturase	glyma.Wm82.gnm2.ann1.Glyma.18g003900
+MADS28	MADS transcription factor	glyma.Wm82.gnm2.ann1.Glyma.18g0047001
+CAMTA11	Calmodulin binding transcription activator 11	glyma.Wm82.gnm2.ann1.Glyma.18G005100
+NTF2B-4	nucleus transporter 2B gene 4	glyma.Wm82.gnm2.ann1.Glyma.18g005300
+DPB3-2	dr1-associated corepressor-like	glyma.Wm82.gnm2.ann1.Glyma.18g007100
+HELRP	ATP-dependent RNA helicase DEAH12, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.18g014800
+H3	histone H3.3 gene 4	glyma.Wm82.gnm2.ann1.Glyma.18g015300
+C2-156	C2 domain containing protein gene 156	glyma.Wm82.gnm2.ann1.Glyma.18G017500
+TPP	trehalose 6-phosphate phosphatase	glyma.Wm82.gnm2.ann1.Glyma.18G018100
+N-70	early nodulin-70	glyma.Wm82.gnm2.ann1.Glyma.18g018900
+MED36-3	Mediator Complex 36 gene 3	glyma.Wm82.gnm2.ann1.Glyma.18g020000
 bZIP140, TGA23	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.18g020900
+SNAP18	soluble NSF attachment protein SNAP18	glyma.Wm82.gnm2.ann1.Glyma.18g022500
+WI12	wound-inducible protein 12	glyma.Wm82.gnm2.ann1.Glyma.18g022700
+PDH1	prephenate dehydrogenase 1	glyma.Wm82.gnm2.ann1.Glyma.18g023100
+RHG1	receptor-like kinase RHG1	glyma.Wm82.gnm2.ann1.Glyma.18g023500
+Lac70	Laccase 70	glyma.Wm82.gnm2.ann1.Glyma.18G023600
+PAP02	multiple inositol polyphosphate phosphatase 1-like	glyma.Wm82.gnm2.ann1.Glyma.18g024700
+JOX2	jasnonate-induced oxygenase 2	glyma.Wm82.gnm2.ann1.Glyma.18G026500
+C2-157	C2 domain containing protein gene 157	glyma.Wm82.gnm2.ann1.Glyma.18G027100
+C2-158	C2 domain containing protein gene 158	glyma.Wm82.gnm2.ann1.Glyma.18G027200
+C2-159	C2 domain containing protein gene 159	glyma.Wm82.gnm2.ann1.Glyma.18G027300
+CYP25	peptidyl-prolyl cis-trans isomerase CYP25	glyma.Wm82.gnm2.ann1.Glyma.18g027400
+ELF4B	protein EARLY FLOWERING 4b	glyma.Wm82.gnm2.ann1.Glyma.18g027500
+LAX14	auxin transporter-like protein 14	glyma.Wm82.gnm2.ann1.Glyma.18g029000
+C2-160	C2 domain containing protein gene 160	glyma.Wm82.gnm2.ann1.Glyma.18G030000
+P5CS	delta-pyrroline-5-carboxylate synthetase	glyma.Wm82.gnm2.ann1.Glyma.18g034300
+RCABETA	ribulose bisphosphate carboxylase/oxygenase activase, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.18g036400
+C2-161	C2 domain containing protein gene 161	glyma.Wm82.gnm2.ann1.Glyma.18G038400
+C2-162	C2 domain containing protein gene 162	glyma.Wm82.gnm2.ann1.Glyma.18G039700
+DHAR-3a, DHAR3, MDHAR-3a	DEHYDROASCORBATE REDUCTASE 3 gene a	glyma.Wm82.gnm2.ann1.Glyma.18G040100
+GS1beta2	Glutamine synthase 1 beta 2 gene	glyma.Wm82.gnm2.ann1.Glyma.18g041100
+13-1-1	syringolide-induced protein 13-1-1	glyma.Wm82.gnm2.ann1.Glyma.18g042100
+GAD	GAD protein	glyma.Wm82.gnm2.ann1.Glyma.18g043600
+NAC136	NAC Transcription Factor gene 136	glyma.Wm82.gnm2.ann1.Glyma.18G043900
+G93	PH/RCC1/FYVE zinc finger domain-containing protein G93	glyma.Wm82.gnm2.ann1.Glyma.18g044000
+CRK50	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g046100
+CRK51	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g046200
+CRK53	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g046400
+CRK54	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g046600
+LEA2-91	late embryogenesis abundant 2 gene 91	glyma.Wm82.gnm2.ann1.Glyma.18G047800
 bZIP141	Basic leucine zipper transcription factor-like protein gene 141	glyma.Wm82.gnm2.ann1.Glyma.18G052500
-bZIP142	Basic leucine zipper transcription factor-like protein gene 142	glyma.Wm82.gnm2.ann1.Glyma.18G117100
+WRKY75	WRKY75 transcription factor	glyma.Wm82.gnm2.ann1.Glyma.18G054400
+PER1	peroxidase	glyma.Wm82.gnm2.ann1.Glyma.18g055300
+WRKY166, WRKY62	WRKY transcription factor 62	glyma.Wm82.gnm2.ann1.Glyma.18g056600
+Lac71	Laccase 71	glyma.Wm82.gnm2.ann1.Glyma.18G057200
+MT2	malonyltransferase	glyma.Wm82.gnm2.ann1.Glyma.18g057700
+MAPKKK14-1	mitogen-activated protein kinase kinase kinase 14 gene 1	glyma.Wm82.gnm2.ann1.Glyma.18G060900
+AS1, ASNS	glutamine-dependent asparagine synthetase	glyma.Wm82.gnm2.ann1.Glyma.18G061100
+FAD3c	omega-3 fatty acid desaturase 3 gene 3	glyma.Wm82.gnm2.ann1.Glyma.18g062000
+CYP24	peptidyl-prolyl cis-trans isomerase CYP24	glyma.Wm82.gnm2.ann1.Glyma.18g062900
+Lac72	Laccase 72	glyma.Wm82.gnm2.ann1.Glyma.18G065100
+NF-YA20	nuclear transcription factor Y subunit A-20	glyma.Wm82.gnm2.ann1.Glyma.18g071000
+LEA2-92	late embryogenesis abundant 2 gene 92	glyma.Wm82.gnm2.ann1.Glyma.18G073200
+HSP90-1	heat shock protein 90-1	glyma.Wm82.gnm2.ann1.Glyma.18g074100
+SRT4	NAD-dependent protein deacetylase SRT1-like	glyma.Wm82.gnm2.ann1.Glyma.18g076300
+SAT1	serine O-acetyltransferase 1	glyma.Wm82.gnm2.ann1.Glyma.18g080000
+F6H2	flavonoid 6-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.18g080200
+F6H1	flavonoid 6-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.18g080400
+WRKY167	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.18G081200
+ZIK8-1	Zinc Finger Protein Interacting With K Protein 8 gene 1	glyma.Wm82.gnm2.ann1.Glyma.18G081500
+C2-163	C2 domain containing protein gene 163	glyma.Wm82.gnm2.ann1.Glyma.18G081900
+PPR161	Psudo-Response Regulator gene 161	glyma.Wm82.gnm2.ann1.Glyma.18G085900
+ERF138	Ethylene-responsive factor gene 138	glyma.Wm82.gnm2.ann1.Glyma.18G091600
+WRKY168	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.18G092200
+PPR162	Psudo-Response Regulator gene 162	glyma.Wm82.gnm2.ann1.Glyma.18G094700
+NAC137	NAC Transcription Factor gene 137	glyma.Wm82.gnm2.ann1.Glyma.18G110700
+F6'H1	feruloyl CoA ortho-hydroxylase 1	glyma.Wm82.gnm2.ann1.Glyma.18g111000
+GSTF13	phi class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.18g111200
+bZIP142, BZIP36	bZIP transcription factor bZIP36	glyma.Wm82.gnm2.ann1.Glyma.18g117100
+NAC138	NAC Transcription Factor gene 138	glyma.Wm82.gnm2.ann1.Glyma.18G119300
+SLD1.6	sphingolipid delta-8 desaturase	glyma.Wm82.gnm2.ann1.Glyma.18g120400
+TCP23	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 23	glyma.Wm82.gnm2.ann1.Glyma.18G121400
+IQD62	protein IQ-DOMAIN 62	glyma.Wm82.gnm2.ann1.Glyma.18g124200
+WRKY169	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.18G124700
+MED10-2	Mediator Complex 10 gene 2	glyma.Wm82.gnm2.ann1.Glyma.18g125700
+PPR163	Psudo-Response Regulator gene 163	glyma.Wm82.gnm2.ann1.Glyma.18G126700
+PPR164	Psudo-Response Regulator gene 164	glyma.Wm82.gnm2.ann1.Glyma.18G128100
+GASA31	gibberellin-regulated protein 31	glyma.Wm82.gnm2.ann1.Glyma.18g132100
+PAP1	PAP1, probable inactive purple acid phosphatase 1	glyma.Wm82.gnm2.ann1.Glyma.18g132500
+MED18-3	Mediator Complex 18 gene 3	glyma.Wm82.gnm2.ann1.Glyma.18g135700
+ALDH2B8	aldehyde dehydrogenase family 2 member B8	glyma.Wm82.gnm2.ann1.Glyma.18g137300
+CRK55	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g141500
+CRK56	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g141700
+ERF139	Ethylene-responsive factor gene 139	glyma.Wm82.gnm2.ann1.Glyma.18G144700
+RPS6	ribosomal protein S6	glyma.Wm82.gnm2.ann1.Glyma.18g151800
+CycC-2	Cyclin C gene 2	glyma.Wm82.gnm2.ann1.Glyma.18g159000
+RIN4c	RIN4c protein	glyma.Wm82.gnm2.ann1.Glyma.18g166800
+Lac73	Laccase 73	glyma.Wm82.gnm2.ann1.Glyma.18G177200
+Lac74	Laccase 74	glyma.Wm82.gnm2.ann1.Glyma.18G177300
+Lac75	Laccase 75	glyma.Wm82.gnm2.ann1.Glyma.18G177400
+PHAN3	MYB/HD-like transcription factor	glyma.Wm82.gnm2.ann1.Glyma.18g181300
+WRKY170	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.18G183100
+Lac76	Laccase 76	glyma.Wm82.gnm2.ann1.Glyma.18G183500
+Lac77	Laccase 77	glyma.Wm82.gnm2.ann1.Glyma.18G183700
+GSTU58	tau class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.18g190200
+GSTU60	tau class glutathione S-transferase	glyma.Wm82.gnm2.ann1.Glyma.18g190500
+Lac78	Laccase 78	glyma.Wm82.gnm2.ann1.Glyma.18G193200
+Lac79	Laccase 79	glyma.Wm82.gnm2.ann1.Glyma.18G193300
+Lac80	Laccase 80	glyma.Wm82.gnm2.ann1.Glyma.18G193400
+ACCA-1	alpha-carboxyltransferase aCT-1 precursor	glyma.Wm82.gnm2.ann1.Glyma.18g195700
+ACCA-2	alfa-carboxyltransferase precursor	glyma.Wm82.gnm2.ann1.Glyma.18g195900
+ACCA-3	carboxyl transferase alpha subunit	glyma.Wm82.gnm2.ann1.Glyma.18g196000
+Lac81	Laccase 81	glyma.Wm82.gnm2.ann1.Glyma.18G197400
+PIP1-2	aquaporin PIP1-2	glyma.Wm82.gnm2.ann1.Glyma.18g198300
+LAX15	auxin transporter-like protein 15	glyma.Wm82.gnm2.ann1.Glyma.18g198400
+PHR29	MYB-CC domain-containing transcription factor PHR29	glyma.Wm82.gnm2.ann1.Glyma.18g201800
+JOX3	jasnonate-induced oxygenase 3	glyma.Wm82.gnm2.ann1.Glyma.18G201900
+FAD7-2	omega-3 fatty acid desaturase 7 gene 2	glyma.Wm82.gnm2.ann1.Glyma.18g202600
+Sle1	Group-1 late embryogenesis abundant protein 1 gene 	glyma.Wm82.gnm2.ann1.Glyma.18g203500
+AMT2.2	ammonium transporter AMT2.2	glyma.Wm82.gnm2.ann1.Glyma.18g204800
+H-1	ferritin light chain	glyma.Wm82.gnm2.ann1.Glyma.18g205800
+WRKY171	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.18G208800
+KASIII-3	beta-ketoacyl-acyl carrier protein synthase III	glyma.Wm82.gnm2.ann1.Glyma.18g211400
+S6K1B	S6 Kinase 1	glyma.Wm82.gnm2.ann1.Glyma.18g212800
+WRKY172, WRKY57	WRKY transcription factor 57	glyma.Wm82.gnm2.ann1.Glyma.18g213200
+WNK11	with no lysine kinase 11	glyma.Wm82.gnm2.ann1.Glyma.18g215100
+GinCrRI,k1l,28	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G215800
+TAP1	acetyltransferase TAP1	glyma.Wm82.gnm2.ann1.Glyma.18g216900
+LEA2-93	late embryogenesis abundant 2 gene 93	glyma.Wm82.gnm2.ann1.Glyma.18G218700
+LEA2-94	late embryogenesis abundant 2 gene 94	glyma.Wm82.gnm2.ann1.Glyma.18G218800
+MED5-5	Mediator Complex 5 gene 5	glyma.Wm82.gnm2.ann1.Glyma.18g218900
+CRK57	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g219200
+CRK58	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g219300
+CRK59	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g219600
+CRK60	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g219700
+CRK61	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g219800
+DHPS1	dihydrodipicolinate synthase	glyma.Wm82.gnm2.ann1.Glyma.18g221700
+ZPR1B	protein LITTLE ZIPPER 2-like	glyma.Wm82.gnm2.ann1.Glyma.18g221802
+C2-164	C2 domain containing protein gene 164	glyma.Wm82.gnm2.ann1.Glyma.18G224000
+C2-165	C2 domain containing protein gene 165	glyma.Wm82.gnm2.ann1.Glyma.18G224800
+C2-166	C2 domain containing protein gene 166	glyma.Wm82.gnm2.ann1.Glyma.18G225300
+C2-167	C2 domain containing protein gene 167	glyma.Wm82.gnm2.ann1.Glyma.18G225400
+PPR165	Psudo-Response Regulator gene 165	glyma.Wm82.gnm2.ann1.Glyma.18G225600
+DGD2	digalactosyldiacylglycerol synthase 2	glyma.Wm82.gnm2.ann1.Glyma.18g228900
+C2-168	C2 domain containing protein gene 168	glyma.Wm82.gnm2.ann1.Glyma.18G230800
+BBI-2	Bowman-Birk type proteinase inhibitor	glyma.Wm82.gnm2.ann1.Glyma.18g231400
+BBI-1	putative Bowman-Birk type protease inhibitor	glyma.Wm82.gnm2.ann1.Glyma.18g231500
+MED12-4	Mediator Complex 12 gene 4	glyma.Wm82.gnm2.ann1.Glyma.18g232900
+OAS-TL3	OAS-TL3 cysteine synthase	glyma.Wm82.gnm2.ann1.Glyma.18g234600
+CRK62	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18g237900
+WRKY10, WRKY173	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.18G238200
+WRKY174, WRKY64	WRKY transcription factor 64	glyma.Wm82.gnm2.ann1.Glyma.18g238600
+LEA2-95	late embryogenesis abundant 2 gene 95	glyma.Wm82.gnm2.ann1.Glyma.18G238700
+CYP97C10	protein LUTEIN DEFICIENT 5, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.18g239900
+PIN5b	PIN-formed 5 gene b	glyma.Wm82.gnm2.ann1.Glyma.18G241000
+PPR166	Psudo-Response Regulator gene 166	glyma.Wm82.gnm2.ann1.Glyma.18G241500
+WRKY175	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.18G242000
+ACCB-1	biotin carboxyl carrier protein precursor	glyma.Wm82.gnm2.ann1.Glyma.18g243500
+CYP29	peptidyl-prolyl cis-trans isomerase CYP29	glyma.Wm82.gnm2.ann1.Glyma.18g248100
+WRKY38	WRKY transcription factor 38	glyma.Wm82.gnm2.ann1.Glyma.18g249500
+ERF140	Ethylene-responsive factor gene 140	glyma.Wm82.gnm2.ann1.Glyma.18G252200
+EREBP1, ERF141	Ethylene-responsive factor gene 141	glyma.Wm82.gnm2.ann1.Glyma.18G252300
+PIN8d	PIN-formed 8 gene d	glyma.Wm82.gnm2.ann1.Glyma.18G255800
+WRKY176	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.18G256500
+MYB60	MYB transcription factor MYB60	glyma.Wm82.gnm2.ann1.Glyma.18g259100
+GASA32	gibberellin-regulated protein 32	glyma.Wm82.gnm2.ann1.Glyma.18g259400
+NIP2-2	putative Si transporter NIP2-2	glyma.Wm82.gnm2.ann1.Glyma.18g259500
+PPR167	Psudo-Response Regulator gene 167	glyma.Wm82.gnm2.ann1.Glyma.18G260300
+CDF2	Cycling Dof Factor 2	glyma.Wm82.gnm2.ann1.Glyma.18G260500
+NAC139, NLP1	NAC domain-containing protein 100-like	glyma.Wm82.gnm2.ann1.Glyma.18g261300
+CGS1	cystathionine gamma-synthase 1, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.18g261600
+PHO1-H6	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.18g261900
+WRKY177	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.18G263400
+ACCB-2	biotin carboxyl carrier protein subunit	glyma.Wm82.gnm2.ann1.Glyma.18g265300
+IMAT1	isoflavone malonyltransferase IMaT1	glyma.Wm82.gnm2.ann1.Glyma.18g268200
+TCP44	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 44	glyma.Wm82.gnm2.ann1.Glyma.18G268700
+CrRLk1L29	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G269900
+GinCrRLk1L30	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G270100
+CrRLk1L31	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G270600
+GinCrRl,k1l,32	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G270700
+GinCrRl,k1l,33	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G270900
+GnCrRLk1L34	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G271000
+GnCrRLk1L35	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.18G271100
+COBL20	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.18G271900
+COBL21	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.18G272000
+COBL22	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.18G272100
+DT2	MADS-box protein Dt2	glyma.Wm82.gnm2.ann1.Glyma.18g273600
+PPR168	Psudo-Response Regulator gene 168	glyma.Wm82.gnm2.ann1.Glyma.18G275000
+PPR169	Psudo-Response Regulator gene 169	glyma.Wm82.gnm2.ann1.Glyma.18G277000
 bZIP143, BZIP73A	bZIP transcription factor bZIP73A	glyma.Wm82.gnm2.ann1.Glyma.18g277100
-bZIP144	Basic leucine zipper transcription factor-like protein gene 144	glyma.Wm82.gnm2.ann1.Glyma.19G037900
-bZIP145	Basic leucine zipper transcription factor-like protein gene 145	glyma.Wm82.gnm2.ann1.Glyma.19G067900
-bZIP146	Basic leucine zipper transcription factor-like protein gene 146	glyma.Wm82.gnm2.ann1.Glyma.19G122800
-bZIP147	Basic leucine zipper transcription factor-like protein gene 147	glyma.Wm82.gnm2.ann1.Glyma.19G126800
+GND	6-phosphogluconate dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.18g277300
+COL1b	Contsans-like 1 gene b 	glyma.Wm82.gnm2.ann1.Glyma.18G278100
+TCP53	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 53	glyma.Wm82.gnm2.ann1.Glyma.18G280700
+AOC6	allene oxide cyclase 4, chloroplastic-like	glyma.Wm82.gnm2.ann1.Glyma.18g280900
+ERF142	Ethylene-responsive factor gene 142	glyma.Wm82.gnm2.ann1.Glyma.18G281400
+BZIP55	bZIP transcription factor 55	glyma.Wm82.gnm2.ann1.Glyma.18g283800
+G6PDH7	Glucose-6-phosphate dehydrogenase gene 7	glyma.Wm82.gnm2.ann1.Glyma.18G284600
+CHR5	chalcone reductase CHR5	glyma.Wm82.gnm2.ann1.Glyma.18g285800
+PPR170	Psudo-Response Regulator gene 170	glyma.Wm82.gnm2.ann1.Glyma.18G287500
+C2-169	C2 domain containing protein gene 169	glyma.Wm82.gnm2.ann1.Glyma.18G288600
+MED37-10	Mediator Complex 37 gene 10	glyma.Wm82.gnm2.ann1.Glyma.18g289100
+MED37-11	Mediator Complex 37 gene 11	glyma.Wm82.gnm2.ann1.Glyma.18g289600
+ACTIN, SAc6	Actin 6 gene	glyma.Wm82.gnm2.ann1.Glyma.18g290800
+SWEET44	sugar efflux transporter SWEET44	glyma.Wm82.gnm2.ann1.Glyma.18g295100
+GF14A, GF14t	GF14 gene family gene t	glyma.Wm82.gnm2.ann1.Glyma.18G298300
+FT1a, TSF2	Twin sister of FT gene 2	glyma.Wm82.gnm2.ann1.Glyma.18g298900
+FT1b, TSF1	Twin sister of FT gene 1	glyma.Wm82.gnm2.ann1.Glyma.18g299000
+GMR1	ras-related protein RABA5d-like	glyma.Wm82.gnm2.ann1.Glyma.18g300600
+SWEET45	sugar efflux transporter SWEET45	glyma.Wm82.gnm2.ann1.Glyma.18g301100
+SWEET46	sugar efflux transporter SWEET46	glyma.Wm82.gnm2.ann1.Glyma.18g301200
+NAC14, NAC179	NAC Transcription Factor gene 179	glyma.Wm82.gnm2.ann1.Glyma.18G301500
+MED5-6	Mediator Complex 5 gene 6	glyma.Wm82.gnm2.ann1.Glyma.19g001500
+NAC180	NAC domain containing protein 180	glyma.Wm82.gnm2.ann1.Glyma.19g002900
+CYP59	peptidyl-prolyl cis-trans isomerase CYP59	glyma.Wm82.gnm2.ann1.Glyma.19g004200
+CRK63	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.19g005700
+ARF	ADP-ribosylation factor	glyma.Wm82.gnm2.ann1.Glyma.19g006400
+CYP60	peptidyl-prolyl cis-trans isomerase CYP60	glyma.Wm82.gnm2.ann1.Glyma.19g009700
+SWEET47	sugar efflux transporter SWEET47	glyma.Wm82.gnm2.ann1.Glyma.19g009800
+SWEET48	sugar efflux transporter SWEET48	glyma.Wm82.gnm2.ann1.Glyma.19g009900
+HSP22.3	low molecular weight heat shock protein Hsp22.3	glyma.Wm82.gnm2.ann1.Glyma.19g011400
+GASA33	gibberellin-regulated protein 33	glyma.Wm82.gnm2.ann1.Glyma.19g013000
+HIR1	hypersensitive-induced response protein 2-like	glyma.Wm82.gnm2.ann1.Glyma.19g020000
+WRKY179	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.19G020600
+NAC140	NAC Transcription Factor gene 140	glyma.Wm82.gnm2.ann1.Glyma.19G021900
+GASA34	gibberellin-regulated protein 34	glyma.Wm82.gnm2.ann1.Glyma.19g022500
+NAC141	NAC Transcription Factor gene 141	glyma.Wm82.gnm2.ann1.Glyma.19G024500
+MYB11	MYB11 protein	glyma.Wm82.gnm2.ann1.Glyma.19g024700
+PPR171	Psudo-Response Regulator gene 171	glyma.Wm82.gnm2.ann1.Glyma.19G025700
+ERF143	Ethylene-responsive factor gene 143	glyma.Wm82.gnm2.ann1.Glyma.19G026000
+MED3-2	Mediator Complex 3 gene 2	glyma.Wm82.gnm2.ann1.Glyma.19g026300
+AT133	malonyl-CoA:isoflavone 7-O-glucoside-6''-O-malonyltransferase	glyma.Wm82.gnm2.ann1.Glyma.19g030500
+TCP45	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 45	glyma.Wm82.gnm2.ann1.Glyma.19G030900
+GinCrRI,k1l,36	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.19G033100
+COBL23	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.19G033500
+COBL24	Regulates cell wall expansion and cellulose depostion	glyma.Wm82.gnm2.ann1.Glyma.19G033600
+SEP1	transcription factor SEP1	glyma.Wm82.gnm2.ann1.Glyma.19g034500
+AGL8d	Agamous 8-Like gene d	glyma.Wm82.gnm2.ann1.Glyma.19G034600
+bZIP144, BZIP25	bZIP transcription factor 25	glyma.Wm82.gnm2.ann1.Glyma.19g037900
+COL2b	Constance-like 2 gene b	glyma.Wm82.gnm2.ann1.Glyma.19G039000
+PDH	proline dehydrogenase	glyma.Wm82.gnm2.ann1.Glyma.19g043000
+TCP54	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 54	glyma.Wm82.gnm2.ann1.Glyma.19G044400
+AOC3	amine oxidase, copper containing 3 (vascular adhesion protein 1)	glyma.Wm82.gnm2.ann1.Glyma.19g044900
+KR1	resistance protein KR1	glyma.Wm82.gnm2.ann1.Glyma.19g054900
+NAC142	NAC Transcription Factor gene 142	glyma.Wm82.gnm2.ann1.Glyma.19G056400
+GER20	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.19g058900
+MDHAR-4b	Peroximal monodehydroascorbate reductase 4 gene b	glyma.Wm82.gnm2.ann1.Glyma.19g061200
+MYB182	MYB transcription factor MYB182	glyma.Wm82.gnm2.ann1.Glyma.19g061300
+MYB98	MYB transcription factor MYB98	glyma.Wm82.gnm2.ann1.Glyma.19g061600
+CRK64	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.19g062300
+P89	P24 oleosin isoform A	glyma.Wm82.gnm2.ann1.Glyma.19g063400
+BZIP119, bZIP145	Basic leucine zipper transcription factor-like protein gene 145	glyma.Wm82.gnm2.ann1.Glyma.19G067900
+SCAM-3	calmodulin	glyma.Wm82.gnm2.ann1.Glyma.19g068300
+C2-170	C2 domain containing protein gene 170	glyma.Wm82.gnm2.ann1.Glyma.19G070700
+C2-171	C2 domain containing protein gene 171	glyma.Wm82.gnm2.ann1.Glyma.19G070800
+N-26B	nodulin-26b (AA 1-213)	glyma.Wm82.gnm2.ann1.Glyma.19g074000
+G6PDH6	Glucose-6-phosphate dehydrogenase gene 6	glyma.Wm82.gnm2.ann1.Glyma.19G077300
+G6PDH, G6PDH2	Glucose-6-phosphate dehydrogenase gene 2	glyma.Wm82.gnm2.ann1.Glyma.19G082300
+GER13	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.19g086100
+GER14	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.19g086200
+HEMG	protoporphyrinogen IX oxidase	glyma.Wm82.gnm2.ann1.Glyma.19g087600
+LYK10	protein LYK2	glyma.Wm82.gnm2.ann1.Glyma.19g088300
+WRKY180, WRKY45, WRKY53	WRKY transcription factor 53	glyma.Wm82.gnm2.ann1.Glyma.19g094100
+TCP24	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 24	glyma.Wm82.gnm2.ann1.Glyma.19G095300
+NAC143	NAC Transcription Factor gene 143	glyma.Wm82.gnm2.ann1.Glyma.19G097700
+COL17	zinc finger protein CONSTANS-LIKE 14-like	glyma.Wm82.gnm2.ann1.Glyma.19g099700
+AFB2, AFB3A	auxin signaling F-box 3 protein	glyma.Wm82.gnm2.ann1.Glyma.19g100200
+ICE2	inducer of CBF expression 2	glyma.Wm82.gnm2.ann1.Glyma.19g102000
+PPR172	Psudo-Response Regulator gene 172	glyma.Wm82.gnm2.ann1.Glyma.19G102300
+ERF144	Ethylene-responsive factor gene 144	glyma.Wm82.gnm2.ann1.Glyma.19G104200
+CHS13	chalcone synthase 13	glyma.Wm82.gnm2.ann1.Glyma.19g105100
+FT3b, FTL2	Flowering locus T-like gene 2	glyma.Wm82.gnm2.ann1.Glyma.19g108100
+FT5b, FTL6	Flowering locus T-like gene 6	glyma.Wm82.gnm2.ann1.Glyma.19g108200
+SIP1-3	aquaporin SIP1-3	glyma.Wm82.gnm2.ann1.Glyma.19g108400
+NAC11, NAC181	NAC Transcription Factor gene 181	glyma.Wm82.gnm2.ann1.Glyma.19G108800
+NAC144	NAC Transcription Factor gene 144	glyma.Wm82.gnm2.ann1.Glyma.19G109100
+ERF145, ERN	ethylene-responsive transcription factor ERN1	glyma.Wm82.gnm2.ann1.Glyma.19g113100
+PUR3	glycinamide ribonucleotide transformylase	glyma.Wm82.gnm2.ann1.Glyma.19g115900
+BSAS	beta-substituted alanine synthase	glyma.Wm82.gnm2.ann1.Glyma.19g119100
+PHR30	MYB-CC domain-containing transcription factor PHR30	glyma.Wm82.gnm2.ann1.Glyma.19g122700
+bZIP146, FDL19	bZIP transcription factor FDL19	glyma.Wm82.gnm2.ann1.Glyma.19g122800
+SIP2-2	aquaporin SIP2-2	glyma.Wm82.gnm2.ann1.Glyma.19g123600
+CYP98A2	cytochrome P450 98A2	glyma.Wm82.gnm2.ann1.Glyma.19g126000
+bZIP147, BZIP37	bZIP transcription factor 37	glyma.Wm82.gnm2.ann1.Glyma.19g126800
+CYCB1;2	G2/mitotic-specific cyclin S13-7	glyma.Wm82.gnm2.ann1.Glyma.19g127200
+MYB142	MYB transcription factor MYB142	glyma.Wm82.gnm2.ann1.Glyma.19g127900
+PIN1e	PIN-formed 1 gene e	glyma.Wm82.gnm2.ann1.Glyma.19G128800
 bZIP148	Basic leucine zipper transcription factor-like protein gene 148	glyma.Wm82.gnm2.ann1.Glyma.19G130200
+P5CR	pyrroline-5-carboxylate reductase	glyma.Wm82.gnm2.ann1.Glyma.19g131500
+BHLH322	bHLH transcription factor bHLH322	glyma.Wm82.gnm2.ann1.Glyma.19g132600
+SDP1-3	triacylglycerol lipase SDP1	glyma.Wm82.gnm2.ann1.Glyma.19g132900
+GASA35	gibberellin-regulated protein 35	glyma.Wm82.gnm2.ann1.Glyma.19g133600
+HSF-36	heat stress transcription factor 36	glyma.Wm82.gnm2.ann1.Glyma.19g137800
+PPR173	Psudo-Response Regulator gene 173	glyma.Wm82.gnm2.ann1.Glyma.19G141800
+CYP93A2	Cytochrome P450 93A2	glyma.Wm82.gnm2.ann1.Glyma.19g144700
 bZIP149, TGA25	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.19g145300
-bZIP15	Basic leucine zipper transcription factor-like protein gene 15	glyma.Wm82.gnm2.ann1.Glyma.02G161100
+C2-172	C2 domain containing protein gene 172	glyma.Wm82.gnm2.ann1.Glyma.19G145400
+SPL9D	squamosa promoter-binding-like protein 9d	glyma.Wm82.gnm2.ann1.Glyma.19g146000
+PHR31	MYB-CC domain-containing transcription factor PHR31	glyma.Wm82.gnm2.ann1.Glyma.19g146600
+PM1	Late embryogenesis abundant protein 1 gene	glyma.Wm82.gnm2.ann1.Glyma.19g147200
+FAD2-2A	fatty acid desaturase-2	glyma.Wm82.gnm2.ann1.Glyma.19g147300
+FAD2-2B	fatty acid desaturase-2	glyma.Wm82.gnm2.ann1.Glyma.19g147400
+ACT2/7, UBQ10	polyubiquitin 10	glyma.Wm82.gnm2.ann1.Glyma.19G147900
+PTS-L2	pterocarpan synthase-like	glyma.Wm82.gnm2.ann1.Glyma.19g150900
+PTS-L3	pterocarpan synthase-like	glyma.Wm82.gnm2.ann1.Glyma.19g151000
+PTS3	pterocarpan synthase	glyma.Wm82.gnm2.ann1.Glyma.19g151100
+PTS4	pterocarpan synthase	glyma.Wm82.gnm2.ann1.Glyma.19g151200
+PTS-L5	pterocarpan synthase-like	glyma.Wm82.gnm2.ann1.Glyma.19g151300
+ALMT28	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.19g155200
+CHI3B2	chalcone isomerase 3B2	glyma.Wm82.gnm2.ann1.Glyma.19g156900
+CPS2, TPS22	terpene synthase 22	glyma.Wm82.gnm2.ann1.Glyma.19g157000
+CYP27	peptidyl-prolyl cis-trans isomerase CYP27	glyma.Wm82.gnm2.ann1.Glyma.19g160200
+TSA	tryptophan synthase alpha chain	glyma.Wm82.gnm2.ann1.Glyma.19g160800
+IAA55	Indole-3-Acetic Acid Responsive Gene 55	glyma.Wm82.gnm2.ann1.Glyma.19G161000
+AUX28, IAA56	Indole-3-Acetic Acid Responsive Gene 56	glyma.Wm82.gnm2.ann1.Glyma.19G161100
+ERF146	Ethylene-responsive factor gene 146	glyma.Wm82.gnm2.ann1.Glyma.19G163700
+ERF147	Ethylene-responsive factor gene 147	glyma.Wm82.gnm2.ann1.Glyma.19G163900
+ERF148	Ethylene-responsive factor gene 148	glyma.Wm82.gnm2.ann1.Glyma.19G164100
+PHT1-7	inorganic phosphate transporter 1-7	glyma.Wm82.gnm2.ann1.Glyma.19g164300
+Gy7	Glycinin gene 7	glyma.Wm82.gnm2.ann1.Glyma.19g164800
+GY3	glycinin G3	glyma.Wm82.gnm2.ann1.Glyma.19g1649001
+NAC182	NAC domain-containing protein	glyma.Wm82.gnm2.ann1.Glyma.19g165600
+PHR32	MYB-CC domain-containing transcription factor PHR32	glyma.Wm82.gnm2.ann1.Glyma.19g167500
+IAA57	Indole-3-Acetic Acid Responsive Gene 57	glyma.Wm82.gnm2.ann1.Glyma.19G168500
+MED11-2	Mediator Complex 11 gene 2	glyma.Wm82.gnm2.ann1.Glyma.19g169600
+MED37-12	Mediator Complex 37 gene 12	glyma.Wm82.gnm2.ann1.Glyma.19g172200
+WRKY181	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.19G177400
+RAP2.7	Target of Early Activation	glyma.Wm82.gnm2.ann1.Glyma.19G178200
+IQD63	protein IQ-DOMAIN 63	glyma.Wm82.gnm2.ann1.Glyma.19g179000
+NAC145	NAC Transcription Factor gene 145	glyma.Wm82.gnm2.ann1.Glyma.19G180300
+PIP2-8	aquaporin PIP2-8	glyma.Wm82.gnm2.ann1.Glyma.19g181300
+PAL1.1	phenylalanine ammonia-lyase 1.1	glyma.Wm82.gnm2.ann1.Glyma.19g182300
+ZFP6	C2H2-type zinc finger protein 6	glyma.Wm82.gnm2.ann1.Glyma.19g186200
+SHOOT2	SHOOT2 protein	glyma.Wm82.gnm2.ann1.Glyma.19g190000
+HDT6	histone deacetylase HDT1-like	glyma.Wm82.gnm2.ann1.Glyma.19g191000
+GRF20	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.19g192700
+PKR19	protein kinase R	glyma.Wm82.gnm2.ann1.Glyma.19G193100
 bZIP150	Basic leucine zipper transcription factor-like protein gene 150	glyma.Wm82.gnm2.ann1.Glyma.19G193400
-bZIP151	Basic leucine zipper transcription factor-like protein gene 151	glyma.Wm82.gnm2.ann1.Glyma.19G194500
+PAP22	purple acid phosphatase 22-like	glyma.Wm82.gnm2.ann1.Glyma.19g193900
+DT1, TFL1b	Terminal Flower 1 gene 2	glyma.Wm82.gnm2.ann1.Glyma.19g194300
+bZIP151, BZIP4	bZIP transcription factor 4	glyma.Wm82.gnm2.ann1.Glyma.19g194500
+NAC183	NAC Transcription Factor gene 183	glyma.Wm82.gnm2.ann1.Glyma.19G195800
+CYP15	peptidyl-prolyl cis-trans isomerase CYP15	glyma.Wm82.gnm2.ann1.Glyma.19g196100
+SYP24	putative syntaxin-24	glyma.Wm82.gnm2.ann1.Glyma.19g198600
+LEA2-97	late embryogenesis abundant 2 gene 97	glyma.Wm82.gnm2.ann1.Glyma.19G19870
+LEA2-98	late embryogenesis abundant 2 gene 98	glyma.Wm82.gnm2.ann1.Glyma.19G198800
+LEA2-99	late embryogenesis abundant 2 gene 99	glyma.Wm82.gnm2.ann1.Glyma.19G198900
+ALMT29	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.19g199900
+DGD1	digalactosyldiacylglycerol synthase 1	glyma.Wm82.gnm2.ann1.Glyma.19g200000
+NF-YA1B	putative CCAAT-binding transcription factor GmNF-YA1b	glyma.Wm82.gnm2.ann1.Glyma.19g200800
+PPR174	Psudo-Response Regulator gene 174	glyma.Wm82.gnm2.ann1.Glyma.19G202500
+TIR1C	protein TRANSPORT INHIBITOR RESPONSE 1C	glyma.Wm82.gnm2.ann1.Glyma.19g206800
+COL9	zinc finger protein CONSTANS-LIKE 13-like	glyma.Wm82.gnm2.ann1.Glyma.19g207100
+ERF149	Ethylene-responsive factor gene 149	glyma.Wm82.gnm2.ann1.Glyma.19G213100
 bZIP152, BZIP53B	bZIP transcription factor 53B	glyma.Wm82.gnm2.ann1.Glyma.19g216200
-bZIP153	Basic leucine zipper transcription factor-like protein gene 153	glyma.Wm82.gnm2.ann1.Glyma.19G244800
+WRKY182, WRKY8	WRKY transcription factor 8	glyma.Wm82.gnm2.ann1.Glyma.19g217000
+STS	stachyose synthase	glyma.Wm82.gnm2.ann1.Glyma.19g217700
+WRKY183	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.19G217800
+WRKY184	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.19G221700
+IAA58	Indole-3-Acetic Acid Responsive Gene 58	glyma.Wm82.gnm2.ann1.Glyma.19G221900
+PIF3	bHLH transcription factor PIF3	glyma.Wm82.gnm2.ann1.Glyma.19g222000
+MYB64	MYB transcription factor MYB64	glyma.Wm82.gnm2.ann1.Glyma.19g222200
+CYP14	peptidyl-prolyl cis-trans isomerase CYP14	glyma.Wm82.gnm2.ann1.Glyma.19g222600
+MAN	endo-1, 4-beta-mannosidase	glyma.Wm82.gnm2.ann1.Glyma.19G223000
+PHYA3	Phytochrome A gene 3	glyma.Wm82.gnm2.ann1.Glyma.19g224200
+SOYAP2	aspartic proteinase 2	glyma.Wm82.gnm2.ann1.Glyma.19g225500
+G6PDH9	Glucose-6-phosphate dehydrogenase gene 9	glyma.Wm82.gnm2.ann1.Glyma.19G226700
+GolS	dehydration-inducible galactinol	glyma.Wm82.gnm2.ann1.Glyma.19g227800
+PDIS-2	protein disulfide isomerase-like protein	glyma.Wm82.gnm2.ann1.Glyma.19g229000
+SWEET49	sugar efflux transporter SWEET49	glyma.Wm82.gnm2.ann1.Glyma.19g232200
+TOPP12	TOPP-type protein phosphatase gene 12	glyma.Wm82.gnm2.ann1.Glyma.19G232300
+NF-YC14	nuclear factor Y transcription factor	glyma.Wm82.gnm2.ann1.Glyma.19g236400
+BG7S-2	basic 7S globulin 2	glyma.Wm82.gnm2.ann1.Glyma.19g236600
+HGS	homoglutathione synthetase	glyma.Wm82.gnm2.ann1.Glyma.19g237700
+C2-173	C2 domain containing protein gene 173	glyma.Wm82.gnm2.ann1.Glyma.19G239500
+SOD, SOD1	superoxide dismutase [Cu-Zn]	glyma.Wm82.gnm2.ann1.Glyma.19g240400
+WNK9, ZIK9-2	Zinc Finger Protein Interacting With K Protein 9 gene 2	glyma.Wm82.gnm2.ann1.Glyma.19G242900
+IQD64	protein IQ-DOMAIN 64	glyma.Wm82.gnm2.ann1.Glyma.19g243700
+AMT4.3	ammonium transporter AMT4.3	glyma.Wm82.gnm2.ann1.Glyma.19g244400
+GME1	GDP-mannose 3',5'-epimerase	glyma.Wm82.gnm2.ann1.Glyma.19g244600
+BZIP104, bZIP153	Basic leucine zipper transcription factor-like protein gene 153	glyma.Wm82.gnm2.ann1.Glyma.19G244800
+MED14-2	Mediator Complex 14 gene 2	glyma.Wm82.gnm2.ann1.Glyma.19g245100
+IAA59	Indole-3-Acetic Acid Responsive Gene 59	glyma.Wm82.gnm2.ann1.Glyma.19G245200
+WIN	wound-induced protein	glyma.Wm82.gnm2.ann1.Glyma.19g245400
+C2-174	C2 domain containing protein gene 174	glyma.Wm82.gnm2.ann1.Glyma.19G247300
+PHR33	MYB-CC domain-containing transcription factor PHR33	glyma.Wm82.gnm2.ann1.Glyma.19g247600
+TOPP13	TOPP-type protein phosphatase gene 13	glyma.Wm82.gnm2.ann1.Glyma.19G248700
+CYP11	peptidyl-prolyl cis-trans isomerase CYP11	glyma.Wm82.gnm2.ann1.Glyma.19g249000
+C2-175	C2 domain containing protein gene 175	glyma.Wm82.gnm2.ann1.Glyma.19G252000
 bZIP154	Basic leucine zipper transcription factor-like protein gene 154	glyma.Wm82.gnm2.ann1.Glyma.19G252600
+ERF150	Ethylene-responsive factor gene 150	glyma.Wm82.gnm2.ann1.Glyma.19G253100
+TUBG2	tubulin gamma-2 chain	glyma.Wm82.gnm2.ann1.Glyma.19g2533001
+WRKY185	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.19G254800
+MYB185	MYB transcription factor MYB185	glyma.Wm82.gnm2.ann1.Glyma.19g257400
+NAC146	NAC Transcription Factor gene 146	glyma.Wm82.gnm2.ann1.Glyma.19G259500
+NAC147	NAC Transcription Factor gene 147	glyma.Wm82.gnm2.ann1.Glyma.19G259700
+LEA2-100	late embryogenesis abundant 2 gene 100	glyma.Wm82.gnm2.ann1.Glyma.19G260500
+LCL-3, LCL3, LHY2a	LATE ELONGATED HYPOCOTYL 2 gene a	glyma.Wm82.gnm2.ann1.Glyma.19G260900
+ERF151	Ethylene-responsive factor gene 151	glyma.Wm82.gnm2.ann1.Glyma.19G262700
+AMT4.2	ammonium transporter AMT4.2	glyma.Wm82.gnm2.ann1.Glyma.20g004100
+CYP61	peptidyl-prolyl cis-trans isomerase CYP61	glyma.Wm82.gnm2.ann1.Glyma.20g005600
 bZIP155	Basic leucine zipper transcription factor-like protein gene 155	glyma.Wm82.gnm2.ann1.Glyma.20G007700
+PAP17	purple acid phosphatase 17-like	glyma.Wm82.gnm2.ann1.Glyma.20g011900
+MYB3A	transcription factor MYB3a	glyma.Wm82.gnm2.ann1.Glyma.20g013000
+PPR175	Psudo-Response Regulator gene 175	glyma.Wm82.gnm2.ann1.Glyma.20G013300
+PIN3B	auxin efflux carrier component 3b	glyma.Wm82.gnm2.ann1.Glyma.20g014300
+MSG	MLP-like protein 28-like	glyma.Wm82.gnm2.ann1.Glyma.20g017900
+PHT1-8	inorganic phosphate transporter 1-8	glyma.Wm82.gnm2.ann1.Glyma.20g021600
+AGO2	Argonaut 2 ranscription factor	glyma.Wm82.gnm2.ann1.Glyma.20G022900
+N-23	nodulin-23	glyma.Wm82.gnm2.ann1.Glyma.20g024200
+PK3	pyruvate kinase	glyma.Wm82.gnm2.ann1.Glyma.20g024800
+Lac82	Laccase 82	glyma.Wm82.gnm2.ann1.Glyma.20G025200
+GF14u, SGF14R	putative 14-3-3 protein SGF14r	glyma.Wm82.gnm2.ann1.Glyma.20g025900
+WRKY186	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.20G028000
+WRKY187	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.20G030500
+ERF152	Ethylene-responsive factor gene 152	glyma.Wm82.gnm2.ann1.Glyma.20G031000
+CHR4	chalcone reductase CHR4	glyma.Wm82.gnm2.ann1.Glyma.20g031100
+PHO1-H7	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.20g031700
+MED25-4	Mediator Complex 25 gene 4	glyma.Wm82.gnm2.ann1.Glyma.20G031800
+PHO1-H9, PHO1;H9	phosphate responsive 1 gene H9	glyma.Wm82.gnm2.ann1.Glyma.20G032400
+PHO1-H10, PHO1;H10	Phosphate responsive 1 gene H10	glyma.Wm82.gnm2.ann1.Glyma.20G032500
+PHO1-H11	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.20g032600
 bZIP156	Basic leucine zipper transcription factor-like protein gene 156	glyma.Wm82.gnm2.ann1.Glyma.20G032700
-bZIP157	Basic leucine zipper transcription factor-like protein gene 157	glyma.Wm82.gnm2.ann1.Glyma.20G049200
+PHR34	MYB-CC domain-containing transcription factor PHR34	glyma.Wm82.gnm2.ann1.Glyma.20g035300
+LEC2b	B3 domain transcription factor	glyma.Wm82.gnm2.ann1.Glyma.20G035700
+LEC2a	B3 domain transcription factor	glyma.Wm82.gnm2.ann1.Glyma.20G035800
+C2-176	C2 domain containing protein gene 176	glyma.Wm82.gnm2.ann1.Glyma.20G037600
+GF14v	GF14 gene family gene v	glyma.Wm82.gnm2.ann1.Glyma.20G043700
+LEA-2, LEA2-101	late embryogenesis abundant 2 gene 101	glyma.Wm82.gnm2.ann1.Glyma.20G044800
+bZIP157, BZIP27	bZIP transcription factor 27	glyma.Wm82.gnm2.ann1.Glyma.20g049200
+Lac83	Laccase 83	glyma.Wm82.gnm2.ann1.Glyma.20G051600
+AO, Lac84	Laccase 84	glyma.Wm82.gnm2.ann1.Glyma.20G051700
+Lac85	Laccase 85	glyma.Wm82.gnm2.ann1.Glyma.20G051900
+SEOP	sieve element occlusion p	glyma.Wm82.gnm2.ann1.Glyma.20g052900
+SEOO	sieve element occlusion o	glyma.Wm82.gnm2.ann1.Glyma.20g0530001
+NRP-A	N-rich protein	glyma.Wm82.gnm2.ann1.Glyma.20g066100
+SWEET51	sugar efflux transporter SWEET51	glyma.Wm82.gnm2.ann1.Glyma.20g066500
+WNK8	with no lysine kinase 8	glyma.Wm82.gnm2.ann1.Glyma.20g066900
+ERF104, ERF153	Ethylene-responsive factor gene 153	glyma.Wm82.gnm2.ann1.Glyma.20G070000
+ERF154	Ethylene-responsive factor gene 154	glyma.Wm82.gnm2.ann1.Glyma.20G070100
+VAD1	protein VASCULAR ASSOCIATED DEATH 1, chloroplastic	glyma.Wm82.gnm2.ann1.Glyma.20g070800
+TPS23	terpene synthase 23	glyma.Wm82.gnm2.ann1.Glyma.20g074400
+C2-177	C2 domain containing protein gene 177	glyma.Wm82.gnm2.ann1.Glyma.20G081500
+C2-178	C2 domain containing protein gene 178	glyma.Wm82.gnm2.ann1.Glyma.20G081900
+SWEET52	sugar efflux transporter SWEET52	glyma.Wm82.gnm2.ann1.Glyma.20g082700
+PHYA2	Phytochrome A gene 2	glyma.Wm82.gnm2.ann1.Glyma.20g090000
+GER19	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.20g090200
+GSTU62	glutathione S-transferase GST 18	glyma.Wm82.gnm2.ann1.Glyma.20g101100
+ALMT32	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.20g101600
+TCP25	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 25	glyma.Wm82.gnm2.ann1.Glyma.20G103400
+Raf30-2	Raf30 proto-oncogene serine/threonine protein kinase gene 2	glyma.Wm82.gnm2.ann1.Glyma.20G105300
+P42-1	conversion of hydroxypyruvate to glycerate	glyma.Wm82.gnm2.ann1.Glyma.20g107800
+FAD2-1, FAD2-1B	omega-6 fatty acid desaturase	glyma.Wm82.gnm2.ann1.Glyma.20g111000
+1-3-1B	syringolide-induced protein 1-3-1B	glyma.Wm82.gnm2.ann1.Glyma.20g111800
+PPR176	Psudo-Response Regulator gene 176	glyma.Wm82.gnm2.ann1.Glyma.20G112100
 bZIP158, TGA26	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.20g113600
-bZIP159	Basic leucine zipper transcription factor-like protein gene 159	glyma.Wm82.gnm2.ann1.Glyma.20G224500
+PDF	serine/threonine-protein phosphatase 2A regulatory subunit A gene	glyma.Wm82.gnm2.ann1.Glyma.20G114000
+ALMT33	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.20g114100
+C4H1	cinnamate 4-hydroxylase	glyma.Wm82.gnm2.ann1.Glyma.20g114200
+ERF155	Ethylene-responsive factor gene 155	glyma.Wm82.gnm2.ann1.Glyma.20G115300
+JAG1, Ln	Narrow leaflets	glyma.Wm82.gnm2.ann1.Glyma.20g116200
+GLYII-12	glyoxalase GLYII-12	glyma.Wm82.gnm2.ann1.Glyma.20g118000
+IAA60	Indole-3-Acetic Acid Responsive Gene 60	glyma.Wm82.gnm2.ann1.Glyma.20G120800
+PDIQ-1A	protein disulfide family pdiq-1a	glyma.Wm82.gnm2.ann1.Glyma.20g124700
+Lac86	Laccase 86	glyma.Wm82.gnm2.ann1.Glyma.20G126500
+SPX9	SPX domain-containing protein 9	glyma.Wm82.gnm2.ann1.Glyma.20g129000
+GASA36	gibberellin-regulated protein 36	glyma.Wm82.gnm2.ann1.Glyma.20g131100
+PPR177	Psudo-Response Regulator gene 177	glyma.Wm82.gnm2.ann1.Glyma.20G132900
+MED35-5	Mediator Complex 35 gene 5	glyma.Wm82.gnm2.ann1.Glyma.20g135800
+CRK65	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g137200
+CRK67	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g137400
+CRK68	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g137500
+CRK69	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g137700
+CRK70	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g137900
+CRK71	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g138100
+CRK72	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g138400
+CRK73	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g138500
+CRK74	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g138600
+CRK75	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g138800
+CRK76	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g138900
+CRK77	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g139000
+CRK78	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g139100
+CRK79	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g139200
+CRK81	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g139400
+CRK82	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g139500
+CRK83	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g139600
+CRK84	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g139700
+CRK86	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g140100
+CRK87	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g140200
+CRK88	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g140400
+CRK89	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g140500
+CRK90	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g140600
+CRK91	cysteine-rich receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20g140700
+LEA2-102	late embryogenesis abundant 2 gene 102	glyma.Wm82.gnm2.ann1.Glyma.20G140900
+SUBI-1, Ubiqutin	Ubiqutin	glyma.Wm82.gnm2.ann1.Glyma.20G141600
+CG-BETA-1, Cgy4	beta-conglycinin beta-subunit 4	glyma.Wm82.gnm2.ann1.Glyma.20g146200
+PM25	seed maturation protein PM25	glyma.Wm82.gnm2.ann1.Glyma.20g147600
+OAS-TL2	cysteine synthase	glyma.Wm82.gnm2.ann1.Glyma.20g148100
+CG-BETA-2	beta-conglycinin, beta chain-like	glyma.Wm82.gnm2.ann1.Glyma.20g148200
+CG-ALPHA-2, Cgy2	beta-conglycinin alpha prime subunit 2	glyma.Wm82.gnm2.ann1.Glyma.20g148400
+TCP55	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 55	glyma.Wm82.gnm2.ann1.Glyma.20G148500
+HMT	homocyteine S-methyltransferase	glyma.Wm82.gnm2.ann1.Glyma.20G148900
+IQD65	protein IQ-DOMAIN 65	glyma.Wm82.gnm2.ann1.Glyma.20g149600
+HSF-37	heat stress transcription factor 37	glyma.Wm82.gnm2.ann1.Glyma.20g150300
+ELIP	early light-induced protein	glyma.Wm82.gnm2.ann1.Glyma.20g150600
+MED31-2	Mediator Complex 31 gene 2	glyma.Wm82.gnm2.ann1.Glyma.20g151600
+RAR1-2	CHORD superfamily protein	glyma.Wm82.gnm2.ann1.Glyma.20g151900
+GA2, GA20OX8	gibberellin 20 oxidase 8	glyma.Wm82.gnm2.ann1.Glyma.20g153400
+PGM4	Phosphoglucomutase 4 gene	glyma.Wm82.gnm2.ann1.Glyma.20g153600
+TCP26	Teosinte branched1 and cycloidea and proliferating cell factor family protein gene 26	glyma.Wm82.gnm2.ann1.Glyma.20G154400
+PPR178	Psudo-Response Regulator gene 178	glyma.Wm82.gnm2.ann1.Glyma.20G155800
+IQD66	protein IQ-DOMAIN 66	glyma.Wm82.gnm2.ann1.Glyma.20g156200
+HSF-38	heat stress transcription factor 38	glyma.Wm82.gnm2.ann1.Glyma.20g156800
+GnCrRLk1L37	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20G162300
+BCH4	beta-carotene hydroxylase 4	glyma.Wm82.gnm2.ann1.Glyma.20g162600
+WRKY188	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma.20G163200
+PLM	putative sphingomyelin synthase family protein	glyma.Wm82.gnm2.ann1.Glyma.20g167800
+ERF156	Ethylene-responsive factor gene 156	glyma.Wm82.gnm2.ann1.Glyma.20G168500
+GI1A, GIGANTEA	protein GIGANTEA	glyma.Wm82.gnm2.ann1.Glyma.20g170000
+NAC149	NAC Transcription Factor gene 149	glyma.Wm82.gnm2.ann1.Glyma.20G172100
+Lac87	Laccase 87	glyma.Wm82.gnm2.ann1.Glyma.20G172600
+Lac88	Laccase 88	glyma.Wm82.gnm2.ann1.Glyma.20G172700
+CDPK-BETA	calmodulin-like domain protein kinase isoenzyme beta	glyma.Wm82.gnm2.ann1.Glyma.20g175100
+GMNAC184, NAC184	NAC Transcription Factor gene 184	glyma.Wm82.gnm2.ann1.Glyma.20G175500
+GASA37	gibberellin-regulated protein 37	glyma.Wm82.gnm2.ann1.Glyma.20g175800
+IQD67	protein IQ-DOMAIN 67	glyma.Wm82.gnm2.ann1.Glyma.20g177900
+PIP2-14	aquaporin PIP2-14	glyma.Wm82.gnm2.ann1.Glyma.20g179700
+PGM5	phosphoglucomutase 5 gene	glyma.Wm82.gnm2.ann1.Glyma.20g179900
+C2-179	C2 domain containing protein gene 179	glyma.Wm82.gnm2.ann1.Glyma.20G180600
+PAL2.2	phenylalanine ammonia-lyase 2.2	glyma.Wm82.gnm2.ann1.Glyma.20g180800
+MYB13	transcription factor MYB13	glyma.Wm82.gnm2.ann1.Glyma.20g184200
+CYP62	peptidyl-prolyl cis-trans isomerase CYP62	glyma.Wm82.gnm2.ann1.Glyma.20g184400
+LAR1	leucoanthocyanidin reductase	glyma.Wm82.gnm2.ann1.Glyma.20g185700
+NAC150	NAC Transcription Factor gene 150	glyma.Wm82.gnm2.ann1.Glyma.20G185800
+CYP77A3	Cytochrome P450 77A3	glyma.Wm82.gnm2.ann1.Glyma.20g188000
+Lbc2	leghemoglobin C2	glyma.Wm82.gnm2.ann1.Glyma.20g191200
+NAC151	NAC Transcription Factor gene 151	glyma.Wm82.gnm2.ann1.Glyma.20G192300
+NAC152	NAC Transcription Factor gene 152	glyma.Wm82.gnm2.ann1.Glyma.20G192500
+Lac89	Laccase 89	glyma.Wm82.gnm2.ann1.Glyma.20G192800
+Lac90	Laccase 90	glyma.Wm82.gnm2.ann1.Glyma.20G192900
+PHR35	MYB-CC domain-containing transcription factor PHR35	glyma.Wm82.gnm2.ann1.Glyma.20g193600
+ERF157	Ethylene-responsive factor gene 157	glyma.Wm82.gnm2.ann1.Glyma.20G195900
+F3G6''Gt, Fg1, UF3GT	anthocyanidin 3-O-glucosyltransferase-like	glyma.Wm82.gnm2.ann1.Glyma.20g196000
+OLEO1	oleosin 1	glyma.Wm82.gnm2.ann1.Glyma.20g196600
+SODB	Fe-superoxide dismutase	glyma.Wm82.gnm2.ann1.Glyma.20g196900
+C2-180	C2 domain containing protein gene 180	glyma.Wm82.gnm2.ann1.Glyma.20G199700
+PPR179	Psudo-Response Regulator gene 179	glyma.Wm82.gnm2.ann1.Glyma.20G200100
+ERF158	Ethylene-responsive factor gene 158	glyma.Wm82.gnm2.ann1.Glyma.20G203500
+ERF159	Ethylene-responsive factor gene 159	glyma.Wm82.gnm2.ann1.Glyma.20G203600
+ERF160	Ethylene-responsive factor gene 160	glyma.Wm82.gnm2.ann1.Glyma.20G203700
+TOPP14	TOPP-type protein phosphatase gene 14	glyma.Wm82.gnm2.ann1.Glyma.20G203900
+PHT1-5	inorganic phosphate transporter 1-5	glyma.Wm82.gnm2.ann1.Glyma.20g204000
+PHT1-10	inorganic phosphate transporter 1-10	glyma.Wm82.gnm2.ann1.Glyma.20g204100
+SEOR	sieve element occlusion r	glyma.Wm82.gnm2.ann1.Glyma.20g204400
+SEOS	sieve element occlusion s	glyma.Wm82.gnm2.ann1.Glyma.20g204500
+SEOU	uncharacterized LOC100795343	glyma.Wm82.gnm2.ann1.Glyma.20g204800
+PHO1-H8	PHO1 family protein	glyma.Wm82.gnm2.ann1.Glyma.20g206900
+HRBP1	harpin binding protein 1	glyma.Wm82.gnm2.ann1.Glyma.20g207100
+PP2C;L1	phloem-specific pumpkin2C gene L1	glyma.Wm82.gnm2.ann1.Glyma.20G207600
+MYB29B2	MYB/HD-like transcription factor	glyma.Wm82.gnm2.ann1.Glyma.20g209700
+CRY2c	Cryptochrome 2c	glyma.Wm82.gnm2.ann1.Glyma.20g209900
+IAA61	Indole-3-Acetic Acid Responsive Gene 61	glyma.Wm82.gnm2.ann1.Glyma.20G210400
+IAA62	Indole-3-Acetic Acid Responsive Gene 62	glyma.Wm82.gnm2.ann1.Glyma.20G210500
+HSP22.0	22.0 kDa class IV heat shock protein	glyma.Wm82.gnm2.ann1.Glyma.20g213900
+LEA2-103	late embryogenesis abundant 2 gene 103	glyma.Wm82.gnm2.ann1.Glyma.20G216300
+ALMT34	aluminum-activated malate transporter family protein	glyma.Wm82.gnm2.ann1.Glyma.20g216800
+GER11	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.20g220800
+GER12	germin-like protein	glyma.Wm82.gnm2.ann1.Glyma.20g220900
+AMT1.6	ammonium transporter AMT1.6	glyma.Wm82.gnm2.ann1.Glyma.20g221400
+TOPP15	TOPP-type protein phosphatase gene 15	glyma.Wm82.gnm2.ann1.Glyma.20G222500
+PPCK2	phosphoenolpyruvate carboxylase kinase	glyma.Wm82.gnm2.ann1.Glyma.20g222600
+bZIP159, BZIP89	bZIP transcription factor bZIP89	glyma.Wm82.gnm2.ann1.Glyma.20g224500
+IAA63	Indole-3-Acetic Acid Responsive Gene 63	glyma.Wm82.gnm2.ann1.Glyma.20G225000
+GinCrRl,k1l,38	receptor-like protein kinase	glyma.Wm82.gnm2.ann1.Glyma.20G225800
+WNK1	with no lysine kinase 1	glyma.Wm82.gnm2.ann1.Glyma.20g228000
+OAS-TL7	cysteine synthase	glyma.Wm82.gnm2.ann1.Glyma.20g228900
+NHX1	sodium/hydrogen exchanger 1	glyma.Wm82.gnm2.ann1.Glyma.20g229900
+GID1C, GR2	giberellic acid responsive gene 2	glyma.Wm82.gnm2.ann1.Glyma.20G230600
+NF-YC15	nuclear factor Y transcription factor	glyma.Wm82.gnm2.ann1.Glyma.20g232400
+PM34	seed maturation protein PM34	glyma.Wm82.gnm2.ann1.Glyma.20g233000
+PLDZ	phospholipase D p1-like	glyma.Wm82.gnm2.ann1.Glyma.20g238000
+DHAR-1b, DHAR4, MDHAR-1b	DEHYDROASCORBATE REDUCTASE 1 gene b	glyma.Wm82.gnm2.ann1.Glyma.20G240300
+CHI1, CHI1A	chalcone-flavonone isomerase 1A	glyma.Wm82.gnm2.ann1.Glyma.20g241500
+CHI1B1, CHI2	chalcone isomerase 2	glyma.Wm82.gnm2.ann1.Glyma.20g241600
+CHI2-A, CHI3	chalcone isomerase 2	glyma.Wm82.gnm2.ann1.Glyma.20g241700
+G2DT	glycinol 2-dimethylallyltransferase	glyma.Wm82.gnm2.ann1.Glyma.20g245100
+PTI1	protein kinase Pti1	glyma.Wm82.gnm2.ann1.Glyma.20g245600
 bZIP160, TGA27	bZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.20g246400
-bZIP17	Basic leucine zipper transcription factor-like protein gene 17	glyma.Wm82.gnm2.ann1.Glyma.02G236200
-bZIP18	Basic leucine zipper transcription factor-like protein gene 18	glyma.Wm82.gnm2.ann1.Glyma.03G003400
-bZIP2	Basic leucine zipper transcription factor-like protein gene 2	glyma.Wm82.gnm2.ann1.Glyma.01G069300
-bZIP20	Basic leucine zipper transcription factor-like protein gene 20	glyma.Wm82.gnm2.ann1.Glyma.03G081700
-bZIP23, TGA05	bZIP transcription factor 5	glyma.Wm82.gnm2.ann1.Glyma.03g128200
-bZIP26	Basic leucine zipper transcription factor-like protein gene 26	glyma.Wm82.gnm2.ann1.Glyma.03G219300
-bZIP29	Basic leucine zipper transcription factor-like protein gene 29	glyma.Wm82.gnm2.ann1.Glyma.04G010300
-bZIP31	Basic leucine zipper transcription factor-like protein gene 31	glyma.Wm82.gnm2.ann1.Glyma.04G026200
-bZIP32	Basic leucine zipper transcription factor-like protein gene 32	glyma.Wm82.gnm2.ann1.Glyma.04G029600
-bZIP34	Basic leucine zipper transcription factor-like protein gene 34	glyma.Wm82.gnm2.ann1.Glyma.04G078300
-bZIP39	Basic leucine zipper transcription factor-like protein gene 39	glyma.Wm82.gnm2.ann1.Glyma.05G017400
-bZIP40	Basic leucine zipper transcription factor-like protein gene 40	glyma.Wm82.gnm2.ann1.Glyma.05G079800
-bZIP41	Basic leucine zipper transcription factor-like protein gene 41	glyma.Wm82.gnm2.ann1.Glyma.05G108200
-bZIP43	Basic leucine zipper transcription factor-like protein gene 43	glyma.Wm82.gnm2.ann1.Glyma.05G157000
-bZIP45	Basic leucine zipper transcription factor-like protein gene 45	glyma.Wm82.gnm2.ann1.Glyma.05G168100
-bZIP49	Basic leucine zipper transcription factor-like protein gene 49	glyma.Wm82.gnm2.ann1.Glyma.06G029600
-bZIP52	Basic leucine zipper transcription factor-like protein gene 52	glyma.Wm82.gnm2.ann1.Glyma.06G062000
-bZIP53	Basic leucine zipper transcription factor-like protein gene 53	glyma.Wm82.gnm2.ann1.Glyma.06G079800
-bZIP54, TGA09	bZIP transcription factor 9	glyma.Wm82.gnm2.ann1.Glyma.06g107300
-bZIP56	Basic leucine zipper transcription factor-like protein gene 56	glyma.Wm82.gnm2.ann1.Glyma.06G307200
-bZIP57	Basic leucine zipper transcription factor-like protein gene 57	glyma.Wm82.gnm2.ann1.Glyma.06G314400
-bZIP6	Basic leucine zipper transcription factor-like protein gene 6	glyma.Wm82.gnm2.ann1.Glyma.01G177400
-bZIP65	Basic leucine zipper transcription factor-like protein gene 65	glyma.Wm82.gnm2.ann1.Glyma.08G183600
-bZIP66	Basic leucine zipper transcription factor-like protein gene 66	glyma.Wm82.gnm2.ann1.Glyma.08G227000
-bZIP67, BZIP73B	BZIP transcription factor	glyma.Wm82.gnm2.ann1.Glyma.08g254400
-bZIP7	Basic leucine zipper transcription factor-like protein gene 7	glyma.Wm82.gnm2.ann1.Glyma.01G195800
-bZIP73	Basic leucine zipper transcription factor-like protein gene 73	glyma.Wm82.gnm2.ann1.Glyma.10G013300
-bZIP75, TGA11	bZIP transcription factor 11	glyma.Wm82.gnm2.ann1.Glyma.10g092100
-bZIP76, SBZ1	bZIP transcription factor protein SBZ1	glyma.Wm82.gnm2.ann1.Glyma.10g162100
-bZIP78	Basic leucine zipper transcription factor-like protein gene 78	glyma.Wm82.gnm2.ann1.Glyma.10G226000
-bZIP79, TGA12	bZIP transcription factor 12	glyma.Wm82.gnm2.ann1.Glyma.10g276100
-bZIP84	Basic leucine zipper transcription factor-like protein gene 84	glyma.Wm82.gnm2.ann1.Glyma.11G108100
-bZIP86	Basic leucine zipper transcription factor-like protein gene 86	glyma.Wm82.gnm2.ann1.Glyma.11G114800
-bZIP88	Basic leucine zipper transcription factor-like protein gene 88	glyma.Wm82.gnm2.ann1.Glyma.11G167400
-bZIP91	Basic leucine zipper transcription factor-like protein gene 91	glyma.Wm82.gnm2.ann1.Glyma.11G168000
-bZIP92	Basic leucine zipper transcription factor-like protein gene 92	glyma.Wm82.gnm2.ann1.Glyma.11G183700
-bZIP95	Basic leucine zipper transcription factor-like protein gene 95	glyma.Wm82.gnm2.ann1.Glyma.12G033000
-bZIP96	Basic leucine zipper transcription factor-like protein gene 96	glyma.Wm82.gnm2.ann1.Glyma.12G036400
-bZIP97	Basic leucine zipper transcription factor-like protein gene 97	glyma.Wm82.gnm2.ann1.Glyma.12G040600
-chs6, CHS6b	Chalcone and stilbene synthases, C-terminal domain; Chalcone and stilbene synthases, N-terminal domain 6 gene b	glyma.Wm82.gnm2.ann1.Glyma.09G075200
-glycinin A2B1a	glycinin A2B1a subunit	glyma.Wm82.gnm2.ann1.Glyma.03g163500
-glycinin A3B4	glycinin A3B4 subunit	glyma.Wm82.gnm2.ann1.Glyma.13g123500
-glycinin A5A4B3	glycinin A5A4B3 subunit	glyma.Wm82.gnm2.ann1.Glyma.10g037100
-jmjC	transcription factor; jumonji (jmjC) domain-containing protein	glyma.Wm82.gnm1.ann1.Glyma12g05890
-ppc2	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.06g229900
-ppc3	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.06g277500
-ppc4	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.12G210600
-ppc7	Phosphoenolpyruvate carboxylase isoform	glyma.Wm82.gnm2.ann1.Glyma.13G270400
-stAPX-a	Ascorbate peroxidase gene a	glyma.Wm82.gnm2.ann1.Glyma.06G114400
-stAPX-b	Ascorbate peroxidase gene b	glyma.Wm82.gnm2.ann1.Glyma.04G248300
+CYP10	peptidyl-prolyl cis-trans isomerase CYP10	glyma.Wm82.gnm2.ann1.Glyma.20g249300
+EXPB6	putative expansin-B2-like	glyma.Wm82.gnm2.ann1.Glyma.u014500
+PGN	polygalacturonase	glyma.Wm82.gnm2.ann1.Glyma.u016300
+CCD7	carotenoid cleavage dioxygenase 7	glyma.Wm82.gnm2.ann1.Glyma.u016700
+AGL15	AGL15 protein	glyma.Wm82.gnm2.ann1.Glyma.u018000
+SIZ1B	E3 SUMO-protein ligase SIZ1b	glyma.Wm82.gnm2.ann1.Glyma.u020100
+MAPK1	mitogen-activated protein kinase 1	glyma.Wm82.gnm2.ann1.Glyma.u021800
+APX-1, APX1	ascorbate peroxidase 1, cytosolic	glyma.Wm82.gnm2.ann1.Glyma.u021900
+Lac91	Laccase 91	glyma.Wm82.gnm2.ann1.Glyma.U027300
+Lac92	Laccase 92	glyma.Wm82.gnm2.ann1.Glyma.U027400
+GRF21	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.u028600
+GRF22	growth-regulating factor	glyma.Wm82.gnm2.ann1.Glyma.u028700
+PSK5	phytosulfokines 3-like	glyma.Wm82.gnm2.ann1.Glyma.u029600
+PRR3A, PRR7a	Pseudo Response Regultor 7 gene a	glyma.Wm82.gnm2.ann1.Glyma.U034500
+B13-1-1, Lac93	Laccase 93	glyma.Wm82.gnm2.ann1.Glyma.U040600
+WRKY54	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma06g06530
+WRKY132	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma14g11440
+WRKY178	WRKY Transcripiton Factor	glyma.Wm82.gnm2.ann1.Glyma18g48460
+PTF1	Pi starvation-induced transcription factor 1	glyma.Wm82.gnm2.ann1.Glyma19G143900


### PR DESCRIPTION
I realized over the weekend that for search and display, we can merge synonymous symbols if they share a gene ID. So I've done that in this branch. To see such cases, search on `, ` (this will pull up both records with synonymous symbols and records in which the "gene symbol full name" has a comma, but it at least permits some testing).

This is a data-only change.