### PR TITLE
Fix navbar variable name

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -64,7 +64,7 @@
           <li><a class="tm-no-underline" href="https://twitter.com/{{ site.twitter_username }}" target="_blank" title="Follow us on Twitter"><span uk-icon="twitter"></span></a></li>
         {% endif %}
         {% if site.newsletter %}
-          <li><a class="tm-no-underline" href="{{ site.newletter }}" target="_blank" title="Subscribe to our newsletter"><span uk-icon="mail"></span></a></li>
+          <li><a class="tm-no-underline" href="{{ site.newsletter }}" target="_blank" title="Subscribe to our newsletter"><span uk-icon="mail"></span></a></li>
         {% endif %}
         {% if site.github_username %}
           <li><a class="tm-no-underline" href="https://github.com/{{ site.github_username }}" target="_blank" title="Fork us on GitHub"><span uk-icon="github"></span></a></li>


### PR DESCRIPTION
Fix variable name in navbar HTML which was preventing newsletter from being linked.