### PR TITLE
Add Zh13 gene ID example

### DIFF
--- a/tools/translate/index.html
+++ b/tools/translate/index.html
@@ -113,7 +113,7 @@ layout: full-width
   <li class="uk-open">
     <a class="uk-accordion-title">Pangene Lookup</a>
     <div class="uk-accordion-content uk-padding uk-padding-remove-vertical">
-      <lis-pangene-lookup-element id="pangene-lookup" genesExample="glyma.Lee.gnm2.ann1.Gm_00017 glyma.Wm82.gnm1.ann1.Glyma01g00510 glyma.Wm82.gnm2.ann1.Glyma.08G002000"></lis-pangene-lookup-element>
+      <lis-pangene-lookup-element id="pangene-lookup" genesExample="glyma.Lee.gnm2.ann1.Gm_00017 glyma.Wm82.gnm1.ann1.Glyma01g00510 glyma.Wm82.gnm2.ann1.Glyma.08G002000 glyma.Zh13.gnm1.ann1.SoyZH13_02G067000"></lis-pangene-lookup-element>
       <lis-modal-element modalId="modal">
         <lis-linkout-element id="linkouts"></lis-linkout-element>
       </lis-modal-element>


### PR DESCRIPTION
added ZH13 gene id to example list on the Gene Model Translation / Correspondence tool. 
<img width="1282" height="477" alt="Screenshot 2025-07-31 at 11 46 11" src="https://github.com/user-attachments/assets/f3e1d902-a5f9-4aff-ac88-1fd8dcc17aa9" />
